### PR TITLE
ETL: add rin / additional_rins fields

### DIFF
--- a/plugins/spicyregs/skills/spicyregs/references/data-layout.md
+++ b/plugins/spicyregs/skills/spicyregs/references/data-layout.md
@@ -29,6 +29,7 @@ These fields are stable enough to start with, but use `--describe` for the actua
 - `docket_type`
 - `modify_date`
 - `abstract`
+- `rin` (Regulation Identifier Number, often null)
 
 ### documents
 
@@ -44,6 +45,7 @@ These fields are stable enough to start with, but use `--describe` for the actua
 - `file_url`
 - `withdrawn` (`"true"`/`"false"`, often null)
 - `reason_withdrawn` (often null)
+- `additional_rins` (JSON array of extra RINs, often null)
 
 ### comments
 

--- a/src/spicy_regs/pipeline/README.md
+++ b/src/spicy_regs/pipeline/README.md
@@ -85,6 +85,7 @@ All columns are stored as strings (`large_string` in PyArrow).
 | `docket_type` | Type of docket (e.g., `Rulemaking`, `Nonrulemaking`) |
 | `modify_date` | Last modification date (ISO 8601) |
 | `abstract` | Docket description/abstract |
+| `rin` | Regulation Identifier Number for the rulemaking (often null) |
 
 ### Documents (~2.1M rows)
 
@@ -102,6 +103,7 @@ All columns are stored as strings (`large_string` in PyArrow).
 | `file_url` | URL to the original document file |
 | `withdrawn` | Whether the document was withdrawn (`"true"`/`"false"`, often null) |
 | `reason_withdrawn` | Stated reason for withdrawal (often null) |
+| `additional_rins` | JSON array of additional RINs linked to the document (often null) |
 
 ### Comments (~31.6M rows)
 

