### PR TITLE
feat: add base classes for sources, pipelines, and record types

### DIFF
--- a/src/spicy_regs/pipelines/__init__.py
+++ b/src/spicy_regs/pipelines/__init__.py
@@ -1,0 +1,3 @@
+from spicy_regs.pipelines.base import Pipeline
+
+__all__ = ["Pipeline"]

--- a/src/spicy_regs/pipelines/base.py
+++ b/src/spicy_regs/pipelines/base.py
@@ -1,0 +1,22 @@
+"""Base class for runnable end-to-end pipelines.
+
+Subclass `Pipeline` to add a workflow that CI invokes. Each pipeline
+wires sources and transforms together and exposes a single ``run()``
+entry point.
+"""
+
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
+
+class Pipeline(ABC):
+    """A runnable end-to-end pipeline invoked by CI.
+
+    Subclasses wire sources + transforms together. The CI runner addresses
+    pipelines by their ``name`` class attribute and calls ``run()``.
+    """
+
+    name: ClassVar[str]
+
+    @abstractmethod
+    def run(self) -> None: ...

--- a/src/spicy_regs/records.py
+++ b/src/spicy_regs/records.py
@@ -1,0 +1,34 @@
+"""Shared data shapes that flow between sources and transforms."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RecordType:
+    """Description of one shape of data that flows through the pipeline.
+
+    A RecordType pairs a name and primary key with a schema and an extract
+    function that maps a raw payload (e.g. a parsed JSON dict) to a flat
+    record dict matching the schema. Instances are values, not classes —
+    contributors add new record shapes by constructing a new RecordType,
+    not by subclassing.
+    """
+
+    name: str
+    path_pattern: str
+    schema: dict[str, Any]
+    dedup_key: str
+    extract: Callable[[dict], dict]
+
+    def __post_init__(self) -> None:
+        if self.dedup_key not in self.schema:
+            raise ValueError(
+                f"RecordType {self.name!r}: dedup_key {self.dedup_key!r} "
+                f"not in schema"
+            )
+        if "modify_date" not in self.schema:
+            raise ValueError(
+                f"RecordType {self.name!r}: schema must include 'modify_date'"
+            )

--- a/src/spicy_regs/sources/__init__.py
+++ b/src/spicy_regs/sources/__init__.py
@@ -1,0 +1,3 @@
+from spicy_regs.sources.base import Reader, Writer
+
+__all__ = ["Reader", "Writer"]

--- a/src/spicy_regs/sources/base.py
+++ b/src/spicy_regs/sources/base.py
@@ -1,0 +1,29 @@
+"""Base classes for data source connectors.
+
+Subclass `Reader` to add a connector that pulls records from an external
+system (S3 bucket, REST API, scraped HTML, etc.). Subclass `Writer` to
+add a connector that pushes records to an external system. A connector
+that does both inherits from both.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Iterator
+
+
+class Reader(ABC):
+    """A connector that reads records from an external system.
+
+    Subclasses configure connection details via ``__init__`` and yield
+    records (dicts) from ``iter_records``. Pagination, batching, retries,
+    and dedup semantics are the subclass's responsibility.
+    """
+
+    @abstractmethod
+    def iter_records(self) -> Iterator[dict]: ...
+
+
+class Writer(ABC):
+    """A connector that writes records to an external system."""
+
+    @abstractmethod
+    def write(self, records: Iterable[dict]) -> None: ...

--- a/src/spicy_regs/transforms/README.md
+++ b/src/spicy_regs/transforms/README.md
@@ -1,0 +1,33 @@
+# Transforms
+
+Pure data transformations that flow between sources. Transforms have **no
+I/O to external systems** — that's a `sources/` concern. Examples of work
+that belongs here: deduplication, schema normalization, joining record
+streams, aggregation, building summaries.
+
+## Convention
+
+Each transform lives in its own module under this directory. A transform
+is a function or small class that takes inputs, returns outputs, and
+makes no network calls or filesystem writes outside the working
+directory passed to it.
+
+```python
+# src/spicy_regs/transforms/dedup.py
+from collections.abc import Iterable, Iterator
+
+
+def dedup_by(records: Iterable[dict], key: str) -> Iterator[dict]:
+    seen: set = set()
+    for r in records:
+        k = r.get(key)
+        if k in seen:
+            continue
+        seen.add(k)
+        yield r
+```
+
+There is no `Transform` ABC today. The shapes of existing transforms
+(records-in, records-out vs. files-in, files-out vs. directory-in,
+file-out) are too varied to share one contract. If a common pattern
+emerges, a base class can be added here without breaking anything.

