### PR TITLE
Docs + pattern consistency: make the ETL building blocks junior-followable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,56 @@ If you find this project useful, please consider giving it a star on GitHub — 
 - Add or update tests for any behavior change.
 - Run the test suite locally before pushing.
 
+## Architecture: the ETL building blocks
+
+The ETL is built from a few small, composable abstractions. Data flows through
+them in one direction:
+
+```
+Reader  ->  Transform  ->  Writer        (a record at a time)
+   \____________ Pipeline ____________/   (wires them together + runs)
+```
+
+| Concept       | Base class                              | What it does                                  | Example |
+|---------------|-----------------------------------------|-----------------------------------------------|---------|
+| `RecordType`  | `spicy_regs.schemas` (a value, not a subclass) | Describes one data shape: schema, primary key, extractor | `schemas/regulations.py` |
+| `Reader`      | `spicy_regs.sources.base.Reader`        | A **source**: yields raw records              | `sources/mirrulations.py` |
+| `Transform`   | `spicy_regs.transforms.base.Transform`  | Maps a record stream → record stream          | `transforms/extract.py` |
+| `Writer`      | `spicy_regs.sources.base.Writer`        | A **sink**: persists records                  | `sources/parquet.py` |
+| `Pipeline`    | `spicy_regs.pipelines.base.Pipeline`    | Composes the above and exposes `run()`        | `pipelines/regulations.py` |
+
+Start with **`tests/test_example_pipeline.py`** — a runnable, minimal pipeline
+with one of each base class wired together. Copy it.
+
+Supporting pieces a pipeline can reuse:
+
+- `pipelines/staging.py` — `stage_agencies(...)` fans agencies out in parallel,
+  pumping each `Reader → Transform → Writer`.
+- `manifest.py` — `Manifest` tracks already-processed keys for incremental runs.
+- `sources/r2.py` — Cloudflare R2 download/upload helpers.
+
+**Two kinds of "transform."** A `Transform` shapes records one at a time
+(`apply(records) -> records`). Whole-dataset operations that need every row at
+once — deduplicating, partitioning, summaries — are *bulk* transforms and live
+in `transforms/merge.py`; they are functions, not `Transform` subclasses.
+
+**Convention:** `Reader`, `Writer`, and `Transform` are classes you subclass.
+Plain helper modules (e.g. `sources/r2.py`) are storage/connection utilities,
+not connectors — don't subclass them.
+
+### Recipes
+
+- **Add a record shape:** construct a new `RecordType` in `schemas/` (set
+  `path_pattern` only if your source addresses files by path).
+- **Add a source:** subclass `Reader`, implement `iter_records()` to yield raw
+  payloads (keep extraction out of the reader). See `sources/mirrulations.py`.
+- **Add a transform:** subclass `Transform`, implement `apply()`. See
+  `transforms/extract.py`.
+- **Add a sink:** subclass `Writer`, implement `write()`. See `sources/parquet.py`.
+- **Add a pipeline:** subclass `Pipeline`, set a `name`, compose your pieces in
+  `run()`. Register it for the CLI in `pipelines/regulations.py`'s `app` if it
+  should be runnable via `run-pipeline`.
+
 ## Commit messages
 
 - Use concise, imperative subject lines (e.g. `fix: handle empty batch`).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Spicy Regs goal is to build an open, contributor-friendly platform for exploring
 - **Claude Code via uvx (stdio MCP):** `claude mcp add spicy-regs -- uvx --from "spicy-regs @ git+https://github.com/civictechdc/spicy-regs" spicy-regs-mcp`. No deploy needed.
 - **Claude.ai or any remote MCP client:** deploy `mcp-server/` to Vercel and add the URL as a Custom Connector. See [`mcp-server/README.md`](mcp-server/README.md).
 