--- a/src/spicy_regs/pipeline/pipeline.py
+++ b/src/spicy_regs/pipeline/pipeline.py
@@ -137,6 +137,7 @@ DATA_TYPES: dict[str, _DataTypeConfig] = {
             "docket_type": pl.Utf8,
             "modify_date": pl.Utf8,
             "abstract": pl.Utf8,
+            "rin": pl.Utf8,
         },
         "extract": lambda d: {
             "docket_id": (v.strip('"') if (v := d.get("data", {}).get("id")) else v),
@@ -145,6 +146,7 @@ DATA_TYPES: dict[str, _DataTypeConfig] = {
             "docket_type": d.get("data", {}).get("attributes", {}).get("docketType"),
             "modify_date": d.get("data", {}).get("attributes", {}).get("modifyDate"),
             "abstract": d.get("data", {}).get("attributes", {}).get("dkAbstract"),
+            "rin": d.get("data", {}).get("attributes", {}).get("rin"),
         },
     },
     "documents": {
@@ -162,6 +164,7 @@ DATA_TYPES: dict[str, _DataTypeConfig] = {
             "file_url": pl.Utf8,
             "withdrawn": pl.Utf8,
             "reason_withdrawn": pl.Utf8,
+            "additional_rins": pl.Utf8,
         },
         "extract": lambda d: {
             "document_id": d.get("data", {}).get("id"),
@@ -176,6 +179,7 @@ DATA_TYPES: dict[str, _DataTypeConfig] = {
             "file_url": (d.get("data", {}).get("attributes", {}).get("fileFormats") or [{}])[0].get("fileUrl"),
             "withdrawn": d.get("data", {}).get("attributes", {}).get("withdrawn"),
             "reason_withdrawn": d.get("data", {}).get("attributes", {}).get("reasonWithdrawn"),
+            "additional_rins": (json_dumps(rins) if (rins := d.get("data", {}).get("attributes", {}).get("additionalRins")) else None),
         },
     },
     "comments": {

--- a/src/spicy_regs/schemas/regulations.py
+++ b/src/spicy_regs/schemas/regulations.py
@@ -57,6 +57,7 @@ DOCKET = RecordType(
         "docket_type": pl.Utf8,
         "modify_date": pl.Utf8,
         "abstract": pl.Utf8,
+        "rin": pl.Utf8,
     },
     dedup_key="docket_id",
     extract=lambda d: {
@@ -66,6 +67,7 @@ DOCKET = RecordType(
         "docket_type": d.get("data", {}).get("attributes", {}).get("docketType"),
         "modify_date": d.get("data", {}).get("attributes", {}).get("modifyDate"),
         "abstract": d.get("data", {}).get("attributes", {}).get("dkAbstract"),
+        "rin": d.get("data", {}).get("attributes", {}).get("rin"),
     },
 )
 
@@ -86,6 +88,7 @@ DOCUMENT = RecordType(
         "file_url": pl.Utf8,
         "withdrawn": pl.Utf8,
         "reason_withdrawn": pl.Utf8,
+        "additional_rins": pl.Utf8,
     },
     dedup_key="document_id",
     extract=lambda d: {
@@ -101,6 +104,7 @@ DOCUMENT = RecordType(
         "file_url": (d.get("data", {}).get("attributes", {}).get("fileFormats") or [{}])[0].get("fileUrl"),
         "withdrawn": d.get("data", {}).get("attributes", {}).get("withdrawn"),
         "reason_withdrawn": d.get("data", {}).get("attributes", {}).get("reasonWithdrawn"),
+        "additional_rins": (json_dumps(rins) if (rins := d.get("data", {}).get("attributes", {}).get("additionalRins")) else None),
     },
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ def sample_dockets() -> list[dict]:
             "docket_type": "Rulemaking",
             "modify_date": "2024-06-15",
             "abstract": "Proposed rule for clean air",
+            "rin": "2060-AG12",
         },
         {
             "docket_id": "FDA-2024-0010",
@@ -32,6 +33,7 @@ def sample_dockets() -> list[dict]:
             "docket_type": "Rulemaking",
             "modify_date": "2024-05-01",
             "abstract": "Updated drug labeling requirements",
+            "rin": "0910-AH34",
         },
         {
             "docket_id": "EPA-2024-0002",
@@ -40,6 +42,7 @@ def sample_dockets() -> list[dict]:
             "docket_type": "Nonrulemaking",
             "modify_date": "2024-07-20",
             "abstract": None,
+            "rin": None,
         },
     ]
 
@@ -57,8 +60,8 @@ def sample_comments() -> list[dict]:
 @pytest.fixture
 def sample_documents() -> list[dict]:
     return [
-        {"document_id": "D-001", "docket_id": "EPA-2024-0001", "agency_code": "EPA", "title": "Proposed Rule", "document_type": "Proposed Rule", "posted_date": "2024-06-01", "modify_date": "2024-06-01", "comment_start_date": "2024-06-01", "comment_end_date": "2024-07-01", "file_url": None, "withdrawn": "false", "reason_withdrawn": None},
-        {"document_id": "D-002", "docket_id": "FDA-2024-0010", "agency_code": "FDA", "title": "Notice", "document_type": "Notice", "posted_date": "2024-04-15", "modify_date": "2024-04-15", "comment_start_date": "2024-04-15", "comment_end_date": "2024-05-15", "file_url": None, "withdrawn": "true", "reason_withdrawn": "Superseded by revised proposal"},
+        {"document_id": "D-001", "docket_id": "EPA-2024-0001", "agency_code": "EPA", "title": "Proposed Rule", "document_type": "Proposed Rule", "posted_date": "2024-06-01", "modify_date": "2024-06-01", "comment_start_date": "2024-06-01", "comment_end_date": "2024-07-01", "file_url": None, "withdrawn": "false", "reason_withdrawn": None, "additional_rins": None},
+        {"document_id": "D-002", "docket_id": "FDA-2024-0010", "agency_code": "FDA", "title": "Notice", "document_type": "Notice", "posted_date": "2024-04-15", "modify_date": "2024-04-15", "comment_start_date": "2024-04-15", "comment_end_date": "2024-05-15", "file_url": None, "withdrawn": "true", "reason_withdrawn": "Superseded by revised proposal", "additional_rins": "[\"0910-AH35\"]"},
     ]
 
 
@@ -69,6 +72,7 @@ DOCKET_SCHEMA = {
     "docket_type": pl.Utf8,
     "modify_date": pl.Utf8,
     "abstract": pl.Utf8,
+    "rin": pl.Utf8,
 }
 
 COMMENT_SCHEMA = {
@@ -101,6 +105,7 @@ DOCUMENT_SCHEMA = {
     "file_url": pl.Utf8,
     "withdrawn": pl.Utf8,
     "reason_withdrawn": pl.Utf8,
+    "additional_rins": pl.Utf8,
 }
 
 

--- a/tests/test_record_types.py
+++ b/tests/test_record_types.py
@@ -30,6 +30,7 @@ def test_docket_extract() -> None:
                 "docketType": "Rulemaking",
                 "modifyDate": "2024-06-15",
                 "dkAbstract": "Proposed rule",
+                "rin": "2060-AG12",
             },
         }
     }
@@ -40,7 +41,15 @@ def test_docket_extract() -> None:
         "docket_type": "Rulemaking",
         "modify_date": "2024-06-15",
         "abstract": "Proposed rule",
+        "rin": "2060-AG12",
     }