--- a/tests/test_example_pipeline.py
+++ b/tests/test_example_pipeline.py
@@ -1,0 +1,110 @@
+"""End-to-end reference: one of each base class wired together.
+
+This file is a contributor reference. It implements a minimal pipeline
+that fetches posts from JSONPlaceholder, uppercases their titles, and
+prints them. The test monkeypatches ``urllib.request.urlopen`` with
+canned data so CI stays hermetic — to see the abstractions run against
+the live API, delete the monkeypatch and run ``pytest -s``.
+"""
+
+from collections.abc import Iterable, Iterator
+from io import BytesIO
+from json import dumps as json_dumps
+from json import loads
+from urllib.request import urlopen
+
+import pytest
+
+from spicy_regs.pipelines import Pipeline
+from spicy_regs.records import RecordType
+from spicy_regs.sources import Reader, Writer
+
+
+Post = RecordType(
+    name="posts",
+    path_pattern="/posts",
+    schema={
+        "post_id": str,
+        "user_id": str,
+        "title": str,
+        "body": str,
+        "modify_date": str,
+    },
+    dedup_key="post_id",
+    extract=lambda raw: {
+        "post_id": str(raw["id"]),
+        "user_id": str(raw["userId"]),
+        "title": raw["title"],
+        "body": raw["body"],
+        "modify_date": "1970-01-01",
+    },
+)
+
+
+class JsonPlaceholderReader(Reader):
+    """Reads posts from JSONPlaceholder and yields extracted records."""
+
+    def __init__(self, url: str, record_type: RecordType) -> None:
+        self.url = url
+        self.record_type = record_type
+
+    def iter_records(self) -> Iterator[dict]:
+        with urlopen(self.url) as resp:
+            payload = loads(resp.read())
+        for raw in payload:
+            yield self.record_type.extract(raw)
+
+
+def uppercase_titles(records: Iterable[dict]) -> Iterator[dict]:
+    """Convention-only transform: uppercases the ``title`` field."""
+    for r in records:
+        yield {**r, "title": r["title"].upper()}
+
+
+class StdoutWriter(Writer):
+    """Writes records by printing each as a line to stdout."""
+
+    def write(self, records: Iterable[dict]) -> None:
+        for r in records:
+            print(r)
+
+
+class ExamplePipeline(Pipeline):
+    name = "example"
+
+    def __init__(self) -> None:
+        self.reader = JsonPlaceholderReader(
+            "https://jsonplaceholder.typicode.com/posts",
+            Post,
+        )
+        self.writer = StdoutWriter()
+
+    def run(self) -> None:
+        self.writer.write(uppercase_titles(self.reader.iter_records()))
+
+
+_CANNED_POSTS = [
+    {"id": 1, "userId": 1, "title": "first post", "body": "hello"},
+    {"id": 2, "userId": 2, "title": "second post", "body": "world"},
+]
+
+
+def test_example_pipeline_runs_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_urlopen(url: str):  # noqa: ARG001 — signature matches stdlib
+        return BytesIO(json_dumps(_CANNED_POSTS).encode())
+
+    monkeypatch.setattr(
+        "tests.test_example_pipeline.urlopen",
+        fake_urlopen,
+    )
+
+    pipeline = ExamplePipeline()
+    pipeline.run()
+
+    captured = capsys.readouterr()
+    assert "FIRST POST" in captured.out
+    assert "SECOND POST" in captured.out
+    assert "post_id" in captured.out

