### PR TITLE
Fix hosted MCP server 421s and document mcp.spicy-regs.dev deployment

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -1,0 +1,45 @@
+name: Deploy MCP server
+
+# Deploys mcp-server/ to Vercel without the Vercel GitHub App (which isn't
+# installed on the civictechdc org). Needs one repo secret: VERCEL_TOKEN,
+# a Vercel personal access token with access to the team in VERCEL_SCOPE.
+# The first run creates the Vercel project if it doesn't exist yet.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mcp-server/**'
+      - '.github/workflows/deploy-mcp.yml'
+  workflow_dispatch:
+
+env:
+  VERCEL_SCOPE: kvec
+  VERCEL_PROJECT: spicy-regs-mcp
+
+concurrency:
+  group: deploy-mcp
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Link Vercel project
+        working-directory: mcp-server
+        run: >
+          npx vercel@latest link --yes
+          --scope "$VERCEL_SCOPE"
+          --project "$VERCEL_PROJECT"
+          --token "${{ secrets.VERCEL_TOKEN }}"
+
+      - name: Deploy to Vercel (production)
+        working-directory: mcp-server
+        run: >
+          npx vercel@latest deploy --prod --yes
+          --token "${{ secrets.VERCEL_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Next steps:
 
 - **Claude Code plugin:** `/plugin marketplace add civictechdc/spicy-regs` then `/plugin install spicyregs@spicy-regs-local`. Bundles the skill in this repo. See `plugins/spicyregs/skills/spicyregs/SKILL.md`.
 - **Claude Code via uvx (stdio MCP):** `claude mcp add spicy-regs -- uvx --from "spicy-regs @ git+https://github.com/civictechdc/spicy-regs" spicy-regs-mcp`. No deploy needed.
-- **Claude.ai or any remote MCP client:** deploy `mcp-server/` to Vercel and add the URL as a Custom Connector. See [`mcp-server/README.md`](mcp-server/README.md).
+- **Claude.ai or any remote MCP client:** add `https://mcp.spicy-regs.dev/mcp` as a Custom Connector (hosted on Vercel from `mcp-server/`). See [`mcp-server/README.md`](mcp-server/README.md).
 - **OpenAI / Cursor / Continue / other providers:** see [`plugins/spicyregs/INSTALL.md`](plugins/spicyregs/INSTALL.md) for the full install matrix across providers, including the provider-agnostic prompt fallback for assistants without MCP or skill support.
 
 ## Contributing

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -36,20 +36,30 @@ Available views: `dockets`, `documents`, `comments`, `comments_index`,
 The production deployment lives at **`https://mcp.spicy-regs.dev/mcp`** —
 that's the MCP endpoint you give to clients.
 
-### One-time project setup (dashboard)
+Deploys run through GitHub Actions
+([`.github/workflows/deploy-mcp.yml`](../.github/workflows/deploy-mcp.yml))
+rather than the Vercel GitHub App, because the app isn't installed on the
+`civictechdc` org. Any push to `main` that touches `mcp-server/` redeploys
+production; the workflow can also be run manually from the Actions tab.
 
-1. In the Vercel dashboard, **Add New → Project** and import this repo
-   (`civictechdc/spicy-regs`).
-2. Name the project (e.g. `spicy-regs-mcp`) and set **Root Directory** to
-   `mcp-server`. Leave Framework Preset as **Other** — `vercel.json` and the
-   `api/` directory drive the build.
-3. Deploy. Pushes to `main` now redeploy production automatically; PRs get
-   preview deployments.
-4. Under **Project → Settings → Domains**, add `mcp.spicy-regs.dev`. If the
-   `spicy-regs.dev` DNS isn't managed by Vercel, add the CNAME record the
-   dashboard shows you (the same setup already used for `app.spicy-regs.dev`).
+### One-time setup
 