+
+
+def test_docket_extract_missing_rin_is_none() -> None:
+    # rin is the docket-level Regulation Identifier Number; it is often absent
+    # (e.g. nonrulemaking dockets) and should surface as None, not KeyError.
+    raw = {"data": {"id": "X-1", "attributes": {}}}
+    assert DOCKET.extract(raw)["rin"] is None
 
 
 def test_document_extract_takes_first_file_url() -> None:
@@ -62,6 +71,7 @@ def test_document_extract_takes_first_file_url() -> None:
                 ],
                 "withdrawn": True,
                 "reasonWithdrawn": "Superseded by revised proposal",
+                "additionalRins": ["2060-AG12", "2060-AG13"],
             },
         }
     }
@@ -71,6 +81,7 @@ def test_document_extract_takes_first_file_url() -> None:
     assert out["file_url"] == "https://example.gov/a.pdf"
     assert out["withdrawn"] is True
     assert out["reason_withdrawn"] == "Superseded by revised proposal"
+    assert loads(out["additional_rins"]) == ["2060-AG12", "2060-AG13"]
 
 
 def test_document_extract_handles_missing_file_formats() -> None:
@@ -85,6 +96,15 @@ def test_document_extract_missing_withdrawal_fields_are_none() -> None:
     out = DOCUMENT.extract(raw)
     assert out["withdrawn"] is None
     assert out["reason_withdrawn"] is None
+
+
+def test_document_extract_additional_rins_empty_or_missing_is_none() -> None:
+    # additionalRins is a source array exploded into a link table downstream;
+    # both an absent key and an empty list should collapse to None rather than
+    # an empty-JSON string, so nothing is materialized for documents with no RINs.
+    assert DOCUMENT.extract({"data": {"id": "X-1", "attributes": {}}})["additional_rins"] is None
+    raw_empty = {"data": {"id": "X-2", "attributes": {"additionalRins": []}}}
+    assert DOCUMENT.extract(raw_empty)["additional_rins"] is None
 
 
 def test_comment_extract_packs_attachments_json() -> None:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -21,6 +21,7 @@ def test_extract_records_flattens_raw_payloads() -> None:
                 "docketType": "Rulemaking",
                 "modifyDate": "2024-06-15",
                 "dkAbstract": "Proposed rule",
+                "rin": "2060-AG12",
             },
         }
     }
@@ -33,6 +34,7 @@ def test_extract_records_flattens_raw_payloads() -> None:
             "docket_type": "Rulemaking",
             "modify_date": "2024-06-15",
             "abstract": "Proposed rule",
+            "rin": "2060-AG12",
         }
     ]
 


### PR DESCRIPTION
## Summary

Adds the `rin` (Regulation Identifier Number) and `additional_rins` fields to the ETL output, closing the §1 ETL gap tracked in #51. These were present in the regulations.gov payloads but dropped at ingest, so the frontend was stuck on a `DemoPill` placeholder and there was no key to link dockets that belong to one multi-stage rulemaking or to join cross-docket campaigns.

This is the next §1 item after #49 (submitter fields) and #50 (withdrawn/reason_withdrawn).

## What the data looks like

Inspecting the sample payloads showed the two fields live on different entities:

- **Dockets** carry `rin` — a single string (the rulemaking's primary RIN).
- **Documents** carry `additionalRins` — an array of extra RIN strings.

So `rin` is added to the docket record and `additional_rins` to the document record, each at its true source.

## Changes

- **Schema + extractor** (`schemas/regulations.py`): `rin` on `DOCKET` (from `attributes.rin`), `additional_rins` on `DOCUMENT` (from `attributes.additionalRins`). The legacy `pipeline/pipeline.py` `DATA_TYPES` stack is kept in sync.
- **Array handling**: `additionalRins` is JSON-stringified (mirroring the existing `attachments_json` convention) so it stays a string column. An absent key or an empty list collapses to `null`, so nothing is materialized for documents with no RINs — keeping the column clean to explode into the planned `rin` link table (#56).
- **Merge**: dockets/documents merge through `merge_staging_files` with `union_by_name=true`, which already tolerates schema evolution — no merge change needed.
- **Tests**: fixtures aligned (`sample_dockets`, `sample_documents`, schemas); added extraction coverage including the missing-key and empty-list null paths.
- **Docs**: new columns documented in the skill data-layout reference and the pipeline README schema tables.

## Testing

- `uv run pytest` — 130 passed
- `uv run ruff check` — clean

Closes #51

https://claude.ai/code/session_013TSLmLSVqw5DE3nKhpRnGN

---
_Generated by [Claude Code](https://claude.ai/code/session_013TSLmLSVqw5DE3nKhpRnGN)_