--- a/tests/test_pipelines_base.py
+++ b/tests/test_pipelines_base.py
@@ -1,0 +1,57 @@
+"""Tests for the Pipeline base class."""
+
+import pytest
+
+from spicy_regs.pipelines import Pipeline
+
+
+def test_pipeline_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError):
+        Pipeline()  # type: ignore[abstract]
+
+
+def test_subclass_missing_run_cannot_be_instantiated() -> None:
+    class IncompletePipeline(Pipeline):
+        name = "incomplete"
+
+    with pytest.raises(TypeError):
+        IncompletePipeline()  # type: ignore[abstract]
+
+
+def test_subclass_without_name_raises_attribute_error_on_access() -> None:
+    class NamelessPipeline(Pipeline):
+        def run(self) -> None:
+            return None
+
+    pipeline = NamelessPipeline()
+    with pytest.raises(AttributeError):
+        _ = NamelessPipeline.name
+    with pytest.raises(AttributeError):
+        _ = pipeline.name
+
+
+def test_minimal_pipeline_subclass() -> None:
+    class FakePipeline(Pipeline):
+        name = "fake"
+
+        def __init__(self) -> None:
+            self.ran = False
+
+        def run(self) -> None:
+            self.ran = True
+
+    assert FakePipeline.name == "fake"
+    pipeline = FakePipeline()
+    assert pipeline.ran is False
+    pipeline.run()
+    assert pipeline.ran is True
+
+
+def test_pipeline_name_addressable_without_instantiation() -> None:
+    class NamedPipeline(Pipeline):
+        name = "named"
+
+        def run(self) -> None:
+            return None
+
+    assert NamedPipeline.name == "named"

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,67 @@
+"""Tests for the RecordType dataclass."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from spicy_regs.records import RecordType
+
+
+def _identity(d: dict) -> dict:
+    return d
+
+
+def _valid_kwargs(**overrides: object) -> dict:
+    base = {
+        "name": "widgets",
+        "path_pattern": "/widgets/",
+        "schema": {"widget_id": str, "modify_date": str},
+        "dedup_key": "widget_id",
+        "extract": _identity,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_valid_instance_round_trips() -> None:
+    rt = RecordType(**_valid_kwargs())
+    assert rt.name == "widgets"
+    assert rt.path_pattern == "/widgets/"
+    assert rt.dedup_key == "widget_id"
+    assert rt.extract({"widget_id": "1", "modify_date": "2024-01-01"}) == {
+        "widget_id": "1",
+        "modify_date": "2024-01-01",
+    }
+
+
+def test_is_frozen() -> None:
+    rt = RecordType(**_valid_kwargs())
+    with pytest.raises(FrozenInstanceError):
+        rt.name = "other"  # type: ignore[misc]
+
+
+def test_dedup_key_must_be_in_schema() -> None:
+    with pytest.raises(ValueError, match="dedup_key"):
+        RecordType(**_valid_kwargs(dedup_key="missing"))
+
+
+def test_modify_date_must_be_in_schema() -> None:
+    with pytest.raises(ValueError, match="modify_date"):
+        RecordType(
+            **_valid_kwargs(
+                schema={"widget_id": str},
+                dedup_key="widget_id",
+            )
+        )
+
+
+def test_equality() -> None:
+    a = RecordType(**_valid_kwargs())
+    b = RecordType(**_valid_kwargs())
+    assert a == b
+
+
+def test_inequality_on_different_field() -> None:
+    a = RecordType(**_valid_kwargs())
+    b = RecordType(**_valid_kwargs(name="other"))
+    assert a != b

--- a/tests/test_sources_base.py
+++ b/tests/test_sources_base.py
@@ -1,0 +1,82 @@
+"""Tests for the Reader and Writer base classes."""
+
+from collections.abc import Iterable, Iterator
+
+import pytest
+
+from spicy_regs.sources import Reader, Writer
+
+
+def test_reader_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError):
+        Reader()  # type: ignore[abstract]
+
+
+def test_writer_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError):
+        Writer()  # type: ignore[abstract]
+
+
+def test_reader_subclass_missing_iter_records_cannot_be_instantiated() -> None:
+    class IncompleteReader(Reader):
+        pass
+
+    with pytest.raises(TypeError):
+        IncompleteReader()  # type: ignore[abstract]
+
+
+def test_writer_subclass_missing_write_cannot_be_instantiated() -> None:
+    class IncompleteWriter(Writer):
+        pass
+
+    with pytest.raises(TypeError):
+        IncompleteWriter()  # type: ignore[abstract]
+
+
+def test_minimal_reader_subclass() -> None:
+    class FakeReader(Reader):
+        def iter_records(self) -> Iterator[dict]:
+            yield {"id": "1"}
+            yield {"id": "2"}
+
+    reader = FakeReader()
+    assert list(reader.iter_records()) == [{"id": "1"}, {"id": "2"}]
+
+
+def test_minimal_writer_subclass() -> None:
+    class FakeWriter(Writer):
+        def __init__(self) -> None:
+            self.received: list[dict] = []
+
+        def write(self, records: Iterable[dict]) -> None:
+            self.received.extend(records)
+
+    writer = FakeWriter()
+    writer.write([{"id": "1"}, {"id": "2"}])
+    assert writer.received == [{"id": "1"}, {"id": "2"}]
+
+
+def test_reader_writer_combined_subclass() -> None:
+    class FakeStore(Reader, Writer):
+        def __init__(self) -> None:
+            self.items: list[dict] = []
+
+        def iter_records(self) -> Iterator[dict]:
+            yield from self.items
+
+        def write(self, records: Iterable[dict]) -> None:
+            self.items.extend(records)
+
+    store = FakeStore()
+    store.write([{"id": "1"}])
+    store.write([{"id": "2"}])
+    assert list(store.iter_records()) == [{"id": "1"}, {"id": "2"}]
+
+
+def test_combined_subclass_missing_one_method_cannot_be_instantiated() -> None:
+    class HalfBaked(Reader, Writer):
+        def iter_records(self) -> Iterator[dict]:
+            yield from ()
+
+    with pytest.raises(TypeError):
+        HalfBaked()  # type: ignore[abstract]


### PR DESCRIPTION
## Summary

Scaffolding so contributors can extend the project by dropping a new file in the right directory.

- `src/spicy_regs/sources/` — `Reader` and `Writer` ABCs for connectors that read from / write to external systems (S3, REST APIs, scraped HTML, R2, etc.).
- `src/spicy_regs/pipelines/` — `Pipeline` ABC for runnable end-to-end workflows invoked by CI. Has a `name` ClassVar and an abstract `run()`.
- `src/spicy_regs/records.py` — `RecordType` frozen `@dataclass` describing one shape of data. Validates at construction time that `dedup_key` and `modify_date` exist in the schema.
- `src/spicy_regs/transforms/` — directory + README documenting the convention for pure data transformations. No ABC for now; today's transforms have varied shapes (records-in vs files-in vs directories-in) and forcing a contract would be premature.

### Contributor cheat sheet

| Adding a... | Where it goes |
|---|---|
| New external system | `sources/.py` extending `Reader` and/or `Writer` |
| New transformation step | `transforms/.py` (function or class; no ABC) |
| New CI workflow | `pipelines/.py` extending `Pipeline` |
| New record shape | new `RecordType(...)` instance (no subclassing) |

### Reference example

`tests/test_example_pipeline.py` wires one of each base class together: a `Post` `RecordType`, a `JsonPlaceholderReader(Reader)`, an `uppercase_titles` transform function, a `StdoutWriter(Writer)`, and an `ExamplePipeline(Pipeline)` that chains them. The test monkeypatches `urllib.request.urlopen` with canned data so CI stays hermetic — delete the monkeypatch and run `pytest -s` to see it run against the live JSONPlaceholder API.

### Out of scope (explicitly deferred)

- Concrete `Reader` / `Writer` / `Pipeline` subclasses for the real data sources.
- Concrete `RecordType` instances for dockets/documents/comments.
- Migration of `DATA_TYPES`, `extract.py`, `transform.py`, `load.py`, `pipeline.py`.
- A `Transform` ABC.
- A pipeline-discovery / CLI runner.
- Updates to `CONTRIBUTING.md` (best written when there's a real concrete example to reference).

No existing code is modified.

## Test plan

- [x] `uv run pytest tests/test_records.py tests/test_sources_base.py tests/test_pipelines_base.py tests/test_example_pipeline.py -v` — 20 new tests covering the three contracts and the end-to-end wiring.
- [x] `uv run pytest -x` — full suite (83 tests) passes; no regressions.
- [x] `python -c "from spicy_regs.records import RecordType; from spicy_regs.sources import Reader, Writer; from spicy_regs.pipelines import Pipeline"` — public re-exports work.

https://claude.ai/code/session_015dxRa5qFe3XCNsk2RqPqHq

---
_Generated by [Claude Code](https://claude.ai/code/session_015dxRa5qFe3XCNsk2RqPqHq)_