-> Note: this must be a **separate Vercel project** from the `spicy-regs-ui`
+1. Create a Vercel access token at **vercel.com → Account Settings →
+   Tokens**, scoped to the team that owns the project.
+2. Add it as a repo secret named `VERCEL_TOKEN` (**repo Settings → Secrets
+   and variables → Actions**).
+3. Run the **Deploy MCP server** workflow once (Actions tab →
+   workflow_dispatch). The first run creates the Vercel project
+   (`spicy-regs-mcp`) if it doesn't exist.
+4. In the Vercel dashboard, under **Project → Settings → Domains**, add
+   `mcp.spicy-regs.dev`. If the `spicy-regs.dev` DNS isn't managed by
+   Vercel, add the CNAME record the dashboard shows you (the same setup
+   already used for `app.spicy-regs.dev`).
+
+The team and project name are pinned in the workflow's `VERCEL_SCOPE` and
+`VERCEL_PROJECT` env vars — edit those if the project moves.
+
+> Note: this is a **separate Vercel project** from the `spicy-regs-ui`
 > frontend project that serves `app.spicy-regs.dev`.
 
 ### Manual deploys (optional)

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -33,18 +33,33 @@ Available views: `dockets`, `documents`, `comments`, `comments_index`,
 
 ## Deploy to Vercel
 
-From this directory:
+The production deployment lives at **`https://mcp.spicy-regs.dev/mcp`** —
+that's the MCP endpoint you give to clients.
+
+### One-time project setup (dashboard)
+
+1. In the Vercel dashboard, **Add New → Project** and import this repo
+   (`civictechdc/spicy-regs`).
+2. Name the project (e.g. `spicy-regs-mcp`) and set **Root Directory** to
+   `mcp-server`. Leave Framework Preset as **Other** — `vercel.json` and the
+   `api/` directory drive the build.
+3. Deploy. Pushes to `main` now redeploy production automatically; PRs get
+   preview deployments.
+4. Under **Project → Settings → Domains**, add `mcp.spicy-regs.dev`. If the
+   `spicy-regs.dev` DNS isn't managed by Vercel, add the CNAME record the
+   dashboard shows you (the same setup already used for `app.spicy-regs.dev`).
+
+> Note: this must be a **separate Vercel project** from the `spicy-regs-ui`
+> frontend project that serves `app.spicy-regs.dev`.
+
+### Manual deploys (optional)
+
+From this directory, with the Vercel CLI authenticated:
 
 ```bash
 cd mcp-server
 npx vercel --prod
 ```
-
-Or set the Vercel project's **Root Directory** to `mcp-server/` in the
-dashboard and let Git pushes deploy automatically.
-
-The deployed URL will look like `https://<project>.vercel.app/mcp` — that's
-the MCP endpoint you give to clients.
 
 ### Environment variables (optional)
 
@@ -60,7 +75,7 @@ Requires Pro, Max, Team, or Enterprise.
 
 1. Open **Settings → Connectors → Add custom connector**.
 2. Name it `Spicy Regs`.
-3. URL: `https://<your-vercel-deploy>.vercel.app/mcp`.
+3. URL: `https://mcp.spicy-regs.dev/mcp`.
 4. Leave authentication as None (the bucket is public).
 5. Save and toggle the connector on in any conversation.
 
@@ -68,10 +83,10 @@ Requires Pro, Max, Team, or Enterprise.
 
 Two transports work. Pick one.
 
-**Remote HTTP (after deploying this directory to Vercel):**
+**Remote HTTP:**
 
 ```bash
-claude mcp add --transport http spicy-regs https://<your-vercel-deploy>.vercel.app/mcp
+claude mcp add --transport http spicy-regs https://mcp.spicy-regs.dev/mcp
 ```
 
 **Local stdio via `uvx` (no deploy needed):**

--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -17,6 +17,7 @@ from uuid import UUID
 
 import duckdb
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 
 DEFAULT_R2_BASE_URL = "https://pub-5fc11ad134984edf8d9af452dd1849d6.r2.dev"
 TABLES = ("dockets", "documents", "comments", "comments_index", "feed_summary")
