### PR TITLE
ETL: add withdrawn / reason_withdrawn fields to documents

### DIFF
--- a/plugins/spicyregs/skills/spicyregs/references/data-layout.md
+++ b/plugins/spicyregs/skills/spicyregs/references/data-layout.md
@@ -42,6 +42,8 @@ These fields are stable enough to start with, but use `--describe` for the actua
 - `comment_start_date`
 - `comment_end_date`
 - `file_url`
+- `withdrawn` (`"true"`/`"false"`, often null)
+- `reason_withdrawn` (often null)
 
 ### comments
 

--- a/src/spicy_regs/pipeline/README.md
+++ b/src/spicy_regs/pipeline/README.md
@@ -100,6 +100,8 @@ All columns are stored as strings (`large_string` in PyArrow).
 | `comment_start_date` | Comment period start |
 | `comment_end_date` | Comment period end |
 | `file_url` | URL to the original document file |
+| `withdrawn` | Whether the document was withdrawn (`"true"`/`"false"`, often null) |
+| `reason_withdrawn` | Stated reason for withdrawal (often null) |
 
 ### Comments (~31.6M rows)
 

--- a/src/spicy_regs/pipeline/pipeline.py
+++ b/src/spicy_regs/pipeline/pipeline.py
@@ -160,6 +160,8 @@ DATA_TYPES: dict[str, _DataTypeConfig] = {
             "comment_start_date": pl.Utf8,
             "comment_end_date": pl.Utf8,
             "file_url": pl.Utf8,
+            "withdrawn": pl.Utf8,
+            "reason_withdrawn": pl.Utf8,
         },
         "extract": lambda d: {
             "document_id": d.get("data", {}).get("id"),
@@ -172,6 +174,8 @@ DATA_TYPES: dict[str, _DataTypeConfig] = {
             "comment_start_date": d.get("data", {}).get("attributes", {}).get("commentStartDate"),
             "comment_end_date": d.get("data", {}).get("attributes", {}).get("commentEndDate"),
             "file_url": (d.get("data", {}).get("attributes", {}).get("fileFormats") or [{}])[0].get("fileUrl"),
+            "withdrawn": d.get("data", {}).get("attributes", {}).get("withdrawn"),
+            "reason_withdrawn": d.get("data", {}).get("attributes", {}).get("reasonWithdrawn"),
         },
     },
     "comments": {

--- a/src/spicy_regs/schemas/regulations.py
+++ b/src/spicy_regs/schemas/regulations.py
@@ -84,6 +84,8 @@ DOCUMENT = RecordType(
         "comment_start_date": pl.Utf8,
         "comment_end_date": pl.Utf8,
         "file_url": pl.Utf8,
+        "withdrawn": pl.Utf8,
+        "reason_withdrawn": pl.Utf8,
     },
     dedup_key="document_id",
     extract=lambda d: {
@@ -97,6 +99,8 @@ DOCUMENT = RecordType(
         "comment_start_date": d.get("data", {}).get("attributes", {}).get("commentStartDate"),
         "comment_end_date": d.get("data", {}).get("attributes", {}).get("commentEndDate"),
         "file_url": (d.get("data", {}).get("attributes", {}).get("fileFormats") or [{}])[0].get("fileUrl"),
+        "withdrawn": d.get("data", {}).get("attributes", {}).get("withdrawn"),
+        "reason_withdrawn": d.get("data", {}).get("attributes", {}).get("reasonWithdrawn"),
     },
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,8 +57,8 @@ def sample_comments() -> list[dict]:
 @pytest.fixture
 def sample_documents() -> list[dict]:
     return [
-        {"document_id": "D-001", "docket_id": "EPA-2024-0001", "agency_code": "EPA", "title": "Proposed Rule", "document_type": "Proposed Rule", "posted_date": "2024-06-01", "modify_date": "2024-06-01", "comment_start_date": "2024-06-01", "comment_end_date": "2024-07-01", "file_url": None},
-        {"document_id": "D-002", "docket_id": "FDA-2024-0010", "agency_code": "FDA", "title": "Notice", "document_type": "Notice", "posted_date": "2024-04-15", "modify_date": "2024-04-15", "comment_start_date": "2024-04-15", "comment_end_date": "2024-05-15", "file_url": None},
+        {"document_id": "D-001", "docket_id": "EPA-2024-0001", "agency_code": "EPA", "title": "Proposed Rule", "document_type": "Proposed Rule", "posted_date": "2024-06-01", "modify_date": "2024-06-01", "comment_start_date": "2024-06-01", "comment_end_date": "2024-07-01", "file_url": None, "withdrawn": "false", "reason_withdrawn": None},
+        {"document_id": "D-002", "docket_id": "FDA-2024-0010", "agency_code": "FDA", "title": "Notice", "document_type": "Notice", "posted_date": "2024-04-15", "modify_date": "2024-04-15", "comment_start_date": "2024-04-15", "comment_end_date": "2024-05-15", "file_url": None, "withdrawn": "true", "reason_withdrawn": "Superseded by revised proposal"},
     ]
 
 
@@ -99,6 +99,8 @@ DOCUMENT_SCHEMA = {
     "comment_start_date": pl.Utf8,
     "comment_end_date": pl.Utf8,
     "file_url": pl.Utf8,
+    "withdrawn": pl.Utf8,
+    "reason_withdrawn": pl.Utf8,
 }
 
 

--- a/tests/test_record_types.py
+++ b/tests/test_record_types.py
@@ -60,6 +60,8 @@ def test_document_extract_takes_first_file_url() -> None:
                     {"fileUrl": "https://example.gov/a.pdf"},
                     {"fileUrl": "https://example.gov/b.pdf"},
                 ],
+                "withdrawn": True,
+                "reasonWithdrawn": "Superseded by revised proposal",
             },
         }
     }
