### PR TITLE
Add Apache Iceberg (R2 Data Catalog) path for the dockets ETL (proof-of-concept)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,5 +9,13 @@ R2_PUBLIC_URL=https://r2.spicy-regs.dev
 CLOUDFLARE_ACCOUNT_ID=your_account_id
 CLOUDFLARE_API_TOKEN=your_api_token
 
+# R2 Data Catalog (Apache Iceberg) — only needed for `run-pipeline --use-iceberg`.
+# URI + warehouse are under R2 > your bucket > Settings > Data Catalog.
+# The token must be an R2 API token with both R2 and data-catalog permissions.
+# R2_CATALOG_URI=https://catalog.cloudflarestorage.com/YOUR_ACCOUNT_ID/spicy-regs
+# R2_CATALOG_WAREHOUSE=YOUR_ACCOUNT_ID_spicy-regs
+# R2_CATALOG_TOKEN=your_data_catalog_api_token
+# R2_CATALOG_NAMESPACE=default
+
 # Optional: Limit agencies for testing
 # AGENCIES=EPA,DOL,HHS

--- a/.github/workflows/etl-new-pipeline.yml
+++ b/.github/workflows/etl-new-pipeline.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: true
         type: boolean
+      use_iceberg:
+        description: 'Route the dockets table through R2 Data Catalog (Iceberg)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   etl-new:
@@ -62,6 +67,11 @@ jobs:
           R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          # Only used when use_iceberg is on; harmless otherwise.
+          R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
+          R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}
+          R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
+          R2_CATALOG_NAMESPACE: ${{ secrets.R2_CATALOG_NAMESPACE }}
         run: |
           ARGS=""
           if [ -n "${{ inputs.agency }}" ]; then
@@ -80,6 +90,9 @@ jobs:
             ARGS="$ARGS --skip-upload"
           else
             ARGS="$ARGS --no-skip-upload"
+          fi
+          if [ "${{ inputs.use_iceberg }}" = "true" ]; then
+            ARGS="$ARGS --use-iceberg"
           fi
           echo "Running: uv run run-pipeline $ARGS"
           uv run run-pipeline $ARGS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "pyarrow",
     "tqdm",
     "httpx",
-    "duckdb",
+    "duckdb>=1.4",  # >=1.4 required to ATTACH an Iceberg REST catalog and MERGE INTO it
     "pandas",
     "prefect",
     "cyclopts",

