### PR TITLE
Fix 404 on mcp.spicy-regs.dev: rewrite destination wasn't routable

### DIFF
--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -166,4 +166,22 @@ def query_sql(sql: str, max_rows: int = 25) -> dict[str, Any]:
     }
 
 
-app = mcp.streamable_http_app()
+_asgi_app = mcp.streamable_http_app()
+
+_FUNCTION_PATH = "/api/index"
+
+
+async def app(scope, receive, send):
+    """ASGI entry point for Vercel.
+
+    vercel.json rewrites /mcp to this function. Only the exact function path
+    (/api/index) is routable on the platform, and depending on how rewritten
+    requests are forwarded the ASGI path can arrive as the original (/mcp) or
+    as the function path; normalize the latter onto the transport's /mcp
+    mount so both work.
+    """
+    if scope["type"] == "http" and scope.get("path", "").startswith(_FUNCTION_PATH):
+        suffix = scope["path"][len(_FUNCTION_PATH) :]
+        path = suffix if suffix.startswith("/mcp") else "/mcp"
+        scope = {**scope, "path": path, "raw_path": path.encode()}
+    await _asgi_app(scope, receive, send)

--- a/mcp-server/vercel.json
+++ b/mcp-server/vercel.json
@@ -6,7 +6,7 @@
     }
   },
   "rewrites": [
-    { "source": "/mcp", "destination": "/api/index/mcp" },
-    { "source": "/mcp/(.*)", "destination": "/api/index/mcp/$1" }
+    { "source": "/mcp", "destination": "/api/index" },
+    { "source": "/mcp/(.*)", "destination": "/api/index" }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #63: the first production deploy of the MCP server succeeded at build time but **every request to `https://mcp.spicy-regs.dev/mcp` returned a platform-level 404**.

### Root cause

Vercel only routes the exact function path (`/api/index`) to `api/index.py` — subpaths like `/api/index/mcp` don't resolve to the function. The rewrite in `vercel.json` pointed `/mcp` at `/api/index/mcp`, so requests died at Vercel's router before ever reaching the app. (Verified against the live deployment: `/mcp` and `/api/index/mcp` return Vercel's `NOT_FOUND`, while `/api/index` reaches the Starlette app.)

### Fix

- `vercel.json`: rewrite `/mcp` (and `/mcp/*`) to `/api/index`, the only routable destination.
- `api/index.py`: a small ASGI shim normalizes the function path back onto the transport's `/mcp` mount, so the app answers whether the platform forwards the original path (`/mcp`) or the rewrite destination (`/api/index`).

## Testing

- In-process `initialize` handshake returns 200 with a valid MCP response on all three paths the function can receive: `/mcp`, `/api/index`, and `/api/index/mcp`.
- `uv run pytest` — 125 passed.

Merging this triggers the deploy workflow and should make `https://mcp.spicy-regs.dev/mcp` live.

https://claude.ai/code/session_01Y7nppoLn1LtrTG6wMm7nYS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7nppoLn1LtrTG6wMm7nYS)_