### PR TITLE
ETL: expand document attachment metadata (#52)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,4 +33,7 @@ jobs:
         run: uv sync
 
       - name: Run integration tests (live Mirrulations S3)
-        run: uv run pytest -m integration -v
+        # -s disables pytest output capture so loguru's step-by-step logs
+        # (which write to stderr) stream live into the Actions log, not just
+        # on failure. -v prints each test id.
+        run: uv run pytest -m integration -v -s

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,36 @@
+name: Integration (live data)
+
+# Exercises the ETL extract -> staging -> merge path against a REAL document
+# fetched live from the public Mirrulations S3 mirror (the pipeline's upstream
+# source). Kept separate from ci.yml because it needs outbound network access
+# and can be affected by upstream availability — the hermetic unit suite in
+# ci.yml stays fast and deterministic. The weekly run catches source-shape drift.
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 1'  # Mondays 12:00 UTC
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run integration tests (live Mirrulations S3)
+        run: uv run pytest -m integration -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,15 @@ spicy-regs-mcp = "spicy_regs.mcp_server:main"
 requires = ["uv_build"]
 build-backend = "uv_build"
 
+[tool.pytest.ini_options]
+# Integration tests hit external services (the public Mirrulations S3 mirror)
+# and are excluded from the default run so the unit suite stays hermetic. The
+# dedicated "Integration (live data)" workflow runs them via `-m integration`.
+addopts = "-m 'not integration'"
+markers = [
+    "integration: live test against external data (anonymous Mirrulations S3); run in the Integration CI workflow, not the default suite",
+]
+
 [tool.ruff]
 line-length = 120
 target-version = "py312"

--- a/src/spicy_regs/pipeline/pipeline.py
+++ b/src/spicy_regs/pipeline/pipeline.py
@@ -114,6 +114,37 @@ def _extract_comment(d: dict) -> dict:
     }
 
 
+def _extract_document(d: dict) -> dict:
+    attrs = d.get("data", {}).get("attributes", {})
+
+    # Each fileFormats entry is one downloadable rendition of the document
+    # (e.g. content.pdf), carrying its own URL, format, and byte size. Keep the
+    # full list — the single file_url below is retained for backward compat.
+    attachments = [
+        {"url": f["fileUrl"], "format": f.get("format"), "size": f.get("size")}
+        for f in attrs.get("fileFormats") or []
+        if f.get("fileUrl")
+    ]
+
+    return {
+        "document_id": d.get("data", {}).get("id"),
+        "docket_id": (v.strip('"') if (v := attrs.get("docketId")) else v),
+        "agency_code": attrs.get("agencyId"),
+        "title": attrs.get("title"),
+        "document_type": attrs.get("documentType"),
+        "posted_date": attrs.get("postedDate"),
+        "modify_date": attrs.get("modifyDate"),
+        "comment_start_date": attrs.get("commentStartDate"),
+        "comment_end_date": attrs.get("commentEndDate"),
+        "file_url": attachments[0]["url"] if attachments else None,
+        "attachments_json": json_dumps(attachments) if attachments else None,
+        "fr_doc_num": attrs.get("frDocNum"),
+        "withdrawn": attrs.get("withdrawn"),
+        "reason_withdrawn": attrs.get("reasonWithdrawn"),
+        "additional_rins": (json_dumps(rins) if (rins := attrs.get("additionalRins")) else None),
+    }
+
+
 DEDUP_KEYS: dict[str, str] = {
     "dockets": "docket_id",
     "documents": "document_id",
@@ -162,25 +193,13 @@ DATA_TYPES: dict[str, _DataTypeConfig] = {
             "comment_start_date": pl.Utf8,
             "comment_end_date": pl.Utf8,
             "file_url": pl.Utf8,
+            "attachments_json": pl.Utf8,
+            "fr_doc_num": pl.Utf8,
             "withdrawn": pl.Utf8,
             "reason_withdrawn": pl.Utf8,
             "additional_rins": pl.Utf8,
         },
-        "extract": lambda d: {
-            "document_id": d.get("data", {}).get("id"),
-            "docket_id": (v.strip('"') if (v := d.get("data", {}).get("attributes", {}).get("docketId")) else v),
-            "agency_code": d.get("data", {}).get("attributes", {}).get("agencyId"),
-            "title": d.get("data", {}).get("attributes", {}).get("title"),
-            "document_type": d.get("data", {}).get("attributes", {}).get("documentType"),
-            "posted_date": d.get("data", {}).get("attributes", {}).get("postedDate"),
-            "modify_date": d.get("data", {}).get("attributes", {}).get("modifyDate"),
-            "comment_start_date": d.get("data", {}).get("attributes", {}).get("commentStartDate"),
-            "comment_end_date": d.get("data", {}).get("attributes", {}).get("commentEndDate"),
-            "file_url": (d.get("data", {}).get("attributes", {}).get("fileFormats") or [{}])[0].get("fileUrl"),
-            "withdrawn": d.get("data", {}).get("attributes", {}).get("withdrawn"),
-            "reason_withdrawn": d.get("data", {}).get("attributes", {}).get("reasonWithdrawn"),
-            "additional_rins": (json_dumps(rins) if (rins := d.get("data", {}).get("attributes", {}).get("additionalRins")) else None),
-        },
+        "extract": _extract_document,
     },
     "comments": {
         "path_pattern": "/comments/",

--- a/src/spicy_regs/schemas/regulations.py
+++ b/src/spicy_regs/schemas/regulations.py
@@ -47,6 +47,37 @@ def _extract_comment(d: dict) -> dict:
     }
 
 
