### PR TITLE
Extract PDF text from document and comment attachments (#9)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,13 @@ dependencies = [
     "pyarrow",
     "tqdm",
     "httpx",
-    "duckdb>=1.4",  # >=1.4 required to ATTACH an Iceberg REST catalog and MERGE INTO it
+    "duckdb>=1.4", # >=1.4 required to ATTACH an Iceberg REST catalog and MERGE INTO it
     "pandas",
     "prefect",
     "cyclopts",
     "loguru",
     "mcp>=1.10.0",
+    "pypdf",
 ]
 
 [project.optional-dependencies]
@@ -41,6 +42,7 @@ dev = [
 [project.scripts]
 etl = "spicy_regs.pipeline.pipeline:app"
 run-pipeline = "spicy_regs.pipelines.regulations:app"
+enrich-pdf-text = "spicy_regs.pipeline.enrich_pdf:main"
 embed = "spicy_regs.vectordb.embed:main"
 spicy-regs = "spicy_regs.cli:main"
 spicy-regs-mcp = "spicy_regs.mcp_server:main"

--- a/src/spicy_regs/cli.py
+++ b/src/spicy_regs/cli.py
@@ -144,7 +144,7 @@ def cmd_search(args):
     search_configs = {
         "dockets": ["title", "abstract"],
         "documents": ["title", "text_content"],
-        "comments": ["title", "comment"],
+        "comments": ["title", "comment", "text_content"],
     }
 
     for data_type, columns in search_configs.items():

--- a/src/spicy_regs/cli.py
+++ b/src/spicy_regs/cli.py
@@ -143,7 +143,7 @@ def cmd_search(args):
 
     search_configs = {
         "dockets": ["title", "abstract"],
-        "documents": ["title"],
+        "documents": ["title", "text_content"],
         "comments": ["title", "comment"],
     }
 

--- a/src/spicy_regs/pipeline/README.md
+++ b/src/spicy_regs/pipeline/README.md
@@ -107,6 +107,28 @@ uv run etl --merge-only --output-dir ./output
 | `--upload-only` | Only upload to R2 |
 | `--partition-only` | Partition comments by agency and upload |
 
+## PDF text extraction
+
+The metadata ETL above only moves JSON, so `documents.text_content` is left
+`NULL`. A separate, opt-in step backfills it by downloading each document's PDF
+rendition and extracting its embedded text:
+
+```bash
+# Enrich ./output/documents.parquet in place. Incremental by default:
+# documents that already have a text_extraction_status are skipped.
+uv run enrich-pdf-text --output-dir ./output
+
+uv run enrich-pdf-text --output-dir ./output --limit 500    # cap a run
+uv run enrich-pdf-text --output-dir ./output --overwrite    # re-extract everything
+```
+
+It is kept out of the hot metadata path on purpose — it makes one HTTP request
+per PDF, which is far slower than the JSON ingest. The pieces are split along
+the usual lines: `sources/pdf.py` fetches the bytes (I/O), `transforms/pdf_text.py`
+turns bytes into text (pure, no network), and `pipeline/enrich_pdf.py` joins them
+over the Parquet. Scanned / image-only PDFs have no text layer and come back
+`empty` — OCR is out of scope.
+
 ## Data Schema
 
 All columns are stored as strings (`large_string` in PyArrow).
@@ -140,6 +162,8 @@ All columns are stored as strings (`large_string` in PyArrow).
 | `withdrawn` | Whether the document was withdrawn (`"true"`/`"false"`, often null) |
 | `reason_withdrawn` | Stated reason for withdrawal (often null) |
 | `additional_rins` | JSON array of additional RINs linked to the document (often null) |
+| `text_content` | Text extracted from the document's PDF rendition (null until the PDF text step runs) |
+| `text_extraction_status` | Outcome of PDF text extraction: `ok` / `empty` (scanned, no text layer) / `encrypted` / `error`, or null if not yet attempted |
 
 ### Comments (~31.6M rows)
 

--- a/src/spicy_regs/pipeline/README.md
+++ b/src/spicy_regs/pipeline/README.md
@@ -109,14 +109,19 @@ uv run etl --merge-only --output-dir ./output
 
 ## PDF text extraction
 
-The metadata ETL above only moves JSON, so `documents.text_content` is left
-`NULL`. A separate, opt-in step backfills it by downloading each document's PDF
-rendition and extracting its embedded text:
+The metadata ETL above only moves JSON, so `text_content` is left `NULL` on
+both documents and comments. A separate, opt-in step backfills it by
+downloading PDF attachments and extracting their embedded text:
 
 ```bash
-# Enrich ./output/documents.parquet in place. Incremental by default:
-# documents that already have a text_extraction_status are skipped.
+# Documents (default). Enriches ./output/documents.parquet in place.
+# Incremental: rows that already have a text_extraction_status are skipped.
 uv run enrich-pdf-text --output-dir ./output
+
+# Comment attachments. Uses the Hive-partitioned comments/agency/ layout when
+# present, else the monolithic comments.parquet. --limit is a total budget
+# across partitions.
+uv run enrich-pdf-text --output-dir ./output --target comments
 
 uv run enrich-pdf-text --output-dir ./output --limit 500    # cap a run
 uv run enrich-pdf-text --output-dir ./output --overwrite    # re-extract everything
@@ -126,8 +131,10 @@ It is kept out of the hot metadata path on purpose — it makes one HTTP request
 per PDF, which is far slower than the JSON ingest. The pieces are split along
 the usual lines: `sources/pdf.py` fetches the bytes (I/O), `transforms/pdf_text.py`
 turns bytes into text (pure, no network), and `pipeline/enrich_pdf.py` joins them
-over the Parquet. Scanned / image-only PDFs have no text layer and come back
-`empty` — OCR is out of scope.
+over the Parquet. Documents and comments pack their attachment renditions
+differently (documents flat, comments nested under each attachment's `formats`),
+so each has its own URL extractor feeding one shared core. Scanned / image-only
+PDFs have no text layer and come back `empty` — OCR is out of scope.
 
 ## Data Schema
 
@@ -183,6 +190,8 @@ All columns are stored as strings (`large_string` in PyArrow).
 | `modify_date` | Last modification date |
 | `receive_date` | Date received |
 | `attachments_json` | Compact JSON array of comment attachments |
+| `text_content` | Text extracted from the comment's PDF attachment(s) (null until the PDF text step runs) |
+| `text_extraction_status` | Outcome of PDF text extraction: `ok` / `empty` / `encrypted` / `error`, or null if not yet attempted |
 
 ## Output Structure on R2
 

--- a/src/spicy_regs/pipeline/enrich_pdf.py
+++ b/src/spicy_regs/pipeline/enrich_pdf.py
@@ -1,23 +1,31 @@
-"""Backfill ``documents.text_content`` from each document's PDF rendition.
+"""Backfill ``text_content`` from PDF attachments on documents and comments.
 
 This wires the two halves of issue #9 together:
 
     sources.fetch_pdf_bytes (download)  →  transforms.extract_pdf_text (parse)
 
-over the rows of ``documents.parquet``. It is intentionally a *separate* step
-from the metadata ETL: that pipeline only moves JSON and is fast, whereas this
-downloads potentially tens of thousands of PDFs and is run on demand / in its
-own job. The metadata ETL leaves ``text_content`` as ``NULL``; this fills it.
+over the rows of ``documents.parquet`` / the comments dataset. It is
+intentionally a *separate* step from the metadata ETL: that pipeline only moves
+JSON and is fast, whereas this downloads potentially many PDFs and is run on
+demand / in its own job. The metadata ETL leaves ``text_content`` as ``NULL``;
+this fills it.
 
-``enrich_documents_with_pdf_text`` takes the fetch + extract callables as
-parameters so it can be exercised without touching the network.
+The enrichment functions take the fetch + extract callables as parameters so
+they can be exercised without touching the network.
+
+Documents and comments pack their attachment renditions differently:
+
+  * documents:  ``[{url, format, size}, ...]``                       (flat)
+  * comments:   ``[{title, formats: [{url, format, size}]}, ...]``   (nested)
+
+so each has its own URL extractor; both feed the same generic core.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -34,39 +42,70 @@ from spicy_regs.transforms.pdf_text import (
 
 FetchFn = Callable[[str], bytes | None]
 ExtractFn = Callable[[bytes], PdfTextResult]
+UrlsFn = Callable[[Mapping[str, object]], list[str]]
+
+
+def _is_pdf(url: str | None, fmt: str | None) -> bool:
+    if not url:
+        return False
+    return (fmt or "").lower() == "pdf" or url.lower().endswith(".pdf")
+
+
+def _dedupe(urls: list[str]) -> list[str]:
+    """Drop duplicate URLs while preserving first-seen order."""
+    return list(dict.fromkeys(urls))
+
+
+def _opt_str(value: object) -> str | None:
+    """Narrow a polars row value (typed ``object``) to ``str | None``."""
+    return value if isinstance(value, str) else None
 
 
 def pdf_urls_for_document(attachments_json: str | None, file_url: str | None) -> list[str]:
-    """Return the PDF download URLs for one document, in order, de-duplicated.
+    """PDF download URLs for one *document*, in order, de-duplicated.
 
-    Prefers the structured ``attachments_json`` (picking renditions whose
-    ``format`` is ``pdf``); falls back to ``file_url`` when it points at a
-    ``.pdf``. Non-PDF renditions (htm, docx, ...) are ignored — extracting
-    those is out of scope.
+    Prefers the structured ``attachments_json`` (a flat list of renditions);
+    falls back to ``file_url`` when it points at a ``.pdf``. Non-PDF renditions
+    (htm, docx, ...) are ignored — extracting those is out of scope.
     """
     urls: list[str] = []
     if attachments_json:
         try:
             for att in json.loads(attachments_json):
-                fmt = (att.get("format") or "").lower()
-                url = att.get("url")
-                if url and (fmt == "pdf" or url.lower().endswith(".pdf")):
-                    urls.append(url)
+                if _is_pdf(att.get("url"), att.get("format")):
+                    urls.append(att["url"])
         except (json.JSONDecodeError, AttributeError, TypeError):
             pass
     if not urls and file_url and file_url.lower().endswith(".pdf"):
         urls.append(file_url)
-    # De-dupe while preserving order.
-    return list(dict.fromkeys(urls))
+    return _dedupe(urls)
 
 
-def _extract_document_text(urls: list[str], fetch: FetchFn, extract: ExtractFn) -> tuple[str | None, str]:
-    """Fetch + extract every PDF for a document and combine into one result.
+def pdf_urls_for_comment(attachments_json: str | None) -> list[str]:
+    """PDF download URLs for one *comment*, in order, de-duplicated.
 
-    Returns ``(text_or_None, status)``. A document can have more than one PDF
-    rendition; their texts are concatenated. The combined status is the best
-    outcome seen: ``ok`` if any PDF yielded text, otherwise ``error`` >
-    ``encrypted`` > ``empty`` in that order of informativeness.
+    Comment attachments nest their renditions: each attachment carries a
+    ``formats`` list of ``{url, format, size}``.
+    """
+    urls: list[str] = []
+    if attachments_json:
+        try:
+            for att in json.loads(attachments_json):
+                for fmt in att.get("formats") or []:
+                    if _is_pdf(fmt.get("url"), fmt.get("format")):
+                        urls.append(fmt["url"])
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            pass
+    return _dedupe(urls)
+
+
+def _extract_combined_text(urls: list[str], fetch: FetchFn, extract: ExtractFn) -> tuple[str | None, str]:
+    """Fetch + extract every PDF for one row and combine into a single result.
+
+    Returns ``(text_or_None, status)``. A row can have more than one PDF
+    rendition; their texts are concatenated. The combined status is ``ok`` if
+    any PDF yielded text, otherwise ``error`` > ``encrypted`` > ``empty`` in
+    that order of informativeness.
     """
     texts: list[str] = []
     statuses: list[str] = []
@@ -88,74 +127,74 @@ def _extract_document_text(urls: list[str], fetch: FetchFn, extract: ExtractFn) 
     return None, PdfTextStatus.EMPTY.value
 
 
-def enrich_documents_with_pdf_text(
+def _enrich_with_pdf_text(
     df: pl.DataFrame,
     *,
-    fetch: FetchFn = fetch_pdf_bytes,
-    extract: ExtractFn = extract_pdf_text,
-    limit: int | None = None,
-    max_workers: int = 8,
-    overwrite: bool = False,
+    id_col: str,
+    url_cols: list[str],
+    urls_fn: UrlsFn,
+    fetch: FetchFn,
+    extract: ExtractFn,
+    limit: int | None,
+    max_workers: int,
+    overwrite: bool,
 ) -> tuple[pl.DataFrame, dict[str, int]]:
-    """Fill ``text_content`` / ``text_extraction_status`` for PDF documents.
+    """Generic core: fill ``text_content`` / ``text_extraction_status`` for the
+    rows of ``df`` whose attachments (via ``urls_fn``) include a PDF.
 
-    Each unique ``document_id`` with a PDF rendition is processed once. Unless
-    ``overwrite`` is set, documents that already have a
-    ``text_extraction_status`` are skipped, so repeated runs are incremental.
-    Returns the updated DataFrame and a stats counter.
+    Each unique ``id_col`` is processed once. Unless ``overwrite`` is set, rows
+    that already have a ``text_extraction_status`` are skipped, so repeated runs
+    are incremental.
     """
-    # Ensure the target columns exist even on older Parquet files.
     for col in ("text_content", "text_extraction_status"):
         if col not in df.columns:
             df = df.with_columns(pl.lit(None, dtype=pl.Utf8).alias(col))
 
-    candidates = df.select("document_id", "attachments_json", "file_url", "text_extraction_status").unique(
-        subset="document_id", keep="first"
-    )
+    candidates = df.select(id_col, *url_cols, "text_extraction_status").unique(subset=id_col, keep="first")
 
     work: list[tuple[str, list[str]]] = []
     for row in candidates.iter_rows(named=True):
-        doc_id = row["document_id"]
-        if doc_id is None:
+        row_id = row[id_col]
+        if row_id is None:
             continue
         if not overwrite and row["text_extraction_status"] is not None:
             continue
-        urls = pdf_urls_for_document(row["attachments_json"], row["file_url"])
+        urls = urls_fn(row)
         if urls:
-            work.append((doc_id, urls))
+            work.append((row_id, urls))
 
     if limit is not None:
         work = work[:limit]
 
     stats = {"selected": len(work), "ok": 0, "empty": 0, "encrypted": 0, "error": 0}
     if not work:
-        logger.info("No PDF documents to enrich")
+        logger.info("No PDF attachments to enrich")
         return df, stats
 
-    logger.info("Enriching {} documents with PDF text ({} workers)...", len(work), max_workers)
+    logger.info("Enriching {} rows with PDF text ({} workers)...", len(work), max_workers)
 
     def _process(item: tuple[str, list[str]]) -> tuple[str, str | None, str]:
-        doc_id, urls = item
-        text, status = _extract_document_text(urls, fetch, extract)
-        return doc_id, text, status
+        row_id, urls = item
+        text, status = _extract_combined_text(urls, fetch, extract)
+        return row_id, text, status
 
     ids: list[str] = []
     texts: list[str | None] = []
     statuses: list[str] = []
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        for doc_id, text, status in executor.map(_process, work):
-            ids.append(doc_id)
+        for row_id, text, status in executor.map(_process, work):
+            ids.append(row_id)
             texts.append(text)
             statuses.append(status)
             stats[status] = stats.get(status, 0) + 1
 
     updates = pl.DataFrame(
-        {"document_id": ids, "_new_text": texts, "_new_status": statuses},
-        schema={"document_id": pl.Utf8, "_new_text": pl.Utf8, "_new_status": pl.Utf8},
+        {id_col: ids, "_new_text": texts, "_new_status": statuses},
+        schema={id_col: pl.Utf8, "_new_text": pl.Utf8, "_new_status": pl.Utf8},
     )
 
     enriched = (
-        df.join(updates, on="document_id", how="left")
+        df.join(updates, on=id_col, how="left")
         .with_columns(
             text_content=pl.coalesce(["_new_text", "text_content"]),
             text_extraction_status=pl.coalesce(["_new_status", "text_extraction_status"]),
@@ -173,6 +212,63 @@ def enrich_documents_with_pdf_text(
     return enriched, stats
 
 
+def enrich_documents_with_pdf_text(
+    df: pl.DataFrame,
+    *,
+    fetch: FetchFn = fetch_pdf_bytes,
+    extract: ExtractFn = extract_pdf_text,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> tuple[pl.DataFrame, dict[str, int]]:
+    """Fill ``text_content`` / ``text_extraction_status`` for PDF documents."""
+    return _enrich_with_pdf_text(
+        df,
+        id_col="document_id",
+        url_cols=["attachments_json", "file_url"],
+        urls_fn=lambda row: pdf_urls_for_document(_opt_str(row["attachments_json"]), _opt_str(row["file_url"])),
+        fetch=fetch,
+        extract=extract,
+        limit=limit,
+        max_workers=max_workers,
+        overwrite=overwrite,
+    )
+
+
+def enrich_comments_with_pdf_text(
+    df: pl.DataFrame,
+    *,
+    fetch: FetchFn = fetch_pdf_bytes,
+    extract: ExtractFn = extract_pdf_text,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> tuple[pl.DataFrame, dict[str, int]]:
+    """Fill ``text_content`` / ``text_extraction_status`` for comment PDF attachments."""
+    return _enrich_with_pdf_text(
+        df,
+        id_col="comment_id",
+        url_cols=["attachments_json"],
+        urls_fn=lambda row: pdf_urls_for_comment(_opt_str(row["attachments_json"])),
+        fetch=fetch,
+        extract=extract,
+        limit=limit,
+        max_workers=max_workers,
+        overwrite=overwrite,
+    )
+
+
+def _enrich_parquet_file(
+    path: Path,
+    enrich: Callable[[pl.DataFrame], tuple[pl.DataFrame, dict[str, int]]],
+) -> dict[str, int]:
+    df = pl.read_parquet(path)
+    enriched, stats = enrich(df)
+    enriched.write_parquet(path, compression="zstd")
+    logger.info("Wrote {} ({} rows)", path, len(enriched))
+    return stats
+
+
 def enrich_documents_parquet(
     documents_path: Path,
     *,
@@ -183,27 +279,103 @@ def enrich_documents_parquet(
     """Read ``documents.parquet``, enrich it in place, and write it back."""
     if not documents_path.exists():
         raise FileNotFoundError(f"{documents_path} not found; run the ETL first")
+    return _enrich_parquet_file(
+        documents_path,
+        lambda df: enrich_documents_with_pdf_text(df, limit=limit, max_workers=max_workers, overwrite=overwrite),
+    )
 
-    df = pl.read_parquet(documents_path)
-    enriched, stats = enrich_documents_with_pdf_text(df, limit=limit, max_workers=max_workers, overwrite=overwrite)
-    enriched.write_parquet(documents_path, compression="zstd")
-    logger.info("Wrote {} ({} rows)", documents_path, len(enriched))
-    return stats
+
+def enrich_comments_parquet(
+    comments_path: Path,
+    *,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> dict[str, int]:
+    """Read a single comments Parquet file, enrich it in place, write it back."""
+    if not comments_path.exists():
+        raise FileNotFoundError(f"{comments_path} not found; run the ETL first")
+    return _enrich_parquet_file(
+        comments_path,
+        lambda df: enrich_comments_with_pdf_text(df, limit=limit, max_workers=max_workers, overwrite=overwrite),
+    )
+
+
+def enrich_comment_partitions(
+    partition_dir: Path,
+    *,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> dict[str, int]:
+    """Enrich every ``agency_code=*/*.parquet`` partition under ``partition_dir``.
+
+    Comments are Hive-partitioned by agency; each partition is enriched and
+    rewritten independently. ``limit`` (if given) is the total budget across
+    all partitions, so a capped run won't silently process every agency.
+    """
+    parts = sorted(partition_dir.glob("agency_code=*/*.parquet"))
+    if not parts:
+        raise FileNotFoundError(f"No comment partitions found under {partition_dir}")
+
+    totals = {"selected": 0, "ok": 0, "empty": 0, "encrypted": 0, "error": 0}
+    remaining = limit
+    for part in parts:
+        if remaining is not None and remaining <= 0:
+            logger.info("Reached --limit budget; {} partitions left unprocessed", len(parts) - parts.index(part))
+            break
+        stats = _enrich_parquet_file(
+            part,
+            lambda df: enrich_comments_with_pdf_text(df, limit=remaining, max_workers=max_workers, overwrite=overwrite),
+        )
+        for k, v in stats.items():
+            totals[k] += v
+        if remaining is not None:
+            remaining -= stats["selected"]
+
+    logger.info("Comment partition enrichment totals: {}", totals)
+    return totals
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description="Backfill documents/comments text_content from PDF attachments.")
     parser.add_argument("--output-dir", type=Path, default=Path("output"))
-    parser.add_argument("--limit", type=int, default=None, help="Max documents to process this run")
-    parser.add_argument("--max-workers", type=int, default=8)
-    parser.add_argument("--overwrite", action="store_true", help="Re-extract documents that already have a status")
-    args = parser.parse_args()
-    enrich_documents_parquet(
-        args.output_dir / "documents.parquet",
-        limit=args.limit,
-        max_workers=args.max_workers,
-        overwrite=args.overwrite,
+    parser.add_argument(
+        "--target",
+        choices=["documents", "comments"],
+        default="documents",
+        help="Which dataset to enrich (default: documents)",
     )
+    parser.add_argument("--limit", type=int, default=None, help="Max rows to process this run")
+    parser.add_argument("--max-workers", type=int, default=8)
+    parser.add_argument("--overwrite", action="store_true", help="Re-extract rows that already have a status")
+    args = parser.parse_args()
+
+    if args.target == "documents":
+        enrich_documents_parquet(
+            args.output_dir / "documents.parquet",
+            limit=args.limit,
+            max_workers=args.max_workers,
+            overwrite=args.overwrite,
+        )
+        return
+
+    # Comments: prefer the Hive-partitioned layout, fall back to the monolithic file.
+    partition_dir = args.output_dir / "comments" / "agency"
+    if partition_dir.exists():
+        enrich_comment_partitions(
+            partition_dir,
+            limit=args.limit,
+            max_workers=args.max_workers,
+            overwrite=args.overwrite,
+        )
+    else:
+        enrich_comments_parquet(
+            args.output_dir / "comments.parquet",
+            limit=args.limit,
+            max_workers=args.max_workers,
+            overwrite=args.overwrite,
+        )
 
 
 if __name__ == "__main__":

--- a/src/spicy_regs/pipeline/enrich_pdf.py
+++ b/src/spicy_regs/pipeline/enrich_pdf.py
@@ -1,0 +1,210 @@
+"""Backfill ``documents.text_content`` from each document's PDF rendition.
+
+This wires the two halves of issue #9 together:
+
+    sources.fetch_pdf_bytes (download)  →  transforms.extract_pdf_text (parse)
+
+over the rows of ``documents.parquet``. It is intentionally a *separate* step
+from the metadata ETL: that pipeline only moves JSON and is fast, whereas this
+downloads potentially tens of thousands of PDFs and is run on demand / in its
+own job. The metadata ETL leaves ``text_content`` as ``NULL``; this fills it.
+
+``enrich_documents_with_pdf_text`` takes the fetch + extract callables as
+parameters so it can be exercised without touching the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import polars as pl
+from loguru import logger
+
+from spicy_regs.sources.pdf import fetch_pdf_bytes
+from spicy_regs.transforms.pdf_text import (
+    PAGE_SEPARATOR,
+    PdfTextResult,
+    PdfTextStatus,
+    extract_pdf_text,
+)
+
+FetchFn = Callable[[str], bytes | None]
+ExtractFn = Callable[[bytes], PdfTextResult]
+
+
+def pdf_urls_for_document(attachments_json: str | None, file_url: str | None) -> list[str]:
+    """Return the PDF download URLs for one document, in order, de-duplicated.
+
+    Prefers the structured ``attachments_json`` (picking renditions whose
+    ``format`` is ``pdf``); falls back to ``file_url`` when it points at a
+    ``.pdf``. Non-PDF renditions (htm, docx, ...) are ignored — extracting
+    those is out of scope.
+    """
+    urls: list[str] = []
+    if attachments_json:
+        try:
+            for att in json.loads(attachments_json):
+                fmt = (att.get("format") or "").lower()
+                url = att.get("url")
+                if url and (fmt == "pdf" or url.lower().endswith(".pdf")):
+                    urls.append(url)
+        except (json.JSONDecodeError, AttributeError, TypeError):
+            pass
+    if not urls and file_url and file_url.lower().endswith(".pdf"):
+        urls.append(file_url)
+    # De-dupe while preserving order.
+    return list(dict.fromkeys(urls))
+
+
+def _extract_document_text(urls: list[str], fetch: FetchFn, extract: ExtractFn) -> tuple[str | None, str]:
+    """Fetch + extract every PDF for a document and combine into one result.
+
+    Returns ``(text_or_None, status)``. A document can have more than one PDF
+    rendition; their texts are concatenated. The combined status is the best
+    outcome seen: ``ok`` if any PDF yielded text, otherwise ``error`` >
+    ``encrypted`` > ``empty`` in that order of informativeness.
+    """
+    texts: list[str] = []
+    statuses: list[str] = []
+    for url in urls:
+        data = fetch(url)
+        if data is None:
+            statuses.append(PdfTextStatus.ERROR.value)
+            continue
+        result = extract(data)
+        statuses.append(result.status.value)
+        if result.text:
+            texts.append(result.text)
+
+    if texts:
+        return PAGE_SEPARATOR.join(texts), PdfTextStatus.OK.value
+    for candidate in (PdfTextStatus.ERROR.value, PdfTextStatus.ENCRYPTED.value, PdfTextStatus.EMPTY.value):
+        if candidate in statuses:
+            return None, candidate
+    return None, PdfTextStatus.EMPTY.value
+
+
+def enrich_documents_with_pdf_text(
+    df: pl.DataFrame,
+    *,
+    fetch: FetchFn = fetch_pdf_bytes,
+    extract: ExtractFn = extract_pdf_text,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> tuple[pl.DataFrame, dict[str, int]]:
+    """Fill ``text_content`` / ``text_extraction_status`` for PDF documents.
+
+    Each unique ``document_id`` with a PDF rendition is processed once. Unless
+    ``overwrite`` is set, documents that already have a
+    ``text_extraction_status`` are skipped, so repeated runs are incremental.
+    Returns the updated DataFrame and a stats counter.
+    """
+    # Ensure the target columns exist even on older Parquet files.
+    for col in ("text_content", "text_extraction_status"):
+        if col not in df.columns:
+            df = df.with_columns(pl.lit(None, dtype=pl.Utf8).alias(col))
+
+    candidates = df.select("document_id", "attachments_json", "file_url", "text_extraction_status").unique(
+        subset="document_id", keep="first"
+    )
+
+    work: list[tuple[str, list[str]]] = []
+    for row in candidates.iter_rows(named=True):
+        doc_id = row["document_id"]
+        if doc_id is None:
+            continue
+        if not overwrite and row["text_extraction_status"] is not None:
+            continue
+        urls = pdf_urls_for_document(row["attachments_json"], row["file_url"])
+        if urls:
+            work.append((doc_id, urls))
+
+    if limit is not None:
+        work = work[:limit]
+
+    stats = {"selected": len(work), "ok": 0, "empty": 0, "encrypted": 0, "error": 0}
+    if not work:
+        logger.info("No PDF documents to enrich")
+        return df, stats
+
+    logger.info("Enriching {} documents with PDF text ({} workers)...", len(work), max_workers)
+
+    def _process(item: tuple[str, list[str]]) -> tuple[str, str | None, str]:
+        doc_id, urls = item
+        text, status = _extract_document_text(urls, fetch, extract)
+        return doc_id, text, status
+
+    ids: list[str] = []
+    texts: list[str | None] = []
+    statuses: list[str] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for doc_id, text, status in executor.map(_process, work):
+            ids.append(doc_id)
+            texts.append(text)
+            statuses.append(status)
+            stats[status] = stats.get(status, 0) + 1
+
+    updates = pl.DataFrame(
+        {"document_id": ids, "_new_text": texts, "_new_status": statuses},
+        schema={"document_id": pl.Utf8, "_new_text": pl.Utf8, "_new_status": pl.Utf8},
+    )
+
+    enriched = (
+        df.join(updates, on="document_id", how="left")
+        .with_columns(
+            text_content=pl.coalesce(["_new_text", "text_content"]),
+            text_extraction_status=pl.coalesce(["_new_status", "text_extraction_status"]),
+        )
+        .drop("_new_text", "_new_status")
+    )
+
+    logger.info(
+        "PDF enrichment: {} ok, {} empty, {} encrypted, {} error",
+        stats["ok"],
+        stats["empty"],
+        stats["encrypted"],
+        stats["error"],
+    )
+    return enriched, stats
+
+
+def enrich_documents_parquet(
+    documents_path: Path,
+    *,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> dict[str, int]:
+    """Read ``documents.parquet``, enrich it in place, and write it back."""
+    if not documents_path.exists():
+        raise FileNotFoundError(f"{documents_path} not found; run the ETL first")
+
+    df = pl.read_parquet(documents_path)
+    enriched, stats = enrich_documents_with_pdf_text(df, limit=limit, max_workers=max_workers, overwrite=overwrite)
+    enriched.write_parquet(documents_path, compression="zstd")
+    logger.info("Wrote {} ({} rows)", documents_path, len(enriched))
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, default=Path("output"))
+    parser.add_argument("--limit", type=int, default=None, help="Max documents to process this run")
+    parser.add_argument("--max-workers", type=int, default=8)
+    parser.add_argument("--overwrite", action="store_true", help="Re-extract documents that already have a status")
+    args = parser.parse_args()
+    enrich_documents_parquet(
+        args.output_dir / "documents.parquet",
+        limit=args.limit,
+        max_workers=args.max_workers,
+        overwrite=args.overwrite,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/spicy_regs/pipeline/pipeline.py
+++ b/src/spicy_regs/pipeline/pipeline.py
@@ -143,6 +143,10 @@ def _extract_document(d: dict) -> dict:
         "withdrawn": attrs.get("withdrawn"),
         "reason_withdrawn": attrs.get("reasonWithdrawn"),
         "additional_rins": (json_dumps(rins) if (rins := attrs.get("additionalRins")) else None),
+        # Populated out-of-band by the PDF text-extraction step
+        # (spicy_regs.pipeline.enrich_pdf); the raw JSON has no text layer.
+        "text_content": None,
+        "text_extraction_status": None,
     }
 
 
@@ -199,6 +203,10 @@ DATA_TYPES: dict[str, _DataTypeConfig] = {
             "withdrawn": pl.Utf8,
             "reason_withdrawn": pl.Utf8,
             "additional_rins": pl.Utf8,
+            # Text extracted from the document's PDF rendition, plus the outcome
+            # of that extraction ("ok"/"empty"/"encrypted"/"error"/None if not yet run).
+            "text_content": pl.Utf8,
+            "text_extraction_status": pl.Utf8,
         },
         "extract": _extract_document,
     },

--- a/src/spicy_regs/pipeline/pipeline.py
+++ b/src/spicy_regs/pipeline/pipeline.py
@@ -112,6 +112,10 @@ def _extract_comment(d: dict) -> dict:
         "modify_date": attrs.get("modifyDate"),
         "receive_date": attrs.get("receiveDate"),
         "attachments_json": json_dumps(attachments) if attachments else None,
+        # Populated out-of-band by the PDF text-extraction step
+        # (spicy_regs.pipeline.enrich_pdf) from any PDF attachments.
+        "text_content": None,
+        "text_extraction_status": None,
     }
 
 
@@ -227,6 +231,10 @@ DATA_TYPES: dict[str, _DataTypeConfig] = {
             "modify_date": pl.Utf8,
             "receive_date": pl.Utf8,
             "attachments_json": pl.Utf8,
+            # Text extracted from the comment's PDF attachment(s), plus the outcome
+            # ("ok"/"empty"/"encrypted"/"error"/None if not yet run).
+            "text_content": pl.Utf8,
+            "text_extraction_status": pl.Utf8,
         },
         "extract": _extract_comment,
     },

--- a/src/spicy_regs/schemas/regulations.py
+++ b/src/spicy_regs/schemas/regulations.py
@@ -44,6 +44,10 @@ def _extract_comment(d: dict) -> dict:
         "modify_date": attrs.get("modifyDate"),
         "receive_date": attrs.get("receiveDate"),
         "attachments_json": json_dumps(attachments) if attachments else None,
+        # Populated out-of-band by the PDF text-extraction step
+        # (spicy_regs.pipeline.enrich_pdf) from any PDF attachments.
+        "text_content": None,
+        "text_extraction_status": None,
     }
 
 
@@ -154,6 +158,10 @@ COMMENT = RecordType(
         "modify_date": pl.Utf8,
         "receive_date": pl.Utf8,
         "attachments_json": pl.Utf8,
+        # Text extracted from the comment's PDF attachment(s), plus the outcome
+        # ("ok"/"empty"/"encrypted"/"error"/None if not yet run).
+        "text_content": pl.Utf8,
+        "text_extraction_status": pl.Utf8,
     },
     dedup_key="comment_id",
     extract=_extract_comment,

--- a/src/spicy_regs/schemas/regulations.py
+++ b/src/spicy_regs/schemas/regulations.py
@@ -75,6 +75,10 @@ def _extract_document(d: dict) -> dict:
         "withdrawn": attrs.get("withdrawn"),
         "reason_withdrawn": attrs.get("reasonWithdrawn"),
         "additional_rins": (json_dumps(rins) if (rins := attrs.get("additionalRins")) else None),
+        # Populated out-of-band by the PDF text-extraction step
+        # (spicy_regs.pipeline.enrich_pdf); the raw JSON has no text layer.
+        "text_content": None,
+        "text_extraction_status": None,
     }
 
 
@@ -122,6 +126,10 @@ DOCUMENT = RecordType(
         "withdrawn": pl.Utf8,
         "reason_withdrawn": pl.Utf8,
         "additional_rins": pl.Utf8,
+        # Text extracted from the document's PDF rendition, plus the outcome
+        # of that extraction ("ok"/"empty"/"encrypted"/"error"/None if not yet run).
+        "text_content": pl.Utf8,
+        "text_extraction_status": pl.Utf8,
     },
     dedup_key="document_id",
     extract=_extract_document,

--- a/src/spicy_regs/sources/__init__.py
+++ b/src/spicy_regs/sources/__init__.py
@@ -2,5 +2,6 @@ from spicy_regs.sources import iceberg, r2
 from spicy_regs.sources.base import Reader, Writer
 from spicy_regs.sources.mirrulations import MirrulationsReader
 from spicy_regs.sources.parquet import StagingWriter
+from spicy_regs.sources.pdf import fetch_pdf_bytes
 
-__all__ = ["Reader", "Writer", "MirrulationsReader", "StagingWriter", "r2", "iceberg"]
+__all__ = ["Reader", "Writer", "MirrulationsReader", "StagingWriter", "fetch_pdf_bytes", "r2", "iceberg"]

--- a/src/spicy_regs/sources/pdf.py
+++ b/src/spicy_regs/sources/pdf.py
@@ -1,0 +1,49 @@
+"""Fetch PDF bytes over HTTP.
+
+The I/O half of the PDF text-extraction step (issue #9): given a document's
+``fileUrl`` (e.g. a regulations.gov ``content.pdf`` rendition), download the
+bytes so :func:`spicy_regs.transforms.extract_pdf_text` can turn them into
+text. Network access lives here in ``sources`` so the transform stays pure.
+"""
+
+from __future__ import annotations
+
+import httpx
+from loguru import logger
+
+# Regulations.gov attachments are almost always well under this; the cap is a
+# guard against a pathological multi-hundred-MB file blowing up a batch run.
+DEFAULT_MAX_BYTES = 100 * 1024 * 1024
+DEFAULT_TIMEOUT = 30.0
+
+
+def fetch_pdf_bytes(
+    url: str,
+    *,
+    client: httpx.Client | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    max_bytes: int = DEFAULT_MAX_BYTES,
+) -> bytes | None:
+    """Download ``url`` and return its bytes, or ``None`` on any failure.
+
+    Follows redirects. Returns ``None`` (rather than raising) on HTTP errors,
+    timeouts, connection problems, or a body exceeding ``max_bytes`` so a
+    batch enrichment run can skip the document and keep going. Pass a shared
+    ``client`` to reuse a connection pool across many fetches.
+    """
+    owns_client = client is None
+    client = client or httpx.Client(timeout=timeout, follow_redirects=True)
+    try:
+        resp = client.get(url)
+        resp.raise_for_status()
+        content = resp.content
+        if len(content) > max_bytes:
+            logger.warning("PDF at {} is {} bytes (> {} cap), skipping", url, len(content), max_bytes)
+            return None
+        return content
+    except httpx.HTTPError as exc:
+        logger.warning("Failed to fetch PDF {}: {}", url, exc)
+        return None
+    finally:
+        if owns_client:
+            client.close()

--- a/src/spicy_regs/transforms/__init__.py
+++ b/src/spicy_regs/transforms/__init__.py
@@ -5,6 +5,12 @@ from spicy_regs.transforms.extract import ExtractRecords
 from spicy_regs.transforms.merge_comments_partitioned import merge_comments_partitioned
 from spicy_regs.transforms.merge_staging_files import merge_staging_files
 from spicy_regs.transforms.partition_comments import partition_comments
+from spicy_regs.transforms.pdf_text import (
+    PAGE_SEPARATOR,
+    PdfTextResult,
+    PdfTextStatus,
+    extract_pdf_text,
+)
 from spicy_regs.transforms.update_comments_index import update_comments_index
 from spicy_regs.transforms.write_staging import write_staging
 
@@ -18,4 +24,8 @@ __all__ = [
     "partition_comments",
     "build_feed_summary",
     "build_agency_rollups",
+    "extract_pdf_text",
+    "PdfTextResult",
+    "PdfTextStatus",
+    "PAGE_SEPARATOR",
 ]

--- a/src/spicy_regs/transforms/pdf_text.py
+++ b/src/spicy_regs/transforms/pdf_text.py
@@ -1,0 +1,103 @@
+"""Pure PDF byte → text extraction.
+
+This is the core of the "extract PDF text" pipeline step (issue #9). It takes
+the *bytes* of a PDF and returns the embedded text, page by page. Fetching
+those bytes from a URL is a :mod:`spicy_regs.sources` concern, not a transform —
+keeping this module pure (bytes in, text out) means it has no network or
+filesystem dependency and is trivially testable.
+
+Scope notes (matching the issue):
+  * Embedded text only. Scanned/image-only PDFs carry no text layer and come
+    back :attr:`PdfTextStatus.EMPTY` — OCR is explicitly out of scope.
+  * Basic structure is preserved by joining pages with :data:`PAGE_SEPARATOR`;
+    table/column reconstruction is out of scope.
+  * Corrupt, truncated, or password-protected PDFs never raise — they return a
+    result with a non-OK status so a batch enrichment run can record the
+    outcome and move on.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass
+from enum import Enum
+
+from pypdf import PdfReader
+from pypdf.errors import PyPdfError
+
+# Pages are joined with a blank line so the boundary survives in the stored
+# text without inventing structure the source PDF didn't have.
+PAGE_SEPARATOR = "\n\n"
+
+
+class PdfTextStatus(str, Enum):
+    """Outcome of an extraction attempt.
+
+    ``str`` mixin so the value serialises straight into Parquet/JSON as a
+    plain string (``"ok"``, ``"empty"``, ...).
+    """
+
+    OK = "ok"
+    """Parsed and produced some text."""
+    EMPTY = "empty"
+    """Parsed fine but no extractable text — almost always a scanned/image PDF."""
+    ENCRYPTED = "encrypted"
+    """Password-protected and could not be opened with an empty password."""
+    ERROR = "error"
+    """Not a PDF, truncated, or otherwise unparseable."""
+
+
+@dataclass(frozen=True)
+class PdfTextResult:
+    """Result of extracting text from one PDF's bytes."""
+
+    status: PdfTextStatus
+    text: str
+    page_count: int
+    error: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status is PdfTextStatus.OK
+
+
+def extract_pdf_text(data: bytes) -> PdfTextResult:
+    """Extract embedded text from PDF ``data``.
+
+    Never raises: every failure mode is mapped to a :class:`PdfTextResult`
+    carrying a non-OK :class:`PdfTextStatus`.
+    """
+    if not data:
+        return PdfTextResult(PdfTextStatus.ERROR, "", 0, error="empty input")
+
+    try:
+        reader = PdfReader(io.BytesIO(data))
+    except (PyPdfError, OSError, ValueError) as exc:
+        return PdfTextResult(PdfTextStatus.ERROR, "", 0, error=str(exc))
+
+    if reader.is_encrypted:
+        # Many regulations.gov PDFs are "encrypted" only with an empty owner
+        # password (encrypted for permissions, not secrecy); try to open them.
+        try:
+            if reader.decrypt("") == 0:  # 0 == PasswordType.NOT_DECRYPTED
+                return PdfTextResult(PdfTextStatus.ENCRYPTED, "", 0, error="password required")
+        except (PyPdfError, NotImplementedError) as exc:
+            return PdfTextResult(PdfTextStatus.ENCRYPTED, "", 0, error=str(exc))
+
+    try:
+        pages = reader.pages
+        page_count = len(pages)
+        parts: list[str] = []
+        for page in pages:
+            # One bad page shouldn't sink the whole document.
+            try:
+                parts.append(page.extract_text() or "")
+            except Exception:  # noqa: BLE001 - pypdf raises a wide variety here
+                parts.append("")
+    except (PyPdfError, OSError, ValueError) as exc:
+        return PdfTextResult(PdfTextStatus.ERROR, "", 0, error=str(exc))
+
+    text = PAGE_SEPARATOR.join(p.strip() for p in parts).strip()
+    if not text:
+        return PdfTextResult(PdfTextStatus.EMPTY, "", page_count)
+    return PdfTextResult(PdfTextStatus.OK, text, page_count)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,8 +60,8 @@ def sample_comments() -> list[dict]:
 @pytest.fixture
 def sample_documents() -> list[dict]:
     return [
-        {"document_id": "D-001", "docket_id": "EPA-2024-0001", "agency_code": "EPA", "title": "Proposed Rule", "document_type": "Proposed Rule", "posted_date": "2024-06-01", "modify_date": "2024-06-01", "comment_start_date": "2024-06-01", "comment_end_date": "2024-07-01", "file_url": None, "attachments_json": None, "fr_doc_num": None, "withdrawn": "false", "reason_withdrawn": None, "additional_rins": None},
-        {"document_id": "D-002", "docket_id": "FDA-2024-0010", "agency_code": "FDA", "title": "Notice", "document_type": "Notice", "posted_date": "2024-04-15", "modify_date": "2024-04-15", "comment_start_date": "2024-04-15", "comment_end_date": "2024-05-15", "file_url": None, "attachments_json": None, "fr_doc_num": "2025-13790", "withdrawn": "true", "reason_withdrawn": "Superseded by revised proposal", "additional_rins": "[\"0910-AH35\"]"},
+        {"document_id": "D-001", "docket_id": "EPA-2024-0001", "agency_code": "EPA", "title": "Proposed Rule", "document_type": "Proposed Rule", "posted_date": "2024-06-01", "modify_date": "2024-06-01", "comment_start_date": "2024-06-01", "comment_end_date": "2024-07-01", "file_url": None, "attachments_json": None, "fr_doc_num": None, "withdrawn": "false", "reason_withdrawn": None, "additional_rins": None, "text_content": None, "text_extraction_status": None},
+        {"document_id": "D-002", "docket_id": "FDA-2024-0010", "agency_code": "FDA", "title": "Notice", "document_type": "Notice", "posted_date": "2024-04-15", "modify_date": "2024-04-15", "comment_start_date": "2024-04-15", "comment_end_date": "2024-05-15", "file_url": None, "attachments_json": None, "fr_doc_num": "2025-13790", "withdrawn": "true", "reason_withdrawn": "Superseded by revised proposal", "additional_rins": "[\"0910-AH35\"]", "text_content": None, "text_extraction_status": None},
     ]
 
 
@@ -108,6 +108,8 @@ DOCUMENT_SCHEMA = {
     "withdrawn": pl.Utf8,
     "reason_withdrawn": pl.Utf8,
     "additional_rins": pl.Utf8,
+    "text_content": pl.Utf8,
+    "text_extraction_status": pl.Utf8,
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,8 @@ COMMENT_SCHEMA = {
     "modify_date": pl.Utf8,
     "receive_date": pl.Utf8,
     "attachments_json": pl.Utf8,
+    "text_content": pl.Utf8,
+    "text_extraction_status": pl.Utf8,
 }
 
 DOCUMENT_SCHEMA = {

--- a/tests/pdf_fixtures.py
+++ b/tests/pdf_fixtures.py
@@ -1,0 +1,70 @@
+"""Helpers to synthesize tiny, valid PDFs for tests.
+
+Building PDFs by hand (rather than committing binary fixtures) keeps the test
+data transparent and avoids a heavyweight PDF-authoring dependency. The output
+is minimal but real: pypdf parses it and extracts the embedded text.
+"""
+
+from __future__ import annotations
+
+import io
+
+
+def make_pdf(pages_text: list[str]) -> bytes:
+    """Return the bytes of a minimal PDF with one text line per page."""
+    n_pages = len(pages_text)
+    font_obj = 3
+    page_ids = [4 + i for i in range(n_pages)]
+    content_ids = [4 + n_pages + i for i in range(n_pages)]
+
+    parts: dict[int, bytes] = {}
+    parts[1] = b"<< /Type /Catalog /Pages 2 0 R >>"
+    kids = b" ".join(b"%d 0 R" % pid for pid in page_ids)
+    parts[2] = b"<< /Type /Pages /Kids [" + kids + b"] /Count %d >>" % n_pages
+    parts[font_obj] = b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"
+    for i in range(n_pages):
+        parts[page_ids[i]] = (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Resources << /Font << /F1 %d 0 R >> >> /Contents %d 0 R >>" % (font_obj, content_ids[i])
+        )
+        text = pages_text[i].encode("latin-1", "replace")
+        stream = b"BT /F1 12 Tf 72 720 Td (" + text + b") Tj ET"
+        parts[content_ids[i]] = b"<< /Length %d >>\nstream\n%s\nendstream" % (len(stream), stream)
+
+    out = io.BytesIO()
+    out.write(b"%PDF-1.4\n")
+    offsets: dict[int, int] = {}
+    for oid in sorted(parts):
+        offsets[oid] = out.tell()
+        out.write(b"%d 0 obj\n" % oid + parts[oid] + b"\nendobj\n")
+    xref_pos = out.tell()
+    max_id = max(parts)
+    out.write(b"xref\n0 %d\n" % (max_id + 1))
+    out.write(b"0000000000 65535 f \n")
+    for oid in range(1, max_id + 1):
+        out.write(b"%010d 00000 n \n" % offsets[oid])
+    out.write(b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF" % (max_id + 1, xref_pos))
+    return out.getvalue()
+
+
+def make_textless_pdf() -> bytes:
+    """A valid single-page PDF with no text content stream (image-only stand-in)."""
+    parts: dict[int, bytes] = {
+        1: b"<< /Type /Catalog /Pages 2 0 R >>",
+        2: b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        3: b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>",
+    }
+    out = io.BytesIO()
+    out.write(b"%PDF-1.4\n")
+    offsets: dict[int, int] = {}
+    for oid in sorted(parts):
+        offsets[oid] = out.tell()
+        out.write(b"%d 0 obj\n" % oid + parts[oid] + b"\nendobj\n")
+    xref_pos = out.tell()
+    max_id = max(parts)
+    out.write(b"xref\n0 %d\n" % (max_id + 1))
+    out.write(b"0000000000 65535 f \n")
+    for oid in range(1, max_id + 1):
+        out.write(b"%010d 00000 n \n" % offsets[oid])
+    out.write(b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF" % (max_id + 1, xref_pos))
+    return out.getvalue()

--- a/tests/test_enrich_pdf.py
+++ b/tests/test_enrich_pdf.py
@@ -7,7 +7,9 @@ import polars as pl
 from tests.pdf_fixtures import make_pdf, make_textless_pdf
 
 from spicy_regs.pipeline.enrich_pdf import (
+    enrich_comments_with_pdf_text,
     enrich_documents_with_pdf_text,
+    pdf_urls_for_comment,
     pdf_urls_for_document,
 )
 
@@ -127,3 +129,62 @@ def test_enrich_respects_limit() -> None:
         limit=1,
     )
     assert stats["selected"] == 1
+
+
+# --- Comment attachments (nested formats shape) ---------------------------
+
+
+def test_comment_pdf_urls_reads_nested_formats() -> None:
+    # Comment attachments nest renditions under each attachment's "formats".
+    attachments = json.dumps(
+        [
+            {
+                "title": "Exhibit A",
+                "formats": [
+                    {"url": "https://x/a.htm", "format": "htm"},
+                    {"url": "https://x/a.pdf", "format": "pdf"},
+                ],
+            },
+            {"title": "Exhibit B", "formats": [{"url": "https://x/b.pdf", "format": "pdf"}]},
+        ]
+    )
+    assert pdf_urls_for_comment(attachments) == ["https://x/a.pdf", "https://x/b.pdf"]
+
+
+def test_comment_pdf_urls_none_and_bad_json() -> None:
+    assert pdf_urls_for_comment(None) == []
+    assert pdf_urls_for_comment("not json") == []
+    assert pdf_urls_for_comment(json.dumps([{"title": "no formats"}])) == []
+
+
+def _comments_frame() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "comment_id": ["C-pdf", "C-plain"],
+            "attachments_json": [
+                json.dumps([{"title": "Letter", "formats": [{"url": "https://x/c.pdf", "format": "pdf"}]}]),
+                None,
+            ],
+            "text_content": [None, None],
+            "text_extraction_status": [None, None],
+        },
+        schema={
+            "comment_id": pl.Utf8,
+            "attachments_json": pl.Utf8,
+            "text_content": pl.Utf8,
+            "text_extraction_status": pl.Utf8,
+        },
+    )
+
+
+def test_enrich_comments_fills_attachment_text() -> None:
+    enriched, stats = enrich_comments_with_pdf_text(
+        _comments_frame(),
+        fetch=lambda url: make_pdf(["Comment attachment body"]),
+    )
+    by_id = {r["comment_id"]: r for r in enriched.iter_rows(named=True)}
+    assert by_id["C-pdf"]["text_extraction_status"] == "ok"
+    assert "Comment attachment body" in by_id["C-pdf"]["text_content"]
+    # Comment with no attachment is never selected.
+    assert by_id["C-plain"]["text_extraction_status"] is None
+    assert stats == {"selected": 1, "ok": 1, "empty": 0, "encrypted": 0, "error": 0}

--- a/tests/test_enrich_pdf.py
+++ b/tests/test_enrich_pdf.py
@@ -1,0 +1,129 @@
+"""Tests for the documents PDF-text enrichment step."""
+
+import json
+
+import polars as pl
+
+from tests.pdf_fixtures import make_pdf, make_textless_pdf
+
+from spicy_regs.pipeline.enrich_pdf import (
+    enrich_documents_with_pdf_text,
+    pdf_urls_for_document,
+)
+
+
+def test_pdf_urls_prefers_pdf_renditions() -> None:
+    attachments = json.dumps(
+        [
+            {"url": "https://x/doc.htm", "format": "htm"},
+            {"url": "https://x/doc.pdf", "format": "pdf"},
+        ]
+    )
+    assert pdf_urls_for_document(attachments, None) == ["https://x/doc.pdf"]
+
+
+def test_pdf_urls_falls_back_to_file_url() -> None:
+    assert pdf_urls_for_document(None, "https://x/content.pdf") == ["https://x/content.pdf"]
+    assert pdf_urls_for_document(None, "https://x/content.htm") == []
+
+
+def test_pdf_urls_dedupes_and_handles_bad_json() -> None:
+    assert pdf_urls_for_document("not json", "https://x/a.pdf") == ["https://x/a.pdf"]
+    dup = json.dumps([{"url": "https://x/a.pdf", "format": "pdf"}, {"url": "https://x/a.pdf", "format": "pdf"}])
+    assert pdf_urls_for_document(dup, None) == ["https://x/a.pdf"]
+
+
+def _docs_frame() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "document_id": ["D-pdf", "D-scan", "D-none"],
+            "attachments_json": [
+                json.dumps([{"url": "https://x/good.pdf", "format": "pdf"}]),
+                json.dumps([{"url": "https://x/scan.pdf", "format": "pdf"}]),
+                None,
+            ],
+            "file_url": ["https://x/good.pdf", "https://x/scan.pdf", None],
+            "text_content": [None, None, None],
+            "text_extraction_status": [None, None, None],
+        },
+        schema={
+            "document_id": pl.Utf8,
+            "attachments_json": pl.Utf8,
+            "file_url": pl.Utf8,
+            "text_content": pl.Utf8,
+            "text_extraction_status": pl.Utf8,
+        },
+    )
+
+
+def test_enrich_fills_text_and_status() -> None:
+    pdfs = {
+        "https://x/good.pdf": make_pdf(["Important regulatory comment"]),
+        "https://x/scan.pdf": make_textless_pdf(),
+    }
+    enriched, stats = enrich_documents_with_pdf_text(
+        _docs_frame(),
+        fetch=lambda url: pdfs.get(url),
+        max_workers=2,
+    )
+
+    by_id = {r["document_id"]: r for r in enriched.iter_rows(named=True)}
+    assert by_id["D-pdf"]["text_extraction_status"] == "ok"
+    assert "Important regulatory comment" in by_id["D-pdf"]["text_content"]
+    assert by_id["D-scan"]["text_extraction_status"] == "empty"
+    assert by_id["D-scan"]["text_content"] is None
+    # No PDF rendition → never selected, stays untouched.
+    assert by_id["D-none"]["text_extraction_status"] is None
+
+    assert stats == {"selected": 2, "ok": 1, "empty": 1, "encrypted": 0, "error": 0}
+
+
+def test_enrich_records_error_when_fetch_fails() -> None:
+    enriched, stats = enrich_documents_with_pdf_text(
+        _docs_frame().head(1),
+        fetch=lambda url: None,  # download always fails
+    )
+    row = enriched.row(0, named=True)
+    assert row["text_extraction_status"] == "error"
+    assert stats["error"] == 1
+
+
+def test_enrich_skips_already_processed_unless_overwrite() -> None:
+    df = _docs_frame().with_columns(
+        text_extraction_status=pl.Series(["ok", None, None]),
+        text_content=pl.Series(["existing text", None, None]),
+    )
+    calls: list[str] = []
+
+    def fetch(url: str) -> bytes:
+        calls.append(url)
+        return make_pdf(["new text"])
+
+    enriched, stats = enrich_documents_with_pdf_text(df, fetch=fetch)
+    # D-pdf already has a status, so only D-scan is fetched.
+    assert "https://x/good.pdf" not in calls
+    assert enriched.row(0, named=True)["text_content"] == "existing text"
+    assert stats["selected"] == 1
+
+
+def test_enrich_overwrite_reprocesses() -> None:
+    df = _docs_frame().with_columns(
+        text_extraction_status=pl.Series(["ok", "ok", None]),
+        text_content=pl.Series(["old", "old", None]),
+    )
+    enriched, stats = enrich_documents_with_pdf_text(
+        df,
+        fetch=lambda url: make_pdf(["fresh text"]),
+        overwrite=True,
+    )
+    assert stats["selected"] == 2
+    assert enriched.row(0, named=True)["text_content"] == "fresh text"
+
+
+def test_enrich_respects_limit() -> None:
+    _, stats = enrich_documents_with_pdf_text(
+        _docs_frame(),
+        fetch=lambda url: make_pdf(["t"]),
+        limit=1,
+    )
+    assert stats["selected"] == 1

--- a/tests/test_fetch_pdf.py
+++ b/tests/test_fetch_pdf.py
@@ -1,0 +1,41 @@
+"""Tests for the PDF fetch source (hermetic via httpx MockTransport)."""
+
+import httpx
+
+from spicy_regs.sources.pdf import fetch_pdf_bytes
+
+
+def _client(handler) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+
+
+def test_fetch_returns_bytes_on_200() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"%PDF-1.4 fake")
+
+    with _client(handler) as client:
+        assert fetch_pdf_bytes("https://example.com/a.pdf", client=client) == b"%PDF-1.4 fake"
+
+
+def test_fetch_returns_none_on_404() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    with _client(handler) as client:
+        assert fetch_pdf_bytes("https://example.com/missing.pdf", client=client) is None
+
+
+def test_fetch_returns_none_on_oversize_body() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"x" * 100)
+
+    with _client(handler) as client:
+        assert fetch_pdf_bytes("https://example.com/big.pdf", client=client, max_bytes=10) is None
+
+
+def test_fetch_returns_none_on_transport_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    with _client(handler) as client:
+        assert fetch_pdf_bytes("https://example.com/a.pdf", client=client) is None

--- a/tests/test_pdf_text.py
+++ b/tests/test_pdf_text.py
@@ -1,0 +1,48 @@
+"""Tests for the pure PDF text-extraction transform."""
+
+from tests.pdf_fixtures import make_pdf, make_textless_pdf
+
+from spicy_regs.transforms import PdfTextStatus, extract_pdf_text
+
+
+def test_extracts_text_from_single_page() -> None:
+    result = extract_pdf_text(make_pdf(["Hello PDF world"]))
+    assert result.status is PdfTextStatus.OK
+    assert result.ok
+    assert result.page_count == 1
+    assert "Hello PDF world" in result.text
+
+
+def test_preserves_page_boundaries() -> None:
+    result = extract_pdf_text(make_pdf(["First page", "Second page"]))
+    assert result.status is PdfTextStatus.OK
+    assert result.page_count == 2
+    assert "First page" in result.text
+    assert "Second page" in result.text
+    # The two pages are separated by a blank line, not run together.
+    assert "\n\n" in result.text
+
+
+def test_textless_pdf_is_empty_not_error() -> None:
+    # Image-only / scanned PDFs parse fine but carry no text layer (OCR is
+    # out of scope) — they must come back EMPTY, not ERROR.
+    result = extract_pdf_text(make_textless_pdf())
+    assert result.status is PdfTextStatus.EMPTY
+    assert result.text == ""
+    assert not result.ok
+
+
+def test_corrupt_bytes_return_error() -> None:
+    result = extract_pdf_text(b"%PDF-1.4 this is not really a pdf")
+    assert result.status is PdfTextStatus.ERROR
+    assert result.error is not None
+
+
+def test_empty_input_returns_error() -> None:
+    result = extract_pdf_text(b"")
+    assert result.status is PdfTextStatus.ERROR
+
+
+def test_non_pdf_bytes_return_error() -> None:
+    result = extract_pdf_text(b"just some plain text, no PDF header at all")
+    assert result.status is PdfTextStatus.ERROR

--- a/tests/test_pdf_text.py
+++ b/tests/test_pdf_text.py
@@ -1,8 +1,14 @@
 """Tests for the pure PDF text-extraction transform."""
 
+from pathlib import Path
+
+import pytest
+
 from tests.pdf_fixtures import make_pdf, make_textless_pdf
 
 from spicy_regs.transforms import PdfTextStatus, extract_pdf_text
+
+SAMPLE_DATA = Path(__file__).resolve().parents[1] / "sample-data" / "mirrulations"
 
 
 def test_extracts_text_from_single_page() -> None:
@@ -46,3 +52,22 @@ def test_empty_input_returns_error() -> None:
 def test_non_pdf_bytes_return_error() -> None:
     result = extract_pdf_text(b"just some plain text, no PDF header at all")
     assert result.status is PdfTextStatus.ERROR
+
+
+@pytest.mark.parametrize(
+    ("filename", "needle"),
+    [
+        # A real comment attachment (Wisconsin DCF comment letter).
+        ("comment-ACF-2025-0038-0004_attachment_1.pdf", "Indian Child Welfare Act"),
+        # A real document content PDF (Federal Register notice).
+        ("document-ACF-2025-0038-0001_content.pdf", "Federal Register"),
+    ],
+)
+def test_extracts_real_regulations_gov_pdfs(filename: str, needle: str) -> None:
+    path = SAMPLE_DATA / filename
+    if not path.exists():
+        pytest.skip(f"sample PDF {filename} not present")
+    result = extract_pdf_text(path.read_bytes())
+    assert result.status is PdfTextStatus.OK
+    assert result.page_count >= 1
+    assert needle in result.text

--- a/uv.lock
+++ b/uv.lock
@@ -3328,6 +3328,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+]
+
+[[package]]
 name = "pyrefly"
 version = "0.52.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4428,6 +4440,7 @@ dependencies = [
     { name = "polars" },
     { name = "prefect" },
     { name = "pyarrow" },
+    { name = "pypdf" },
     { name = "python-dotenv" },
     { name = "tqdm" },
 ]
@@ -4465,6 +4478,7 @@ requires-dist = [
     { name = "polars" },
     { name = "prefect" },
     { name = "pyarrow" },
+    { name = "pypdf" },
     { name = "python-dotenv" },
     { name = "sentence-transformers", marker = "extra == 'embed'" },
     { name = "torch", marker = "extra == 'embed'" },


### PR DESCRIPTION
## Summary

Closes #9.

The ETL ingests regulations.gov JSON metadata only, so PDF attachments on documents *and* comments are referenced but their text is never extracted — you can search filenames and titles, not contents. This adds the ability to pull embedded text out of those PDFs and store it on both tables.

The work follows the repo's `sources` (I/O) vs `transforms` (pure) split:

- **`transforms/pdf_text.py`** — pure `extract_pdf_text(bytes) -> PdfTextResult` using `pypdf`. Preserves page boundaries (blank-line separator) and maps every failure mode to a status instead of raising: `ok` / `empty` (scanned/image-only, no text layer) / `encrypted` / `error`.
- **`sources/pdf.py`** — `fetch_pdf_bytes(url)` over `httpx` (the I/O half), with a size cap and graceful `None` on any HTTP/transport error.
- **schema** — `documents` and `comments` both gain `text_content` and `text_extraction_status` columns (in both `schemas/regulations.py` and the `pipeline/pipeline.py` copy). The metadata ETL leaves them `NULL`.
- **`pipeline/enrich_pdf.py`** — opt-in step plus an `enrich-pdf-text` CLI. A shared core drives two wrappers:
  - `enrich_documents_with_pdf_text` — documents pack renditions as a flat `[{url, format, size}]`.
  - `enrich_comments_with_pdf_text` — comment attachments nest renditions under each attachment's `formats`.
  - `--target {documents,comments}` selects the dataset; for comments it handles the Hive-partitioned `comments/agency/` layout (with `--limit` as a budget across partitions) or the monolithic file.
  - The fetch + extract callables are injectable so it's testable without the network. Kept **out of the hot metadata path** (one HTTP request per PDF) and incremental by default — rows that already have a status are skipped unless `--overwrite`.
- **CLI search** now matches `documents.text_content` and `comments.text_content`.

Out of scope per the issue: OCR for scanned PDFs, table/chart extraction, and LanceDB index changes. The `text_content` columns are the foundation those can build on.

## Verified on real data

Ran the full path on the committed sample PDFs:
- Real **comment attachment** (`comment-ACF-2025-0038-0004_attachment_1.pdf`, a Wisconsin DCF comment letter) → `ok`, 2 pages, 4,182 chars, through `COMMENT.extract` → nested `attachments_json` → `pdf_urls_for_comment` → extract.
- Real **document content PDF** (Federal Register notice) → `ok`, 4 pages, 30,490 chars.

These are now a parametrized test, so they guard against pypdf regressions on real-world files.

## Test plan

- [x] `uv run pytest` — 171 passed, 1 deselected
- [x] `uv run ruff check` / `ruff format --check` — clean on new files
- [x] `uv run ty check` — no new diagnostics (the 2 pre-existing ones are in `vectordb/embed.py`)
- [x] Exercised the `enrich-pdf-text` CLI and both enrichment paths end-to-end on real sample PDFs

New tests: `tests/test_pdf_text.py` (extraction incl. corrupt/empty/textless + real samples), `tests/test_fetch_pdf.py` (hermetic via `httpx.MockTransport`), `tests/test_enrich_pdf.py` (document + comment URL parsing, fill, skip/overwrite, limit, error recording).

## Checklist

- [x] My change is scoped to one concern
- [x] I added or updated tests for new behavior
- [x] I updated docs (pipeline `README.md`: new step + schema columns for documents and comments)
- [ ] CI is green (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)