@@ -89,6 +90,13 @@ mcp = FastMCP(
     instructions=INSTRUCTIONS,
     stateless_http=True,
     streamable_http_path="/mcp",
+    # The hosted deployment is reached via mcp.spicy-regs.dev and per-deploy
+    # *.vercel.app hosts; FastMCP's default localhost-only DNS-rebinding
+    # allowlist would reject all of them with 421. The server is public,
+    # stateless, and read-only, so rebinding protection buys nothing here.
+    transport_security=TransportSecuritySettings(
+        enable_dns_rebinding_protection=False
+    ),
 )
 
 

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -24,6 +24,7 @@ from uuid import UUID
 
 import duckdb
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 
 DEFAULT_R2_BASE_URL = "https://pub-5fc11ad134984edf8d9af452dd1849d6.r2.dev"
 TABLES = ("dockets", "documents", "comments", "comments_index", "feed_summary")
@@ -170,6 +171,14 @@ def build_app():
         instructions=INSTRUCTIONS,
         stateless_http=True,
         streamable_http_path="/mcp",
+        # The hosted deployment is reached via mcp.spicy-regs.dev and
+        # per-deploy *.vercel.app hosts; FastMCP's default localhost-only
+        # DNS-rebinding allowlist would reject all of them with 421. The
+        # server is public, stateless, and read-only, so rebinding
+        # protection buys nothing here.
+        transport_security=TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        ),
     )
     _register_tools(mcp)
     return mcp.streamable_http_app()


### PR DESCRIPTION
## Summary

Prepares `mcp-server/` for its Vercel deployment at `https://mcp.spicy-regs.dev/mcp`.

### Bug fix: 421 Misdirected Request on any non-localhost host

FastMCP (mcp 1.27) auto-enables DNS-rebinding protection with a **localhost-only Host allowlist** when no `transport_security` is passed and the bind host defaults to `127.0.0.1`. Deployed behind `mcp.spicy-regs.dev` (or any `*.vercel.app` preview URL), every request would be rejected with `421 Invalid Host header` — reproduced with an in-process `initialize` handshake before the fix, and verified 200 after.

The fix disables rebinding protection on the streamable-HTTP app in both the Vercel function (`mcp-server/api/index.py`) and the canonical module (`src/spicy_regs/mcp_server.py`, `build_app()`). An exact-host allowlist isn't viable because Vercel preview hostnames are unpredictable, and rebinding protection adds nothing for a public, stateless, read-only server.

### CI deploy workflow

The Vercel GitHub App isn't installed on the `civictechdc` org, so the dashboard repo import is blocked. `.github/workflows/deploy-mcp.yml` deploys with the Vercel CLI instead: pushes to `main` touching `mcp-server/` (or a manual dispatch) link to the `spicy-regs-mcp` project on the `kvec` team and deploy to production. The only secret required is `VERCEL_TOKEN`; the first run creates the project if it doesn't exist.

**One-time setup after merge:**
1. Add a `VERCEL_TOKEN` repo secret (Vercel personal access token scoped to the team).
2. Run the **Deploy MCP server** workflow once via workflow_dispatch.
3. Add the `mcp.spicy-regs.dev` domain to the new `spicy-regs-mcp` project in the Vercel dashboard.

### Docs

- `mcp-server/README.md`: canonical endpoint is now `https://mcp.spicy-regs.dev/mcp`; documents the Actions-based deploy, the one-time token/domain setup, and notes this is a separate project from the `spicy-regs-ui` frontend that serves `app.spicy-regs.dev`.
- Root `README.md`: Custom Connector instructions now point at the hosted endpoint.

## Testing

- `uv run pytest` — 125 passed (includes `test_vercel_copy_in_sync`).
- Simulated the Vercel build in a clean venv with only `mcp-server/requirements.txt` installed; the ASGI app imports and the MCP `initialize` handshake returns 200 under the `mcp.spicy-regs.dev` hostname.
- Workflow YAML parses cleanly.

https://claude.ai/code/session_01Y7nppoLn1LtrTG6wMm7nYS