+def _extract_document(d: dict) -> dict:
+    attrs = d.get("data", {}).get("attributes", {})
+
+    # Each fileFormats entry is one downloadable rendition of the document
+    # (e.g. content.pdf), carrying its own URL, format, and byte size. Keep the
+    # full list — the single file_url below is retained for backward compat.
+    attachments = [
+        {"url": f["fileUrl"], "format": f.get("format"), "size": f.get("size")}
+        for f in attrs.get("fileFormats") or []
+        if f.get("fileUrl")
+    ]
+
+    return {
+        "document_id": d.get("data", {}).get("id"),
+        "docket_id": (v.strip('"') if (v := attrs.get("docketId")) else v),
+        "agency_code": attrs.get("agencyId"),
+        "title": attrs.get("title"),
+        "document_type": attrs.get("documentType"),
+        "posted_date": attrs.get("postedDate"),
+        "modify_date": attrs.get("modifyDate"),
+        "comment_start_date": attrs.get("commentStartDate"),
+        "comment_end_date": attrs.get("commentEndDate"),
+        "file_url": attachments[0]["url"] if attachments else None,
+        "attachments_json": json_dumps(attachments) if attachments else None,
+        "fr_doc_num": attrs.get("frDocNum"),
+        "withdrawn": attrs.get("withdrawn"),
+        "reason_withdrawn": attrs.get("reasonWithdrawn"),
+        "additional_rins": (json_dumps(rins) if (rins := attrs.get("additionalRins")) else None),
+    }
+
+
 DOCKET = RecordType(
     name="dockets",
     path_pattern="/docket/",
@@ -86,26 +117,14 @@ DOCUMENT = RecordType(
         "comment_start_date": pl.Utf8,
         "comment_end_date": pl.Utf8,
         "file_url": pl.Utf8,
+        "attachments_json": pl.Utf8,
+        "fr_doc_num": pl.Utf8,
         "withdrawn": pl.Utf8,
         "reason_withdrawn": pl.Utf8,
         "additional_rins": pl.Utf8,
     },
     dedup_key="document_id",
-    extract=lambda d: {
-        "document_id": d.get("data", {}).get("id"),
-        "docket_id": (v.strip('"') if (v := d.get("data", {}).get("attributes", {}).get("docketId")) else v),
-        "agency_code": d.get("data", {}).get("attributes", {}).get("agencyId"),
-        "title": d.get("data", {}).get("attributes", {}).get("title"),
-        "document_type": d.get("data", {}).get("attributes", {}).get("documentType"),
-        "posted_date": d.get("data", {}).get("attributes", {}).get("postedDate"),
-        "modify_date": d.get("data", {}).get("attributes", {}).get("modifyDate"),
-        "comment_start_date": d.get("data", {}).get("attributes", {}).get("commentStartDate"),
-        "comment_end_date": d.get("data", {}).get("attributes", {}).get("commentEndDate"),
-        "file_url": (d.get("data", {}).get("attributes", {}).get("fileFormats") or [{}])[0].get("fileUrl"),
-        "withdrawn": d.get("data", {}).get("attributes", {}).get("withdrawn"),
-        "reason_withdrawn": d.get("data", {}).get("attributes", {}).get("reasonWithdrawn"),
-        "additional_rins": (json_dumps(rins) if (rins := d.get("data", {}).get("attributes", {}).get("additionalRins")) else None),
-    },
+    extract=_extract_document,
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,8 +60,8 @@ def sample_comments() -> list[dict]:
 @pytest.fixture
 def sample_documents() -> list[dict]:
     return [
-        {"document_id": "D-001", "docket_id": "EPA-2024-0001", "agency_code": "EPA", "title": "Proposed Rule", "document_type": "Proposed Rule", "posted_date": "2024-06-01", "modify_date": "2024-06-01", "comment_start_date": "2024-06-01", "comment_end_date": "2024-07-01", "file_url": None, "withdrawn": "false", "reason_withdrawn": None, "additional_rins": None},
-        {"document_id": "D-002", "docket_id": "FDA-2024-0010", "agency_code": "FDA", "title": "Notice", "document_type": "Notice", "posted_date": "2024-04-15", "modify_date": "2024-04-15", "comment_start_date": "2024-04-15", "comment_end_date": "2024-05-15", "file_url": None, "withdrawn": "true", "reason_withdrawn": "Superseded by revised proposal", "additional_rins": "[\"0910-AH35\"]"},
+        {"document_id": "D-001", "docket_id": "EPA-2024-0001", "agency_code": "EPA", "title": "Proposed Rule", "document_type": "Proposed Rule", "posted_date": "2024-06-01", "modify_date": "2024-06-01", "comment_start_date": "2024-06-01", "comment_end_date": "2024-07-01", "file_url": None, "attachments_json": None, "fr_doc_num": None, "withdrawn": "false", "reason_withdrawn": None, "additional_rins": None},
+        {"document_id": "D-002", "docket_id": "FDA-2024-0010", "agency_code": "FDA", "title": "Notice", "document_type": "Notice", "posted_date": "2024-04-15", "modify_date": "2024-04-15", "comment_start_date": "2024-04-15", "comment_end_date": "2024-05-15", "file_url": None, "attachments_json": None, "fr_doc_num": "2025-13790", "withdrawn": "true", "reason_withdrawn": "Superseded by revised proposal", "additional_rins": "[\"0910-AH35\"]"},
     ]
 
 
@@ -103,6 +103,8 @@ DOCUMENT_SCHEMA = {
     "comment_start_date": pl.Utf8,
     "comment_end_date": pl.Utf8,
     "file_url": pl.Utf8,
+    "attachments_json": pl.Utf8,
+    "fr_doc_num": pl.Utf8,
     "withdrawn": pl.Utf8,
     "reason_withdrawn": pl.Utf8,
     "additional_rins": pl.Utf8,

--- a/tests/test_integration_mirrulations.py
+++ b/tests/test_integration_mirrulations.py
@@ -1,0 +1,78 @@
+"""Live integration test against real regulations.gov data.
+
+Fetches a real document JSON straight from the public Mirrulations S3 mirror
+(``s3://mirrulations`` — the pipeline's actual upstream) and runs it through the
+production extract -> staging -> merge path, asserting the document attachment
+metadata (``attachments_json`` / ``fr_doc_num``) survives end to end.
+
+Marked ``integration`` so it is excluded from the default hermetic suite (see
+``addopts`` in pyproject.toml); the dedicated "Integration (live data)" CI
+workflow runs it via ``pytest -m integration``. It needs outbound network access
+to the anonymous S3 bucket.
+"""
+
+import json
+
+import boto3
+import polars as pl
+import pytest
+from botocore import UNSIGNED
+from botocore.config import Config as BotoConfig
+
+from spicy_regs.pipeline.extract import download_and_parse
+from spicy_regs.pipeline.transform import merge_staging_files, write_staging
+from spicy_regs.schemas import DOCUMENT
+from tests.conftest import DOCUMENT_SCHEMA
+
+BUCKET = "mirrulations"
+
+# A real, published EPA notice in the mirror. Posted documents are immutable, so
+# the identifiers below are stable; file sizes are asserted structurally (present
+# and positive) rather than exactly, in case regulations.gov re-renders a file.
+DOC_KEY = (
+    "raw-data/EPA/EPA-HQ-OA-2025-0172/text-EPA-HQ-OA-2025-0172/"
+    "documents/EPA-HQ-OA-2025-0172-0001.json"
+)
+EXPECTED_DOCUMENT_ID = "EPA-HQ-OA-2025-0172-0001"
+EXPECTED_DOCKET_ID = "EPA-HQ-OA-2025-0172"
+EXPECTED_FR_DOC_NUM = "2025-16478"
+
+
+@pytest.mark.integration
+def test_real_document_attachment_metadata_through_transform(tmp_path):
+    s3 = boto3.resource(
+        "s3", region_name="us-east-1", config=BotoConfig(signature_version=UNSIGNED)
+    )
+
+    # download_and_parse is the exact function the pipeline uses per file.
+    record = download_and_parse(s3, BUCKET, DOC_KEY, DOCUMENT.extract)
+    assert record is not None, f"could not fetch {DOC_KEY} from s3://{BUCKET}"
+
+    staging = tmp_path / "staging"
+    output = tmp_path / "output"
+    output.mkdir()
+
+    write_staging("EPA", "documents", [record], staging, DOCUMENT_SCHEMA)
+    merge_staging_files(
+        staging, output, ["documents"],
+        {"documents": DOCUMENT_SCHEMA},
+        {"documents": "document_id"},
+    )
+
+    merged = pl.read_parquet(output / "documents.parquet")
+    assert merged.height == 1
+    row = merged.row(0, named=True)
+
+    assert row["document_id"] == EXPECTED_DOCUMENT_ID
+    assert row["docket_id"] == EXPECTED_DOCKET_ID
+    assert row["fr_doc_num"] == EXPECTED_FR_DOC_NUM
+
+    attachments = json.loads(row["attachments_json"])
+    assert len(attachments) >= 2
+    assert {a["format"] for a in attachments} >= {"pdf", "html"}
+    for a in attachments:
+        assert a["url"].startswith("https://downloads.regulations.gov/")
+        assert isinstance(a["size"], int) and a["size"] > 0
+
+    # file_url stays the first usable rendition for backward compatibility.
+    assert row["file_url"] == attachments[0]["url"]

--- a/tests/test_integration_mirrulations.py
+++ b/tests/test_integration_mirrulations.py
@@ -18,6 +18,7 @@ import polars as pl
 import pytest
 from botocore import UNSIGNED
 from botocore.config import Config as BotoConfig
+from loguru import logger
 
 from spicy_regs.pipeline.extract import download_and_parse
 from spicy_regs.pipeline.transform import merge_staging_files, write_staging
@@ -44,15 +45,22 @@ def test_real_document_attachment_metadata_through_transform(tmp_path):
         "s3", region_name="us-east-1", config=BotoConfig(signature_version=UNSIGNED)
     )
 
+    logger.info("Fetching live document s3://{}/{}", BUCKET, DOC_KEY)
     # download_and_parse is the exact function the pipeline uses per file.
     record = download_and_parse(s3, BUCKET, DOC_KEY, DOCUMENT.extract)
     assert record is not None, f"could not fetch {DOC_KEY} from s3://{BUCKET}"
+    logger.success(
+        "Fetched + extracted {} (docket {}, fr_doc_num {})",
+        record["document_id"], record["docket_id"], record["fr_doc_num"],
+    )
 
     staging = tmp_path / "staging"
     output = tmp_path / "output"
     output.mkdir()
 
+    logger.info("Writing staging Parquet under {}", staging)
     write_staging("EPA", "documents", [record], staging, DOCUMENT_SCHEMA)
+    logger.info("Merging staging -> {}/documents.parquet", output)
     merge_staging_files(
         staging, output, ["documents"],
         {"documents": DOCUMENT_SCHEMA},
@@ -60,6 +68,7 @@ def test_real_document_attachment_metadata_through_transform(tmp_path):
     )
 
     merged = pl.read_parquet(output / "documents.parquet")
+    logger.info("Merged output: {} row(s), columns={}", merged.height, merged.columns)
     assert merged.height == 1
     row = merged.row(0, named=True)
 
@@ -68,6 +77,11 @@ def test_real_document_attachment_metadata_through_transform(tmp_path):
     assert row["fr_doc_num"] == EXPECTED_FR_DOC_NUM
 
     attachments = json.loads(row["attachments_json"])
+    logger.info(
+        "Recovered {} attachment(s): {}",
+        len(attachments),
+        ", ".join(f"{a['format']}={a['size']}B" for a in attachments),
+    )
     assert len(attachments) >= 2
     assert {a["format"] for a in attachments} >= {"pdf", "html"}
     for a in attachments:
@@ -76,3 +90,7 @@ def test_real_document_attachment_metadata_through_transform(tmp_path):
 
     # file_url stays the first usable rendition for backward compatibility.
     assert row["file_url"] == attachments[0]["url"]
+    logger.success(
+        "Document attachment metadata survived extract -> staging -> merge "
+        "for {}", row["document_id"],
+    )

--- a/tests/test_record_types.py
+++ b/tests/test_record_types.py
@@ -1,8 +1,11 @@
 """Tests for the RecordType registry in spicy_regs.schemas.regulations."""
 
 from json import loads
+from pathlib import Path
 
 from spicy_regs.schemas import COMMENT, DOCKET, DOCUMENT, RECORD_TYPES, RecordType
+
+SAMPLE_DATA = Path(__file__).resolve().parents[1] / "sample-data" / "mirrulations"
 
 
 def test_registry_keys_and_names_match() -> None:
@@ -119,6 +122,24 @@ def test_document_extract_handles_missing_file_formats() -> None:
     assert out["file_url"] is None
     assert out["attachments_json"] is None
     assert out["fr_doc_num"] is None
+
+
+def test_document_extract_matches_real_sample_payload() -> None:
+    # Guard against drift from the real regulations.gov shape: run the extract
+    # against the committed sample payload, not a hand-built dict.
+    raw = loads((SAMPLE_DATA / "document-ACF-2025-0038-0001.json").read_text())
+    out = DOCUMENT.extract(raw)
+    assert out["document_id"] == "ACF-2025-0038-0001"
+    assert out["docket_id"] == "ACF-2025-0038"
+    assert out["fr_doc_num"] == "2025-13790"
+    assert out["file_url"] == "https://downloads.regulations.gov/ACF-2025-0038-0001/content.pdf"
+    assert loads(out["attachments_json"]) == [
+        {
+            "url": "https://downloads.regulations.gov/ACF-2025-0038-0001/content.pdf",
+            "format": "pdf",
+            "size": 239826,
+        }
+    ]
 
 
 def test_document_extract_missing_withdrawal_fields_are_none() -> None:

--- a/tests/test_record_types.py
+++ b/tests/test_record_types.py
@@ -84,9 +84,41 @@ def test_document_extract_takes_first_file_url() -> None:
     assert loads(out["additional_rins"]) == ["2060-AG12", "2060-AG13"]
 
 
+def test_document_extract_packs_attachment_list_and_fr_doc_num() -> None:
+    # The document's fileFormats are its downloadable renditions; the full list
+    # (url + format + size) is packed into attachments_json, and the Federal
+    # Register document number is surfaced as fr_doc_num.
+    raw = {
+        "data": {
+            "id": "ACF-2025-0038-0001",
+            "attributes": {
+                "docketId": "ACF-2025-0038",
+                "agencyId": "ACF",
+                "frDocNum": "2025-13790",
+                "fileFormats": [
+                    {"fileUrl": "https://downloads.gov/content.pdf", "format": "pdf", "size": 239826},
+                    {"fileUrl": "https://downloads.gov/content.htm", "format": "htm", "size": 5120},
+                    {"format": "pdf"},  # no fileUrl -> skipped
+                ],
+            },
+        }
+    }
+    out = DOCUMENT.extract(raw)
+    assert out["fr_doc_num"] == "2025-13790"
+    # file_url stays the first usable rendition for backward compatibility.
+    assert out["file_url"] == "https://downloads.gov/content.pdf"
+    assert loads(out["attachments_json"]) == [
+        {"url": "https://downloads.gov/content.pdf", "format": "pdf", "size": 239826},
+        {"url": "https://downloads.gov/content.htm", "format": "htm", "size": 5120},
+    ]
+
+
 def test_document_extract_handles_missing_file_formats() -> None:
     raw = {"data": {"id": "X-1", "attributes": {}}}
-    assert DOCUMENT.extract(raw)["file_url"] is None
+    out = DOCUMENT.extract(raw)
+    assert out["file_url"] is None
+    assert out["attachments_json"] is None
+    assert out["fr_doc_num"] is None
 
 
 def test_document_extract_missing_withdrawal_fields_are_none() -> None:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,5 +1,7 @@
 """Tests for transform module: staging, merging, partitioning, feed summary."""
 
+import json
+from pathlib import Path
 from unittest.mock import patch
 
 import polars as pl
@@ -14,12 +16,15 @@ from spicy_regs.pipeline.transform import (
     update_comments_index,
     write_staging,
 )
+from spicy_regs.schemas import DOCUMENT
 from tests.conftest import (
     COMMENT_SCHEMA,
     DOCKET_SCHEMA,
     DOCUMENT_SCHEMA,
     write_parquet_from_dicts,
 )
+
+SAMPLE_DATA = Path(__file__).resolve().parents[1] / "sample-data" / "mirrulations"
 
 
 class TestWriteStaging:
@@ -665,3 +670,75 @@ class TestUpdateCommentsIndex:
         assert len(idx) == 2  # old entry preserved + new entry
         assert idx.filter(pl.col("docket_id") == "OLD-001")["row_count"][0] == 100
         assert idx.filter(pl.col("docket_id") == "NEW-001")["row_count"][0] == 1
+
+
+class TestDocumentAttachmentColumns:
+    """End-to-end coverage that the document attachment columns survive the
+    transform layer: extract -> staging Parquet -> DuckDB merge -> read back."""
+
+    def test_attachment_columns_survive_staging_and_merge(self, tmp_path):
+        staging = tmp_path / "staging"
+        output = tmp_path / "output"
+        output.mkdir()
+
+        # Start from the real regulations.gov sample so the staging schema cast
+        # and merge are exercised against an actual payload.
+        raw = json.loads((SAMPLE_DATA / "document-ACF-2025-0038-0001.json").read_text())
+        record = DOCUMENT.extract(raw)
+        write_staging("ACF", "documents", [record], staging, DOCUMENT_SCHEMA)
+
+        merge_staging_files(
+            staging, output, ["documents"],
+            {"documents": DOCUMENT_SCHEMA},
+            {"documents": "document_id"},
+        )
+
+        merged = pl.read_parquet(output / "documents.parquet")
+        assert merged.height == 1
+        row = merged.row(0, named=True)
+        assert row["document_id"] == "ACF-2025-0038-0001"
+        assert row["fr_doc_num"] == "2025-13790"
+        assert json.loads(row["attachments_json"]) == [
+            {
+                "url": "https://downloads.regulations.gov/ACF-2025-0038-0001/content.pdf",
+                "format": "pdf",
+                "size": 239826,
+            }
+        ]
+
+    def test_merge_unions_new_attachment_columns_into_existing_output(self, tmp_path):
+        # Schema evolution: an existing documents.parquet written before these
+        # columns existed should merge cleanly, with the new columns NULL on the
+        # old row and populated on the freshly-extracted one.
+        staging = tmp_path / "staging"
+        output = tmp_path / "output"
+        output.mkdir()
+
+        legacy_schema = {k: v for k, v in DOCUMENT_SCHEMA.items() if k not in ("attachments_json", "fr_doc_num")}
+        existing = [{
+            "document_id": "OLD-001", "docket_id": "ACF-2025-0038", "agency_code": "ACF",
+            "title": "old", "document_type": "Notice",
+            "posted_date": "2024-01-01", "modify_date": "2024-01-01",
+            "comment_start_date": None, "comment_end_date": None, "file_url": None,
+            "withdrawn": "false", "reason_withdrawn": None, "additional_rins": None,
+        }]
+        write_parquet_from_dicts(output / "documents.parquet", existing, legacy_schema)
+
+        raw = json.loads((SAMPLE_DATA / "document-ACF-2025-0038-0001.json").read_text())
+        write_staging("ACF", "documents", [DOCUMENT.extract(raw)], staging, DOCUMENT_SCHEMA)
+
+        merge_staging_files(
+            staging, output, ["documents"],
+            {"documents": DOCUMENT_SCHEMA},
+            {"documents": "document_id"},
+        )
+
+        merged = pl.read_parquet(output / "documents.parquet").sort("document_id")
+        assert merged.height == 2
+        assert "attachments_json" in merged.columns
+        assert "fr_doc_num" in merged.columns
+        old_row = merged.filter(pl.col("document_id") == "OLD-001").row(0, named=True)
+        assert old_row["attachments_json"] is None
+        assert old_row["fr_doc_num"] is None
+        new_row = merged.filter(pl.col("document_id") == "ACF-2025-0038-0001").row(0, named=True)
+        assert new_row["fr_doc_num"] == "2025-13790"


### PR DESCRIPTION
Closes #52.

## Problem

Document attachments were captured as a single nullable `file_url` per document row, so the Document page degraded to showing 0-or-1 attachment and dropped the Size column.

## Change

Capture the document's full `fileFormats` list into a new `attachments_json` column and surface the Federal Register document number as `fr_doc_num`:

- **`attachments_json`** — JSON array of `{"url", "format", "size"}` for each rendition with a URL (entries without a `fileUrl` are skipped). This mirrors the existing comment `attachments_json` shape, so the UI can reuse the same parsing. `size` is the byte size; `format` is regulations.gov's format string (e.g. `"pdf"`).
- **`fr_doc_num`** — the `frDocNum` attribute (e.g. `2025-13790`).
- **`file_url`** — retained (now the first usable rendition's URL) for backward compatibility with the current UI.

The same change is applied to **both** extract paths the repo keeps in sync:
- legacy `pipeline/pipeline.py` `DATA_TYPES`
- the `RecordType`-based `schemas/regulations.py`

In both, the document extract is lifted from an inline `lambda` into a named `_extract_document` function, matching the existing `_extract_comment` and making it directly unit-testable.

## Notes / scope

- The issue mentions "MIME type"; regulations.gov exposes a `format` string (`pdf`, `htm`, …) rather than a true MIME type, so that's what's stored under `"format"`, consistent with the comment attachment shape. Mapping to a MIME type can happen in the UI if needed.
- This covers the document-side metadata. The separate `relationships.attachments` endpoint (true secondary attachments, fetched via `?include=attachments`) is out of scope here, matching how the source payload is currently ingested.

## Tests

- New `test_document_extract_packs_attachment_list_and_fr_doc_num` and an expanded missing-`fileFormats` case in `tests/test_record_types.py`.
- Updated `tests/conftest.py` document fixtures + `DOCUMENT_SCHEMA` for the new columns.
- Full suite passes (`131 passed`); `ruff check` and `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYt8vpmoLqajsb9XZGwXEj)_