### PR TITLE
Point spicyregs skill at r2.spicy-regs.dev

### DIFF
--- a/plugins/spicyregs/skills/spicyregs/references/data-layout.md
+++ b/plugins/spicyregs/skills/spicyregs/references/data-layout.md
@@ -4,7 +4,7 @@ Use this reference when you need a quick map of the remote or local data files b
 
 ## Common locations
 
-- Default public R2 bucket: `https://pub-5fc11ad134984edf8d9af452dd1849d6.r2.dev`
+- Default public R2 bucket: `https://r2.spicy-regs.dev`
 - Default local parquet directory: `./spicy-regs-data/`
 - Sample JSON for offline examples: `sample-data/mirrulations/`
 

--- a/plugins/spicyregs/skills/spicyregs/scripts/find_duplicate_regulations.py
+++ b/plugins/spicyregs/skills/spicyregs/scripts/find_duplicate_regulations.py
@@ -22,7 +22,7 @@ from difflib import SequenceMatcher
 from itertools import combinations
 from pathlib import Path
 
-R2_BASE_URL = "https://pub-5fc11ad134984edf8d9af452dd1849d6.r2.dev"
+R2_BASE_URL = "https://r2.spicy-regs.dev"
 
 STOPWORDS = {
     "a",

--- a/plugins/spicyregs/skills/spicyregs/scripts/query_spicy_regs.py
+++ b/plugins/spicyregs/skills/spicyregs/scripts/query_spicy_regs.py
@@ -14,7 +14,7 @@ import json
 import sys
 from pathlib import Path
 
-R2_BASE_URL = "https://pub-5fc11ad134984edf8d9af452dd1849d6.r2.dev"
+R2_BASE_URL = "https://r2.spicy-regs.dev"
 
 
 def _escape_sql_string(value: str) -> str:


### PR DESCRIPTION
## Summary
- Switch the spicyregs skill's default R2 base URL from the raw `pub-*.r2.dev` hostname to the custom domain `https://r2.spicy-regs.dev`.
- Updates both helper scripts (`query_spicy_regs.py`, `find_duplicate_regulations.py`) and the `references/data-layout.md` doc that ships with the skill.

Scope intentionally limited to the skill under `plugins/spicyregs/skills/spicyregs/`. The notebooks, MCP server, and pipeline README still use the old URL — happy to update those in a follow-up if desired.

## Test plan
- [ ] `uv run --script plugins/spicyregs/skills/spicyregs/scripts/query_spicy_regs.py --source r2 --list-sources` returns the expected tables
- [ ] `uv run --script plugins/spicyregs/skills/spicyregs/scripts/query_spicy_regs.py --source r2 --describe dockets` succeeds against the new domain
- [ ] `uv run --script plugins/spicyregs/skills/spicyregs/scripts/find_duplicate_regulations.py --source r2 --limit 5` runs end-to-end

https://claude.ai/code/session_01UjugZckWtkxnK9DZfVtNjS

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjugZckWtkxnK9DZfVtNjS)_