--- a/src/spicy_regs/pipeline/README.md
+++ b/src/spicy_regs/pipeline/README.md
@@ -26,6 +26,42 @@ uv sync
 cp .env.example .env  # Then fill in your credentials
 ```
 
+## Apache Iceberg (R2 Data Catalog) — experimental
+
+The new `run-pipeline` ETL can route the **dockets** table through
+[R2 Data Catalog](https://developers.cloudflare.com/r2/data-catalog/), the
+managed Apache Iceberg REST catalog built into R2, instead of the whole-file
+read-dedup-rewrite merge. This is a **proof-of-concept** scope: only `dockets`
+goes through Iceberg, and only when you opt in with `--use-iceberg`. Documents
+and comments are untouched, and the production `etl.yml` cron never uses this
+path.
+
+How it works (see `src/spicy_regs/sources/iceberg.py`):
+
+1. The staged per-agency Parquet is upserted into the catalog table via DuckDB
+   `MERGE INTO` (dedup by `docket_id`, keep the latest `modify_date`) — a
+   row-level commit that produces a new Iceberg snapshot, not a full rewrite.
+2. The full table is exported back to `output/dockets.parquet` so the
+   no-credentials CLI `download` and the public MCP server keep working
+   unchanged (the "dual model" — Iceberg is the system of record, public
+   Parquet is the read mirror).
+
+Requires DuckDB ≥ 1.4 and these env vars (URI + warehouse are under
+*R2 → your bucket → Settings → Data Catalog*; the token needs **R2 + data
+catalog** permissions):
+
+```bash
+R2_CATALOG_URI=...        # the Iceberg REST catalog endpoint
+R2_CATALOG_WAREHOUSE=...  # the warehouse name
+R2_CATALOG_TOKEN=...      # R2 API token (R2 + data-catalog scopes)
+R2_CATALOG_NAMESPACE=default  # optional, defaults to "default"
+```
+
+```bash
+# Smallest useful Iceberg run: one agency, recent dockets only, no upload.
+uv run run-pipeline --agency EPA --skip-comments --since-year 2025 --use-iceberg --skip-upload
+```
+
 ## Usage
 
 ### Full ETL (all agencies)

--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -35,7 +35,7 @@ from spicy_regs.manifest import Manifest
 from spicy_regs.pipelines.base import Pipeline
 from spicy_regs.pipelines.staging import stage_agencies
 from spicy_regs.schemas import RECORD_TYPES, RecordType
-from spicy_regs.sources import mirrulations, r2
+from spicy_regs.sources import iceberg, mirrulations, r2
 from spicy_regs.transforms import (
     ExtractRecords,
     build_agency_rollups,
@@ -67,6 +67,7 @@ class RegulationsPipeline(Pipeline):
         skip_post_process: bool = False,
         full_refresh: bool = False,
         max_workers: int = 4,
+        use_iceberg: bool = False,
         verbose: bool = False,
     ) -> None:
         self.agency = agency
@@ -80,6 +81,7 @@ class RegulationsPipeline(Pipeline):
         self.skip_post_process = skip_post_process
         self.full_refresh = full_refresh
         self.max_workers = max_workers
+        self.use_iceberg = use_iceberg
         self.verbose = verbose
 
     def run(self) -> None:
@@ -179,14 +181,32 @@ class RegulationsPipeline(Pipeline):
         record_types: list[RecordType],
         staged: dict[str, int],
     ) -> None:
-        """Merge staging files: dockets/documents monolithically, comments partitioned."""
+        """Merge staging files: dockets/documents monolithically, comments partitioned.
+
+        When ``use_iceberg`` is set, the ``dockets`` table is routed through the
+        R2 Data Catalog (Iceberg ``MERGE INTO`` + public Parquet export) instead
+        of the whole-file ``merge_staging_files`` rewrite. This is the
+        proof-of-concept scope — documents and comments stay on the existing
+        path until the Iceberg flow is vetted.
+        """
         names = [rt.name for rt in record_types]
 
         non_comment = [n for n in names if n != "comments"]
+
+        iceberg_names = []
+        if self.use_iceberg and "dockets" in non_comment:
+            iceberg_names = ["dockets"]
+            non_comment = [n for n in non_comment if n != "dockets"]
+
         if non_comment:
             schemas = {n: RECORD_TYPES[n].schema for n in non_comment}
             dedup_keys = {n: RECORD_TYPES[n].dedup_key for n in non_comment}
             merge_staging_files(staging_dir, output_dir, non_comment, schemas, dedup_keys)
+
+        # Iceberg path: MERGE into the catalog, then export the public Parquet
+        # snapshot that the existing R2 upload (dual model) will publish.
+        for name in iceberg_names:
+            iceberg.merge_and_export(staging_dir, output_dir, RECORD_TYPES[name])
 
         if "comments" in names and staged.get("comments", 0) > 0:
             changed = merge_comments_partitioned(
@@ -218,6 +238,9 @@ def main(
     skip_post_process: Annotated[bool, Parameter(help="Skip feed summary build")] = False,
     full_refresh: Annotated[bool, Parameter(help="Ignore manifest + existing output")] = False,
     max_workers: Annotated[int, Parameter(help="Agencies processed in parallel")] = 4,
+    use_iceberg: Annotated[
+        bool, Parameter(help="Route the dockets table through R2 Data Catalog (Iceberg)")
+    ] = False,
     verbose: Annotated[bool, Parameter(name=["--verbose", "-v"], help="Verbose logging")] = False,
 ) -> None:
     """Run the regulations.gov ETL pipeline."""
@@ -233,6 +256,7 @@ def main(
         skip_post_process=skip_post_process,
         full_refresh=full_refresh,
         max_workers=max_workers,
+        use_iceberg=use_iceberg,
         verbose=verbose,
     ).run()
 

--- a/src/spicy_regs/sources/__init__.py
+++ b/src/spicy_regs/sources/__init__.py
@@ -1,6 +1,6 @@
-from spicy_regs.sources import r2
+from spicy_regs.sources import iceberg, r2
 from spicy_regs.sources.base import Reader, Writer
 from spicy_regs.sources.mirrulations import MirrulationsReader
 from spicy_regs.sources.parquet import StagingWriter
 
-__all__ = ["Reader", "Writer", "MirrulationsReader", "StagingWriter", "r2"]
+__all__ = ["Reader", "Writer", "MirrulationsReader", "StagingWriter", "r2", "iceberg"]

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -1,0 +1,208 @@
+"""Cloudflare R2 Data Catalog (Apache Iceberg) connector.
+
+The internal, write-side table format for the ETL. The catalog is **R2 Data
+Catalog** — a managed Iceberg REST catalog built into the same R2 bucket the
+project already publishes Parquet to, so no separate metastore (Glue/Nessie/
+Postgres) has to be stood up.
+
+Everything is driven through DuckDB's ``iceberg`` + ``httpfs`` extensions:
+DuckDB >= 1.4 can ``ATTACH`` a REST catalog and run ``MERGE INTO``, which lets
+us reuse the exact DuckDB merge idiom already proven in
+:mod:`spicy_regs.transforms.merge_staging_files` (dedup by primary key, keep the
+row with the most recent ``modify_date``) — only now it's a *row-level* upsert
+into a versioned table instead of a whole-file rewrite.
+
+This module is the "Iceberg load" stage only, mirroring the thin-wrapper style
+of :mod:`spicy_regs.sources.r2`:
+
+* :func:`merge_and_export` — ensure the table exists, MERGE the per-agency
+  staging Parquet in, then export a public ``{name}.parquet`` snapshot so the
+  no-credentials CLI / MCP read path keeps working (the "dual model").
+
+Credentials are read from the environment, alongside the existing ``R2_*`` vars:
+
+* ``R2_CATALOG_URI``        — the Iceberg REST catalog endpoint (catalog-uri)
+* ``R2_CATALOG_WAREHOUSE``  — the warehouse name
+* ``R2_CATALOG_TOKEN``      — an R2 API token with R2 + data-catalog permissions
+* ``R2_CATALOG_NAMESPACE``  — Iceberg namespace/schema (optional, default ``default``)
+"""
+
+from os import getenv
+from pathlib import Path
+
+from loguru import logger
+
+from spicy_regs.schemas import RecordType
+
+# DuckDB alias the attached catalog is addressed by (``<alias>.<namespace>.<table>``).
+_CATALOG_ALIAS = "reg_catalog"
+
+# Required environment variables for the catalog connection.
+_REQUIRED_ENV = ("R2_CATALOG_URI", "R2_CATALOG_WAREHOUSE", "R2_CATALOG_TOKEN")
+
+
+def is_configured() -> bool:
+    """True when every credential needed to reach the catalog is present."""
+    return all(getenv(var) for var in _REQUIRED_ENV)
+
+
+def _namespace() -> str:
+    return getenv("R2_CATALOG_NAMESPACE", "default")
+
+
+def _schema_ref() -> str:
+    """Quoted ``alias."namespace"`` reference (the default namespace is a keyword)."""
+    return f'{_CATALOG_ALIAS}."{_namespace()}"'
+
+
+def _sql_str(value: str) -> str:
+    """Escape a value for inlining inside a single-quoted SQL literal."""
+    return value.replace("'", "''")
+
+
+def _connect():
+    """Open a DuckDB connection with the R2 Data Catalog attached.
+
+    ``CREATE SECRET`` / ``ATTACH`` do not accept bind parameters, so the
+    credentials are inlined with single-quote escaping. The token never leaves
+    this process — it is read from the environment, used to attach, and the
+    connection is closed by the caller.
+    """
+    import duckdb
+
+    if not is_configured():
+        missing = [var for var in _REQUIRED_ENV if not getenv(var)]
+        raise RuntimeError(
+            "R2 Data Catalog is not configured; missing env var(s): " + ", ".join(missing)
+        )
+
+    uri = getenv("R2_CATALOG_URI", "")
+    warehouse = getenv("R2_CATALOG_WAREHOUSE", "")
+    token = getenv("R2_CATALOG_TOKEN", "")
+
+    con = duckdb.connect()
+    con.execute("INSTALL iceberg; LOAD iceberg;")
+    con.execute("INSTALL httpfs; LOAD httpfs;")
+    con.execute(f"CREATE OR REPLACE SECRET r2_catalog_secret (TYPE ICEBERG, TOKEN '{_sql_str(token)}');")
+    con.execute(
+        f"ATTACH '{_sql_str(warehouse)}' AS {_CATALOG_ALIAS} "
+        f"(TYPE ICEBERG, ENDPOINT '{_sql_str(uri)}');"
+    )
+    return con
+
+
+def _qualified(record_type: RecordType) -> str:
+    """Fully-qualified catalog table identifier: ``alias."namespace"."name"``."""
+    return f'{_schema_ref()}."{record_type.name}"'
+
+
+def _ensure_table(con, record_type: RecordType) -> None:
+    """Create the namespace + table (all columns VARCHAR) if they don't exist.
+
+    The schema mirrors the published Parquet: every column is a UTF-8 string
+    (see :mod:`spicy_regs.schemas.regulations`), so a flat ``VARCHAR`` table is
+    a faithful representation and keeps ``MERGE``/export trivially type-safe.
+    """
+    columns = ", ".join(f'"{col}" VARCHAR' for col in record_type.schema)
+    con.execute(f"CREATE SCHEMA IF NOT EXISTS {_schema_ref()};")
+    con.execute(f"CREATE TABLE IF NOT EXISTS {_qualified(record_type)} ({columns});")
+
+
+def _staging_files(staging_dir: Path, record_type: RecordType) -> list[Path]:
+    """Per-agency staging Parquet files for this record type (see write_staging)."""
+    staging_type_dir = staging_dir / record_type.name
+    if not staging_type_dir.exists():
+        return []
+    return sorted(staging_type_dir.glob("*.parquet"))
+
+
+def _merge(con, staging_files: list[Path], record_type: RecordType) -> None:
+    """Row-level upsert of the staged rows into the Iceberg table via ``MERGE INTO``.
+
+    Mirrors the dedup semantics of ``transforms.merge_staging_files``: collapse
+    the staging rows to one per key (latest ``modify_date`` wins), then merge
+    that against the table — updating only when the incoming row is newer and
+    inserting brand-new keys. ``modify_date`` is an ISO-8601 string, so the
+    lexical ``>`` comparison orders chronologically.
+    """
+    cols = list(record_type.schema)
+    key = record_type.dedup_key
+
+    files_sql = ", ".join(f"'{_sql_str(str(p))}'" for p in staging_files)
+    col_select = ", ".join(f'CAST("{c}" AS VARCHAR) AS "{c}"' for c in cols)
+    set_clause = ", ".join(f'"{c}" = s."{c}"' for c in cols if c != key)
+    insert_cols = ", ".join(f'"{c}"' for c in cols)
+    insert_vals = ", ".join(f's."{c}"' for c in cols)
+
+    con.execute(
+        f"""
+        MERGE INTO {_qualified(record_type)} AS t
+        USING (
+            SELECT {col_select}
+            FROM read_parquet([{files_sql}], union_by_name=true)
+            QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY "{key}"
+                ORDER BY modify_date DESC NULLS LAST
+            ) = 1
+        ) AS s
+        ON t."{key}" = s."{key}"
+        WHEN MATCHED AND (t.modify_date IS NULL OR s.modify_date > t.modify_date)
+            THEN UPDATE SET {set_clause}
+        WHEN NOT MATCHED
+            THEN INSERT ({insert_cols}) VALUES ({insert_vals});
+        """
+    )
+
+
+def _export_parquet(con, record_type: RecordType, output_dir: Path) -> Path:
+    """Write the full table back out as the public ``{name}.parquet`` snapshot.
+
+    Reuses the published layout's sort + compression (zstd, sorted by
+    ``agency_code, modify_date`` for dockets) so downstream consumers — the CLI
+    ``download`` and the anonymous MCP server — see byte-for-byte the same shape
+    they do today. This is what makes the "dual model" work: Iceberg is the
+    system of record, public Parquet is the read mirror.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_file = output_dir / f"{record_type.name}.parquet"
+
+    sort_cols = [c for c in ("agency_code", "modify_date") if c in record_type.schema]
+    order_by = f"ORDER BY {', '.join(sort_cols)}" if sort_cols else ""
+
+    con.execute(
+        f"""
+        COPY (SELECT * FROM {_qualified(record_type)} {order_by})
+        TO '{_sql_str(str(out_file))}'
+        (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000);
+        """
+    )
+    return out_file
+
+
+def merge_and_export(staging_dir: Path, output_dir: Path, record_type: RecordType) -> Path | None:
+    """Upsert staged rows into the catalog table, then export the public Parquet.
+
+    Returns the path to the exported ``{name}.parquet`` (so the pipeline can
+    publish it via the existing R2 upload), or ``None`` when there was nothing
+    staged for this record type.
+    """
+    staging_files = _staging_files(staging_dir, record_type)
+    if not staging_files:
+        logger.info("iceberg: no staging files for {}; skipping merge", record_type.name)
+        return None
+
+    con = _connect()
+    try:
+        _ensure_table(con, record_type)
+        logger.info(
+            "iceberg: MERGE {} staging file(s) into {}",
+            len(staging_files), _qualified(record_type),
+        )
+        _merge(con, staging_files, record_type)
+        total = con.execute(f"SELECT count(*) FROM {_qualified(record_type)}").fetchone()[0]
+        logger.info("iceberg: {} now holds {:,} rows", record_type.name, total)
+        out_file = _export_parquet(con, record_type, output_dir)
+        logger.info("iceberg: exported public snapshot to {}", out_file)
+        return out_file
+    finally:
+        con.close()

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -1,0 +1,148 @@
+"""Tests for the R2 Data Catalog (Iceberg) connector.
+
+The live ``merge_and_export`` needs a real R2 Data Catalog, so these tests
+exercise the catalog-independent pieces — the SQL building / dedup / export
+logic — against a *local* in-memory DuckDB attached under the same alias the
+connector uses. ``_ensure_table``, ``_merge``, and ``_export_parquet`` all take
+the connection as an argument precisely so this is possible without network.
+
+A genuinely end-to-end run against R2 is covered by the manual
+"ETL (new pipeline – vetting)" workflow with ``--use-iceberg``.
+"""
+
+from pathlib import Path
+
+import duckdb
+import polars as pl
+import pytest
+
+from spicy_regs.schemas import DOCKET
+from spicy_regs.sources import iceberg
+
+
+def _write_staging(staging_dir: Path, agency: str, rows: list[dict]) -> None:
+    """Mimic transforms.write_staging: staging_dir/dockets/{agency}.parquet."""
+    type_dir = staging_dir / DOCKET.name
+    type_dir.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(rows, schema=DOCKET.schema).write_parquet(type_dir / f"{agency}.parquet")
+
+
+@pytest.fixture
+def local_catalog():
+    """A local DuckDB standing in for the attached R2 catalog (alias reg_catalog)."""
+    con = duckdb.connect()
+    con.execute(f"ATTACH ':memory:' AS {iceberg._CATALOG_ALIAS};")
+    try:
+        yield con
+    finally:
+        con.close()
+
+
+def _docket(docket_id: str, agency: str, title: str, modify_date: str) -> dict:
+    row = {col: None for col in DOCKET.schema}
+    row.update(docket_id=docket_id, agency_code=agency, title=title, modify_date=modify_date)
+    return row
+
+
+def test_is_configured(monkeypatch) -> None:
+    for var in iceberg._REQUIRED_ENV:
+        monkeypatch.delenv(var, raising=False)
+    assert iceberg.is_configured() is False
+
+    for var in iceberg._REQUIRED_ENV:
+        monkeypatch.setenv(var, "x")
+    assert iceberg.is_configured() is True
+
+
+def test_connect_raises_when_unconfigured(monkeypatch) -> None:
+    for var in iceberg._REQUIRED_ENV:
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(RuntimeError, match="R2_CATALOG_URI"):
+        iceberg._connect()
+
+
+def test_merge_inserts_then_dedups(tmp_path, local_catalog) -> None:
+    con = local_catalog
+    iceberg._ensure_table(con, DOCKET)
+
+    # First batch: two distinct dockets.
+    staging = tmp_path / "staging"
+    _write_staging(
+        staging,
+        "EPA",
+        [
+            _docket("EPA-1", "EPA", "First", "2025-01-01"),
+            _docket("EPA-2", "EPA", "Second", "2025-01-02"),
+        ],
+    )
+    iceberg._merge(con, iceberg._staging_files(staging, DOCKET), DOCKET)
+    assert con.execute(f"SELECT count(*) FROM {iceberg._qualified(DOCKET)}").fetchone()[0] == 2
+
+    # Second batch: one updated row (newer modify_date) + one brand-new row.
+    # An older copy of EPA-1 in the same batch must lose to the newer one.
+    staging2 = tmp_path / "staging2"
+    _write_staging(
+        staging2,
+        "EPA",
+        [
+            _docket("EPA-1", "EPA", "First UPDATED", "2025-02-01"),
+            _docket("EPA-1", "EPA", "stale dup", "2024-12-31"),
+            _docket("EPA-3", "EPA", "Third", "2025-02-02"),
+        ],
+    )
+    iceberg._merge(con, iceberg._staging_files(staging2, DOCKET), DOCKET)
+
+    rows = dict(
+        con.execute(
+            f'SELECT docket_id, title FROM {iceberg._qualified(DOCKET)} ORDER BY docket_id'
+        ).fetchall()
+    )
+    assert rows == {"EPA-1": "First UPDATED", "EPA-2": "Second", "EPA-3": "Third"}
+
+
+def test_merge_keeps_existing_when_incoming_is_older(tmp_path, local_catalog) -> None:
+    con = local_catalog
+    iceberg._ensure_table(con, DOCKET)
+
+    staging = tmp_path / "staging"
+    _write_staging(staging, "EPA", [_docket("EPA-1", "EPA", "Newer", "2025-05-01")])
+    iceberg._merge(con, iceberg._staging_files(staging, DOCKET), DOCKET)
+
+    # An older row for the same key must NOT overwrite the newer one.
+    staging2 = tmp_path / "staging2"
+    _write_staging(staging2, "EPA", [_docket("EPA-1", "EPA", "Older", "2025-01-01")])
+    iceberg._merge(con, iceberg._staging_files(staging2, DOCKET), DOCKET)
+
+    title = con.execute(
+        f'SELECT title FROM {iceberg._qualified(DOCKET)} WHERE docket_id = \'EPA-1\''
+    ).fetchone()[0]
+    assert title == "Newer"
+
+
+def test_export_parquet_matches_published_shape(tmp_path, local_catalog) -> None:
+    con = local_catalog
+    iceberg._ensure_table(con, DOCKET)
+    staging = tmp_path / "staging"
+    _write_staging(
+        staging,
+        "EPA",
+        [
+            _docket("EPA-2", "EPA", "b", "2025-01-02"),
+            _docket("EPA-1", "EPA", "a", "2025-01-01"),
+        ],
+    )
+    iceberg._merge(con, iceberg._staging_files(staging, DOCKET), DOCKET)
+
+    out = tmp_path / "output"
+    out_file = iceberg._export_parquet(con, DOCKET, out)
+    assert out_file == out / "dockets.parquet"
+
+    df = pl.read_parquet(out_file)
+    # Same columns as the published schema, sorted by (agency_code, modify_date).
+    assert df.columns == list(DOCKET.schema)
+    assert df["docket_id"].to_list() == ["EPA-1", "EPA-2"]
+
+
+def test_merge_and_export_noop_without_staging(tmp_path) -> None:
+    # No staging files for dockets -> returns None and never touches the catalog.
+    assert iceberg.merge_and_export(tmp_path / "empty", tmp_path / "out", DOCKET) is None

--- a/uv.lock
+++ b/uv.lock
@@ -4457,7 +4457,7 @@ dev = [
 requires-dist = [
     { name = "boto3" },
     { name = "cyclopts" },
-    { name = "duckdb" },
+    { name = "duckdb", specifier = ">=1.4" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "mcp", specifier = ">=1.10.0" },


### PR DESCRIPTION
## Why

Today the ETL's merge step reads the **entire** existing table plus staging, dedups by primary key keeping `MAX(modify_date)`, and **rewrites the whole Parquet file** (`transforms/merge_staging_files.py`). At 31.6M comments this is the scaling pain point, and "publish = re-upload the whole file" has no atomicity or history.

Apache Iceberg is a *table format* (snapshots + metadata over the same Parquet files) that replaces this with row-level `MERGE INTO`, atomic snapshot commits, schema evolution, and time travel — the last directly serving the project's reproducible-analysis goal. Crucially, we're **already on Cloudflare R2**, which now offers [**R2 Data Catalog**](https://developers.cloudflare.com/r2/data-catalog/), a *managed Iceberg REST catalog built into the bucket* — so no separate metastore (Glue/Nessie/Postgres) is needed.

## What this PR does (proof-of-concept scope)

An **opt-in** Iceberg path *alongside* the existing pipeline, so nothing changes until it's vetted:

- **New `sources/iceberg.py`** connector (modeled on the thin-wrapper `sources/r2.py`): attach the R2 catalog via DuckDB's `iceberg`+`httpfs` extensions, `CREATE TABLE IF NOT EXISTS`, `MERGE INTO` the staged rows (dedup by `docket_id`, keep latest `modify_date`), then export the full table back to `output/dockets.parquet`.
- **`run-pipeline --use-iceberg`** flag threaded through `RegulationsPipeline`. Only **dockets** (~393k rows) is routed through Iceberg; documents and comments stay on the existing path.
- **Dual model:** Iceberg is the system of record, but the run still emits the public `dockets.parquet`, so the no-credentials CLI `download` and the public MCP server keep working unchanged. The catalog token never enters the public read path.
- **DuckDB `MERGE INTO`** as the engine (reuses existing DuckDB expertise + the `MAX(modify_date)` dedup idiom); pinned `duckdb>=1.4` (required for Iceberg REST catalog writes).
- **CI:** added a `use_iceberg` input + `R2_CATALOG_*` secrets to the manual *"ETL (new pipeline – vetting)"* workflow. The production `etl.yml` cron is **untouched**.
- **Tests:** `tests/test_iceberg.py` exercises insert / upsert / dedup-keeps-newer / export-shape end-to-end against a *local* in-memory DuckDB attached under the same alias — fully hermetic, no R2 needed.

## Out of scope (future phases)
- Migrating `documents` and the 31.6M-row `comments` (incl. retiring `partition_comments.py` for Iceberg hidden partitioning).
- Pointing the MCP server / analytics directly at the catalog (would revisit the public-access tradeoff).
- Switching the daily production cron over.

## Setup / verification
Requires a one-time ops step: enable R2 Data Catalog on the bucket, mint an R2 token with R2 + data-catalog scopes, and set `R2_CATALOG_URI` / `R2_CATALOG_WAREHOUSE` / `R2_CATALOG_TOKEN` (see `.env.example` and `src/spicy_regs/pipeline/README.md`). Then:

```bash
uv run run-pipeline --agency EPA --skip-comments --since-year 2025 --use-iceberg --skip-upload
```

Re-running shows a stable row count (upsert dedup) and a new entry in `…dockets.snapshots` (history) — the whole point versus the old full rewrite.

`uv run pytest` (148 passed), `uv run ruff check .`, and `uv run ty check` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPJzymfnxmjNygeNkS4Y5K

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPJzymfnxmjNygeNkS4Y5K)_