### PR TITLE
docs: onboard new members to running a pipeline and downloading data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,41 @@ Prerequisites: **Python 3.10+** and [**uv**](https://docs.astral.sh/uv/getting-s
    ```
 
 You don't need any credentials to run the tests or hack on most of the code.
-A `.env` file (copy from `.env.example`) is only required to talk to live
-Cloudflare R2 storage.
+A `.env` file (copy from `.env.example`) is only required to *upload* to live
+Cloudflare R2 storage — reading from the public Mirrulations mirror and
+downloading our published parquet files both work anonymously.
+
+### Get the data on your machine
+
+Two ways to get real data locally — pick whichever fits your task.
+
+**A. Download the published parquet files (fast, ~minutes).** Pulls our
+processed output from the public R2 bucket:
+
+```bash
+uv run spicy-regs download                       # dockets + documents + comments
+uv run spicy-regs download --types comments      # just comments
+uv run spicy-regs stats                          # sanity-check what you got
+uv run spicy-regs sample comments -n 5           # peek at a few rows
+```
+
+Files default to `./spicy-regs-data/`; override with `-o some/dir`.
+
+**B. Run the ETL pipeline yourself (slower, but it's the real thing).**
+Reads JSON from the Mirrulations S3 mirror, flattens it, writes Parquet to
+`./output/`. Keep the first run tiny so it finishes quickly:
+
+```bash
+# One agency, recent only, comments only — finishes in a few minutes.
+uv run run-pipeline --agency EPA --only-comments --since-year 2025
+```
+
+Outputs land in `./output/` (e.g. `output/comments.parquet`) alongside an
+incremental `manifest.json` — re-running picks up where the last run left
+off. Drop `--only-comments` / `--agency` / `--since-year` to widen the scope;
+add `--full-refresh` to ignore the manifest. `uv run run-pipeline --help`
+lists every flag. Upload to R2 stays off by default (`--skip-upload`); only
+the maintainers publish.
 
 ### Stuck?
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,62 @@ uv run pytest                 # run the test suite
 uv run ruff check .           # lint
 ```
 
-You don't need any credentials to run the tests or explore the code. A `.env`
-file (copy `.env.example` to `.env`) is only required if you want to talk to
-live Cloudflare R2 storage.
+You don't need any credentials to run the tests, download the published
+parquet files, or run the pipeline against the public Mirrulations mirror. A
+`.env` file (copy `.env.example` to `.env`) is only required if you want to
+upload your output to live Cloudflare R2 storage.
+
+### Download the published data locally
+
+The processed dockets / documents / comments parquet files are published to a
+public Cloudflare R2 bucket. Grab them with the bundled CLI — no credentials
+needed:
+
+```bash
+uv run spicy-regs download                        # all three (dockets, documents, comments)
+uv run spicy-regs download --types comments       # comments only
+uv run spicy-regs download -o ./my-data           # custom output dir
+```
+
+Files land in `./spicy-regs-data/` by default. Once downloaded, poke around:
+
+```bash
+uv run spicy-regs stats                # row counts + top agencies per file
+uv run spicy-regs sample comments -n 5 # 5 random rows from comments.parquet
+uv run spicy-regs search "climate"     # substring search across files
+uv run spicy-regs agencies             # list every agency code
+```
+
+> Don't have the repo cloned? You can also run it one-shot with
+> `uvx --from "spicy-regs @ git+https://github.com/civictechdc/spicy-regs" spicy-regs download --types comments`.
+
+### Run the ETL pipeline yourself
+
+The pipeline reads raw JSON from the public Mirrulations S3 mirror, flattens
+it, and writes Parquet to `./output/`. For a first run, scope it tight so it
+finishes in minutes instead of hours:
+
+```bash
+# Smallest useful run: one agency, recent dockets, comments only, no upload.
+uv run run-pipeline --agency EPA --only-comments --since-year 2025
+```
+
+What you get when it finishes:
+- `output/comments.parquet` — the merged + deduplicated comments
+- `output/manifest.json` — tracks already-processed source keys so the next
+  run is incremental (delete it for a full refresh, or pass `--full-refresh`)
+
+Other useful flags (see `uv run run-pipeline --help` for the full list):
+
+| Flag                    | What it does                                              |
+|-------------------------|-----------------------------------------------------------|
+| `--agency EPA`          | Process a single agency instead of all of them            |
+| `--since-year 2025`     | Skip dockets older than the given year                    |
+| `--only-comments`       | Stage comments only (skip dockets + documents)            |
+| `--skip-comments`       | Inverse — dockets + documents only (much faster)          |
+| `--max-workers 8`       | Agencies processed in parallel (default 4)                |
+| `--full-refresh`        | Ignore the existing manifest and rebuild from scratch     |
+| `--no-skip-upload`      | Also publish to R2 (needs credentials in `.env`)          |
 
 Next steps:
 - Open the runnable example pipeline at `tests/test_example_pipeline.py`.


### PR DESCRIPTION
## Summary

A new member dropping into the repo today can run the tests but isn't told how to (a) grab the published comments / dockets / documents parquet files or (b) actually execute the ETL. This PR closes both gaps in the two docs they're most likely to read.

**README.md** — adds two new sections under Quickstart:
- **Download the published data locally** — shows `uv run spicy-regs download`, including a `--types comments` example, the `stats` / `sample` / `search` / `agencies` helpers, and the no-clone `uvx` one-liner.
- **Run the ETL pipeline yourself** — gives a small, fast first-run invocation (`--agency EPA --only-comments --since-year 2025`), describes what lands in `./output/`, and tables the flags a newcomer is most likely to need.

**CONTRIBUTING.md** — adds a "Get the data on your machine" section to Getting started that mirrors the README's two paths (download vs. run), keeping the doc useful as the actual onramp for contributors. Also clarifies that `.env` is only needed for *uploading* to R2 — reading from Mirrulations and downloading published files both work anonymously.

No code changes.

## Test plan

- [x] `uv run spicy-regs download --types comments` matches the documented behavior (verified against `src/spicy_regs/cli.py`).
- [x] `uv run run-pipeline --agency EPA --only-comments --since-year 2025` matches the flag signature in `src/spicy_regs/pipelines/regulations.py`.
- [x] Markdown renders cleanly (tables, code fences, blockquote).


---
_Generated by [Claude Code](https://claude.ai/code/session_014kZyua53k6At1b1oi2CDsU)_