@@ -67,11 +69,22 @@ def test_document_extract_takes_first_file_url() -> None:
     assert out["document_id"] == "EPA-2024-0001-0002"
     assert out["docket_id"] == "EPA-2024-0001"
     assert out["file_url"] == "https://example.gov/a.pdf"
+    assert out["withdrawn"] is True
+    assert out["reason_withdrawn"] == "Superseded by revised proposal"
 
 
 def test_document_extract_handles_missing_file_formats() -> None:
     raw = {"data": {"id": "X-1", "attributes": {}}}
     assert DOCUMENT.extract(raw)["file_url"] is None
+
+
+def test_document_extract_missing_withdrawal_fields_are_none() -> None:
+    # withdrawn/reason_withdrawn come from the source attributes but are absent
+    # on most documents; they should surface as None, not KeyError.
+    raw = {"data": {"id": "X-1", "attributes": {}}}
+    out = DOCUMENT.extract(raw)
+    assert out["withdrawn"] is None
+    assert out["reason_withdrawn"] is None
 
 
 def test_comment_extract_packs_attachments_json() -> None:


### PR DESCRIPTION
## Summary

Closes #50.

The `withdrawn` and `reasonWithdrawn` fields exist in the regulations.gov document payload but were dropped at ingest, so `documents.parquet` carried neither. Without them, the lifecycle view can't distinguish **abandoned vs. withdrawn vs. pending** rulemakings — leaving the frontend on a `DemoPill` placeholder and an age-window "stuck" heuristic instead of the real withdrawal status.

I confirmed both fields are present in the source payload (`sample-data/mirrulations/document-ACF-2025-0038-0001.json` carries `withdrawn: false` and `reasonWithdrawn: null`).

## Changes

- Add `withdrawn` / `reason_withdrawn` to the `DOCUMENT` schema + extractor in **both** ingest paths — the current `pipelines/` stack (`schemas/regulations.py`) and the legacy `pipeline/` stack (`pipeline/pipeline.py`) — keeping them in sync, mirroring how #49 was handled.
- polars stringifies the source boolean to `"true"`/`"false"` (null when absent) under the existing all-strings column convention; `reason_withdrawn` is a string/null passthrough.
- No merge change needed: documents flow through `merge_staging_files`, which already tolerates schema evolution via `union_by_name=true` (missing columns on older files become NULL).
- Align test fixtures (`conftest` `sample_documents` + `DOCUMENT_SCHEMA`) and add extraction coverage for the new fields, including the missing-field null path.
- Document the new columns in the skill data-layout reference and the pipeline README schema table.

## Testing

- `uv run pytest` — 128 passed
- `uv run ruff check` — clean
- `uv run ty check` — clean
- Verified extraction against the real sample document payload

## Follow-up (out of scope, separate repo)

Frontend work to replace the `DemoPill` and the age-window "stuck" heuristic with the real fields, as noted in the issue.

https://claude.ai/code/session_01Qb1vYBqb8T8DKnGKEuTvj6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qb1vYBqb8T8DKnGKEuTvj6)_