### PR TITLE
Fix DuckDB "home directory" error on serverless MCP deploy

### DIFF
--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -9,6 +9,7 @@ the same tool surface (names, parameters, behavior); the test at
 from __future__ import annotations
 
 import os
+import tempfile
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import Any
@@ -47,6 +48,27 @@ def _resolve_r2_base_url() -> str:
 R2_BASE_URL = _resolve_r2_base_url()
 
 
+def _resolve_home_directory() -> str:
+    """Pick a writable directory for DuckDB's extension/home cache.
+
+    DuckDB resolves its extension cache under ``$HOME/.duckdb``. Serverless
+    hosts (Vercel/AWS Lambda) frequently have no writable home directory, or
+    none defined at all, so ``INSTALL httpfs`` fails with
+    ``Can't find the home directory at ''``. Defaulting to the platform temp
+    directory keeps the extension fetch working there while staying valid on
+    local stdio installs; ``SPICY_REGS_HOME_DIR`` overrides it.
+    """
+    raw = os.environ.get("SPICY_REGS_HOME_DIR", tempfile.gettempdir())
+    if any(c in raw for c in ("\x00", "\n", "\r")):
+        raise RuntimeError(
+            f"SPICY_REGS_HOME_DIR contains illegal characters: {raw!r}"
+        )
+    return raw
+
+
+HOME_DIRECTORY = _resolve_home_directory()
+
+
 def _jsonify(value: Any) -> Any:
     """Coerce DuckDB row values into JSON-serializable forms."""
     if value is None or isinstance(value, (str, int, float, bool)):
@@ -70,6 +92,10 @@ def _jsonify(value: Any) -> Any:
 
 def _connect() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
+    # Must precede INSTALL/LOAD: that step writes the extension under
+    # <home_directory>/.duckdb, and the default home is read-only or undefined
+    # on serverless hosts.
+    con.execute(f"SET home_directory='{HOME_DIRECTORY.replace(chr(39), chr(39) * 2)}'")
     con.execute("INSTALL httpfs")
     con.execute("LOAD httpfs")
     con.execute("SET preserve_insertion_order=false")

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -16,6 +16,7 @@ tool surface (names, parameters, behavior) in sync between the two files;
 from __future__ import annotations
 
 import os
+import tempfile
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import Any
@@ -54,6 +55,27 @@ def _resolve_r2_base_url() -> str:
 R2_BASE_URL = _resolve_r2_base_url()
 
 
+def _resolve_home_directory() -> str:
+    """Pick a writable directory for DuckDB's extension/home cache.
+
+    DuckDB resolves its extension cache under ``$HOME/.duckdb``. Serverless
+    hosts (Vercel/AWS Lambda) frequently have no writable home directory, or
+    none defined at all, so ``INSTALL httpfs`` fails with
+    ``Can't find the home directory at ''``. Defaulting to the platform temp
+    directory keeps the extension fetch working there while staying valid on
+    local stdio installs; ``SPICY_REGS_HOME_DIR`` overrides it.
+    """
+    raw = os.environ.get("SPICY_REGS_HOME_DIR", tempfile.gettempdir())
+    if any(c in raw for c in ("\x00", "\n", "\r")):
+        raise RuntimeError(
+            f"SPICY_REGS_HOME_DIR contains illegal characters: {raw!r}"
+        )
+    return raw
+
+
+HOME_DIRECTORY = _resolve_home_directory()
+
+
 def _jsonify(value: Any) -> Any:
     """Coerce DuckDB row values into JSON-serializable forms."""
     if value is None or isinstance(value, (str, int, float, bool)):
@@ -77,6 +99,10 @@ def _jsonify(value: Any) -> Any:
 
 def _connect() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
+    # Must precede INSTALL/LOAD: that step writes the extension under
+    # <home_directory>/.duckdb, and the default home is read-only or undefined
+    # on serverless hosts.
+    con.execute(f"SET home_directory='{HOME_DIRECTORY.replace(chr(39), chr(39) * 2)}'")
     con.execute("INSTALL httpfs")
     con.execute("LOAD httpfs")
     con.execute("SET preserve_insertion_order=false")


### PR DESCRIPTION
## Problem

The deployed MCP server can connect and `list_sources`, but `describe_table` / `query_sql` fail. Each query opens a fresh DuckDB connection and runs `INSTALL httpfs`, which writes the extension under `$HOME/.duckdb`. On Vercel/AWS Lambda the home directory is read-only or undefined, so DuckDB raises:

```
IO Error: Can't find the home directory at ''
Specify a home directory using the SET home_directory='/path/to/dir' option.
```

(Reproduced locally by unsetting `HOME` before `INSTALL httpfs` — the error message matches exactly, and DuckDB itself recommends `SET home_directory`.)

## Fix

Run `SET home_directory=...` **before** `INSTALL`/`LOAD httpfs` (that's the step touching `$HOME/.duckdb`) so the extension is fetched and cached in a writable location.

- Defaults to `tempfile.gettempdir()` — `/tmp` on Vercel/Lambda, and a valid writable temp dir on Linux/macOS/Windows, so the local stdio server keeps working everywhere (no hardcoded `/tmp`).
- Overridable via `SPICY_REGS_HOME_DIR`.
- Single quotes in the path are escaped before interpolation; control chars are rejected.

Applied to both the canonical server (`src/spicy_regs/mcp_server.py`) and the in-sync Vercel copy (`mcp-server/api/index.py`).

## Testing

- `tests/test_mcp_server.py` — all 7 pass, including `test_vercel_copy_in_sync`.
- Verified locally that with `HOME` unset the home-directory error is resolved by the new `SET home_directory` (the only remaining failure in the sandbox is the blocked extension download, which works on Vercel).

https://claude.ai/code/session_018oDwbRe6ukq5r7Qr1XRjMh

---
_Generated by [Claude Code](https://claude.ai/code/session_018oDwbRe6ukq5r7Qr1XRjMh)_