+## Contributing
+
+The ETL is built from small, composable building blocks (`Reader → Transform →
+Writer`, wired by a `Pipeline`). See the [Architecture section in
+CONTRIBUTING.md](CONTRIBUTING.md#architecture-the-etl-building-blocks) and the
+runnable reference in `tests/test_example_pipeline.py` for how to add your own.
+
 ## Contact us
 
 Join our [slack channel](https://civictechdc.slack.com/archives/C09H576E6LU)!

--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -32,17 +32,17 @@ from dotenv import load_dotenv
 from loguru import logger
 
 from spicy_regs.manifest import Manifest
-from spicy_regs.pipeline.transform import (
-    build_feed_summary,
-    merge_comments_partitioned,
-    merge_staging_files,
-    update_comments_index,
-)
 from spicy_regs.pipelines.base import Pipeline
 from spicy_regs.pipelines.staging import stage_agencies
 from spicy_regs.schemas import RECORD_TYPES, RecordType
 from spicy_regs.sources import mirrulations, r2
 from spicy_regs.transforms import ExtractRecords
+from spicy_regs.transforms.merge import (
+    build_feed_summary,
+    merge_comments_partitioned,
+    merge_staging_files,
+    update_comments_index,
+)
 
 load_dotenv()
 

--- a/src/spicy_regs/schemas/base.py
+++ b/src/spicy_regs/schemas/base.py
@@ -14,13 +14,17 @@ class RecordType:
     record dict matching the schema. Instances are values, not classes —
     contributors add new record shapes by constructing a new RecordType,
     not by subclassing.
+
+    ``path_pattern`` is optional and source-specific: the Mirrulations S3
+    reader uses it to locate this record type's files in the bucket. Sources
+    that don't address records by path (e.g. an HTTP API) can leave it unset.
     """
 
     name: str
-    path_pattern: str
     schema: dict[str, Any]
     dedup_key: str
     extract: Callable[[dict], dict]
+    path_pattern: str | None = None
 
     def __post_init__(self) -> None:
         if self.dedup_key not in self.schema:

--- a/src/spicy_regs/transforms/merge.py
+++ b/src/spicy_regs/transforms/merge.py
@@ -1,0 +1,29 @@
+"""Dataset-level (bulk) transforms.
+
+These operate on the *whole* staged dataset at once — merging per-agency Parquet
+files, deduplicating by key (keeping the latest ``modify_date``), partitioning
+comments, and building the feed summary. They run columnar / out-of-core in
+DuckDB, so unlike a record-stream :class:`~spicy_regs.transforms.base.Transform`
+they cannot be expressed as ``apply(records) -> records`` without buffering
+everything in memory.
+
+They live in the production pipeline (``spicy_regs.pipeline.transform``) and are
+re-exported here so every "transform" concept is discoverable from one package:
+
+* per-record shaping  -> :mod:`spicy_regs.transforms.extract` (a ``Transform``)
+* whole-dataset bulk  -> this module
+"""
+
+from spicy_regs.pipeline.transform import (
+    build_feed_summary,
+    merge_comments_partitioned,
+    merge_staging_files,
+    update_comments_index,
+)
+
+__all__ = [
+    "merge_staging_files",
+    "merge_comments_partitioned",
+    "update_comments_index",
+    "build_feed_summary",
+]

--- a/tests/test_example_pipeline.py
+++ b/tests/test_example_pipeline.py
@@ -1,10 +1,15 @@
 """End-to-end reference: one of each base class wired together.
 
-This file is a contributor reference. It implements a minimal pipeline
-that fetches posts from JSONPlaceholder, uppercases their titles, and
-prints them. The test monkeypatches ``urllib.request.urlopen`` with
-canned data so CI stays hermetic — to see the abstractions run against
-the live API, delete the monkeypatch and run ``pytest -s``.
+This file is the contributor reference — copy it when adding your own source,
+transform, or pipeline. It implements a minimal pipeline that fetches posts
+from JSONPlaceholder and uppercases their titles, composed exactly the way the
+real pipeline is:
+
+    Reader (raw JSON)  ->  Transform (shape)  ->  Transform (enrich)  ->  Writer
+
+The test monkeypatches ``urllib.request.urlopen`` with canned data so CI stays
+hermetic — to see it run against the live API, delete the monkeypatch and run
+``pytest -s``.
 """
 
 from collections.abc import Iterable, Iterator
@@ -18,11 +23,13 @@ import pytest
 from spicy_regs.pipelines import Pipeline
 from spicy_regs.schemas import RecordType
 from spicy_regs.sources import Reader, Writer
+from spicy_regs.transforms import ExtractRecords, Transform
 
-
+# A RecordType describes one data shape: its schema, primary key, and how to
+# flatten a raw payload into a row. ``path_pattern`` is S3-specific, so an HTTP
+# source like this one leaves it unset.
 Post = RecordType(
     name="posts",
-    path_pattern="/posts",
     schema={
         "post_id": str,
         "user_id": str,
@@ -42,45 +49,52 @@ Post = RecordType(
 
 
 class JsonPlaceholderReader(Reader):
-    """Reads posts from JSONPlaceholder and yields extracted records."""
+    """A source: fetches posts and yields the *raw* JSON payloads.
 
-    def __init__(self, url: str, record_type: RecordType) -> None:
+    Readers stay pure sources — shaping a payload into a record is the
+    ExtractRecords transform's job, not the reader's.
+    """
+
+    def __init__(self, url: str) -> None:
         self.url = url
-        self.record_type = record_type
 
     def iter_records(self) -> Iterator[dict]:
         with urlopen(self.url) as resp:
-            payload = loads(resp.read())
-        for raw in payload:
-            yield self.record_type.extract(raw)
+            yield from loads(resp.read())
 
 
-def uppercase_titles(records: Iterable[dict]) -> Iterator[dict]:
-    """Convention-only transform: uppercases the ``title`` field."""
-    for r in records:
-        yield {**r, "title": r["title"].upper()}
+class UppercaseTitles(Transform):
+    """A transform: uppercases the ``title`` field of each record."""
+
+    def apply(self, records: Iterable[dict]) -> Iterator[dict]:
+        for record in records:
+            yield {**record, "title": record["title"].upper()}
 
 
 class StdoutWriter(Writer):
-    """Writes records by printing each as a line to stdout."""
+    """A sink: writes records by printing each as a line to stdout."""
 
     def write(self, records: Iterable[dict]) -> None:
-        for r in records:
-            print(r)
+        for record in records:
+            print(record)
 
 
 class ExamplePipeline(Pipeline):
+    """Wires the source, transforms, and sink together."""
+
     name = "example"
 
     def __init__(self) -> None:
-        self.reader = JsonPlaceholderReader(
-            "https://jsonplaceholder.typicode.com/posts",
-            Post,
-        )
+        self.reader = JsonPlaceholderReader("https://jsonplaceholder.typicode.com/posts")
+        self.extract = ExtractRecords(Post)  # built-in transform: raw JSON -> record
+        self.uppercase = UppercaseTitles()  # our own transform
         self.writer = StdoutWriter()
 
     def run(self) -> None:
-        self.writer.write(uppercase_titles(self.reader.iter_records()))
+        records = self.reader.iter_records()
+        records = self.extract.apply(records)
+        records = self.uppercase.apply(records)
+        self.writer.write(records)
 
 
 _CANNED_POSTS = [


### PR DESCRIPTION
## Why

Follow-up to #44, which introduced the `Reader` / `Transform` / `Writer` / `Pipeline` building blocks. A review of that work through a new-contributor lens found the pieces are individually clean but hard to **follow**: there was no entry point describing the pattern, the one file labeled "contributor reference" taught a *different* shape than the production code, and "transform" meant two different things in two different import paths.

This PR closes those gaps. **No production behavior changes** — it's docs, the reference example, a re-export module, and one small schema tweak.

## What changed

- **Refresh the contributor reference** (`tests/test_example_pipeline.py`) to match the current pattern. The `Reader` is now a pure source yielding raw JSON, and the "uppercase titles" step is a real `Transform` subclass composed *after* the built-in `ExtractRecords`. Previously it taught the opposite (extraction inside the reader, a convention-only function "transform") — i.e. copying it produced the wrong shape.

- **Add an "Architecture: the ETL building blocks" section to `CONTRIBUTING.md`** — a one-screen data-flow diagram, a base-class/example table, the supporting pieces (`stage_agencies`, `Manifest`, `sources/r2`), the two-kinds-of-transform distinction, the class-vs-module convention, and copy-paste recipes for adding a record shape / source / transform / sink / pipeline. `README.md` links to it.

- **Disambiguate the two "transform" namespaces.** Added `transforms/merge.py` re-exporting the bulk dataset ops (`merge_staging_files`, `merge_comments_partitioned`, …) from `pipeline.transform`, so every transform concept is discoverable under `spicy_regs.transforms`: per-record shaping in `transforms/extract.py` vs. whole-dataset bulk in `transforms/merge.py`. `pipelines/regulations.py` now imports the bulk ops from there.

- **Make `RecordType.path_pattern` optional.** It's Mirrulations/S3-specific (used by the S3 reader to locate files); non-S3 sources like the HTTP example no longer have to supply a meaningless value.

## Out of scope

The production Prefect flow (`pipeline/pipeline.py`) and the scheduled ETL workflow are untouched. The remaining review items (e.g. settling whether connectors are always classes) are folded into the documented convention rather than a code change.

## Tests

Full suite green (`uv run pytest` → 125 passed); `ruff check` clean on all touched files. The reference example still runs end-to-end (`test_example_pipeline_runs_end_to_end`). The only remaining `ruff` findings are pre-existing in untouched files (`test_manifest.py`, `test_bloom_filter.py`, `conftest.py`).

https://claude.ai/code/session_01VarFnotZno16kSb9ADzXjA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VarFnotZno16kSb9ADzXjA)_