### PR TITLE
Fix MCP query crash on disk spill and add sandbox regression tests

### DIFF
--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -152,6 +152,31 @@ def _jsonify(value: Any) -> Any:
     return str(value)
 
 
+def _apply_security_settings(con: duckdb.DuckDBPyConnection) -> None:
+    """Lock a fresh connection down to read-only remote access.
+
+    Separated from :func:`_connect` (which also installs httpfs and creates the
+    R2 views) so the sandbox can be exercised in tests without network access.
+    Run after httpfs is loaded and before any user SQL.
+    """
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("SET autoinstall_known_extensions=false")
+    con.execute("SET autoload_known_extensions=false")
+    con.execute("SET allow_unsigned_extensions=false")
+    # Disabling LocalFileSystem stops user SQL from reading local files, but it
+    # also blocks DuckDB's on-disk spill target: temp_directory defaults to a
+    # local ".tmp", so any query that exceeds memory_limit (e.g. a GROUP BY or
+    # ORDER BY over the larger tables) would otherwise fail with the confusing
+    # "File system LocalFileSystem has been disabled by configuration". An empty
+    # temp_directory disables spilling — queries run in memory or fail with a
+    # clear out-of-memory error instead. Must precede disabling the filesystem.
+    con.execute("SET temp_directory=''")
+    con.execute("SET disabled_filesystems='LocalFileSystem'")
+    # DuckDB has no statement_timeout parameter; the per-query cap is enforced
+    # by the _statement_timeout watchdog wrapping each tool's execution.
+    con.execute("SET lock_configuration=true")
+
+
 def _connect() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
     # Must precede INSTALL/LOAD: that step writes the extension under
@@ -160,14 +185,7 @@ def _connect() -> duckdb.DuckDBPyConnection:
     con.execute(f"SET home_directory='{HOME_DIRECTORY.replace(chr(39), chr(39) * 2)}'")
     con.execute("INSTALL httpfs")
     con.execute("LOAD httpfs")
-    con.execute("SET preserve_insertion_order=false")
-    con.execute("SET autoinstall_known_extensions=false")
-    con.execute("SET autoload_known_extensions=false")
-    con.execute("SET allow_unsigned_extensions=false")
-    con.execute("SET disabled_filesystems='LocalFileSystem'")
-    # DuckDB has no statement_timeout parameter; the per-query cap is enforced
-    # by the _statement_timeout watchdog wrapping each tool's execution.
-    con.execute("SET lock_configuration=true")
+    _apply_security_settings(con)
     for name in TABLES:
         url = f"{R2_BASE_URL}/{name}.parquet"
         con.execute(f"CREATE VIEW {name} AS SELECT * FROM read_parquet('{url}')")

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -152,6 +152,31 @@ def _jsonify(value: Any) -> Any:
     return str(value)
 
 
+def _apply_security_settings(con: duckdb.DuckDBPyConnection) -> None:
+    """Lock a fresh connection down to read-only remote access.
+
+    Separated from :func:`_connect` (which also installs httpfs and creates the
+    R2 views) so the sandbox can be exercised in tests without network access.
+    Run after httpfs is loaded and before any user SQL.
+    """
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("SET autoinstall_known_extensions=false")
+    con.execute("SET autoload_known_extensions=false")
+    con.execute("SET allow_unsigned_extensions=false")
+    # Disabling LocalFileSystem stops user SQL from reading local files, but it
+    # also blocks DuckDB's on-disk spill target: temp_directory defaults to a
+    # local ".tmp", so any query that exceeds memory_limit (e.g. a GROUP BY or
+    # ORDER BY over the larger tables) would otherwise fail with the confusing
+    # "File system LocalFileSystem has been disabled by configuration". An empty
+    # temp_directory disables spilling — queries run in memory or fail with a
+    # clear out-of-memory error instead. Must precede disabling the filesystem.
+    con.execute("SET temp_directory=''")
+    con.execute("SET disabled_filesystems='LocalFileSystem'")
+    # DuckDB has no statement_timeout parameter; the per-query cap is enforced
+    # by the _statement_timeout watchdog wrapping each tool's execution.
+    con.execute("SET lock_configuration=true")
+
+
 def _connect() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
     # Must precede INSTALL/LOAD: that step writes the extension under
@@ -160,14 +185,7 @@ def _connect() -> duckdb.DuckDBPyConnection:
     con.execute(f"SET home_directory='{HOME_DIRECTORY.replace(chr(39), chr(39) * 2)}'")
     con.execute("INSTALL httpfs")
     con.execute("LOAD httpfs")
-    con.execute("SET preserve_insertion_order=false")
-    con.execute("SET autoinstall_known_extensions=false")
-    con.execute("SET autoload_known_extensions=false")
-    con.execute("SET allow_unsigned_extensions=false")
-    con.execute("SET disabled_filesystems='LocalFileSystem'")
-    # DuckDB has no statement_timeout parameter; the per-query cap is enforced
-    # by the _statement_timeout watchdog wrapping each tool's execution.
-    con.execute("SET lock_configuration=true")
+    _apply_security_settings(con)
     for name in TABLES:
         url = f"{R2_BASE_URL}/{name}.parquet"
         con.execute(f"CREATE VIEW {name} AS SELECT * FROM read_parquet('{url}')")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 from pathlib import Path
 from uuid import UUID
 
+import duckdb
 import pytest
 
 from spicy_regs import mcp_server
@@ -88,3 +89,110 @@ def test_vercel_copy_in_sync():
     assert vercel.TABLES == mcp_server.TABLES
     assert vercel.INSTRUCTIONS == mcp_server.INSTRUCTIONS
     assert vercel.DEFAULT_R2_BASE_URL == mcp_server.DEFAULT_R2_BASE_URL
+
+
+# --- Connection sandbox -----------------------------------------------------
+#
+# These exercise the real ``_apply_security_settings`` pragmas, which is where
+# both shipped runtime crashes lived (the bogus ``statement_timeout`` SET and
+# the spill-to-disabled-LocalFileSystem error). They are hermetic: the sandbox
+# is applied to a plain in-memory connection, so no httpfs install or network
+# is needed. The live ``_connect`` + R2 path is covered by the integration test
+# below.
+
+
+def _sandboxed_connection(memory_limit: str | None = None):
+    """A connection with the production read-only sandbox applied.
+
+    ``memory_limit`` is set before the sandbox locks the configuration, so a
+    test can force spilling behavior.
+    """
+    con = duckdb.connect()
+    if memory_limit is not None:
+        con.execute(f"SET memory_limit='{memory_limit}'")
+    mcp_server._apply_security_settings(con)
+    return con
+
+
+@pytest.mark.parametrize("module_name", ["canonical", "vercel"])
+def test_security_settings_apply_cleanly(module_name):
+    """Every pragma must be accepted by the installed DuckDB (no Catalog Error).
+
+    The original ``SET statement_timeout`` regression failed exactly here, on a
+    parameter DuckDB does not recognize.
+    """
+    module = mcp_server if module_name == "canonical" else _load_vercel_copy()
+    con = duckdb.connect()
+    module._apply_security_settings(con)  # must not raise
+
+
+def test_sandbox_allows_in_memory_query():
+    con = _sandboxed_connection()
+    assert con.execute("SELECT 1 + 1").fetchone() == (2,)
+    assert con.execute("SELECT count(*) FROM range(100)").fetchone() == (100,)
+
+
+def test_sandbox_survives_temp_spill():
+    """A query that exceeds memory must not raise the LocalFileSystem error.
+
+    Regression for ``Permission Error: File system LocalFileSystem has been
+    disabled by configuration``: ``temp_directory`` defaulted to a local
+    ``.tmp`` that the sandbox forbids, so any spilling query crashed. With
+    spilling disabled the query either runs in memory or fails with a clear
+    out-of-memory error — never the confusing permission error.
+    """
+    con = _sandboxed_connection(memory_limit="20MB")
+    spilling_sql = (
+        "SELECT i, count(*) AS c FROM range(3_000_000) r(i) "
+        "GROUP BY i ORDER BY c, i DESC"
+    )
+    try:
+        con.execute(spilling_sql).fetchall()
+    except duckdb.OutOfMemoryException:
+        pass  # acceptable: spilling disabled, no local temp touched
+    except duckdb.PermissionException as exc:
+        pytest.fail(f"sandbox crashed a spilling query on local temp: {exc}")
+
+
+def test_sandbox_blocks_local_file_reads(tmp_path):
+    """The local-file sandbox must stay intact (security regression guard)."""
+    con = _sandboxed_connection()
+    secret = tmp_path / "secret.csv"
+    secret.write_text("a,b\n1,2\n")
+    with pytest.raises(duckdb.PermissionException):
+        con.execute(f"SELECT * FROM read_csv_auto('{secret}')").fetchall()
+
+
+def test_sandbox_locks_configuration():
+    """User SQL must not be able to re-enable a disabled filesystem."""
+    con = _sandboxed_connection()
+    with pytest.raises(duckdb.Error):
+        con.execute("SET disabled_filesystems=''")
+
+
+@pytest.mark.integration
+def test_connect_queries_r2_end_to_end():
+    """Live: the real ``_connect`` (httpfs + R2 views) serves the MCP tools.
+
+    Covers the full path the hermetic tests cannot — httpfs install, the R2
+    parquet views, and a spilling aggregation over real data — asserting none
+    of it raises. Needs outbound network; run via ``pytest -m integration``.
+    """
+    server = mcp_server.build_server()
+
+    sources = asyncio.run(server.call_tool("list_sources", {}))
+    assert mcp_server.TABLES[0] in str(sources)
+
+    schema = asyncio.run(server.call_tool("describe_table", {"table": "agency_stats"}))
+    assert "column" in str(schema).lower()
+
+    # An ORDER BY over a full remote table is the spill-prone shape that
+    # crashed in production (sorts everything before applying the limit);
+    # ``ORDER BY 1`` keeps it schema-agnostic. Assert it returns without error.
+    result = asyncio.run(
+        server.call_tool(
+            "query_sql",
+            {"sql": "SELECT * FROM agency_stats ORDER BY 1", "max_rows": 5},
+        )
+    )
+    assert result is not None


### PR DESCRIPTION
## Summary

After the `statement_timeout` crash was fixed (#77), querying the MCP server hit the **next** latent failure in `_connect()`:

```
Permission Error: File system LocalFileSystem has been disabled by configuration
```

**Root cause:** `SET disabled_filesystems='LocalFileSystem'` stops user SQL from reading local files, but it also blocks DuckDB's on-disk **spill target**. `temp_directory` defaults to a local `.tmp`, so any query that exceeds `memory_limit` — a `GROUP BY` or `ORDER BY` over the larger tables — spills to a forbidden filesystem and crashes. The `LIMIT`-bounded smoke queries never spilled, so it went unnoticed. The entire sandbox block had in fact never been exercised end-to-end, because the `statement_timeout` SET crashed `_connect` before any query could run.

I reproduced the exact error locally with a spilling query (`SELECT i, count(*) FROM range(3_000_000) GROUP BY i ORDER BY ...` under a small `memory_limit`) and confirmed DuckDB's default `temp_directory` is `.tmp` (local), not empty.

**Fix:** `SET temp_directory=''` disables on-disk spilling. Queries now run in memory or fail with a clear out-of-memory error instead of the confusing permission error. The local-file sandbox is fully preserved.

**Refactor:** the sandbox pragmas are extracted into `_apply_security_settings()` (called by `_connect` after httpfs loads) so they can be tested without network or httpfs.

## Test plan

New tests in `tests/test_mcp_server.py` — these are what was missing (the prior suite never opened a connection, which is why two runtime crashes shipped):

- `test_security_settings_apply_cleanly` (canonical + Vercel copy) — every pragma is accepted by the installed DuckDB; this is exactly where the `statement_timeout` regression failed (unrecognized parameter → `Catalog Error`).
- `test_sandbox_survives_temp_spill` — a memory-exceeding query must **not** raise the `LocalFileSystem`-disabled `PermissionException` (OOM is acceptable). Fails without this fix, passes with it.
- `test_sandbox_blocks_local_file_reads` — local-file reads stay blocked (security regression guard).
- `test_sandbox_locks_configuration` — user SQL can't re-enable a disabled filesystem.
- `test_sandbox_allows_in_memory_query` — normal queries return rows.
- `test_connect_queries_r2_end_to_end` (`@pytest.mark.integration`) — drives the real `_connect` (httpfs install + R2 views) through the MCP tools, including a full-table `ORDER BY`; runs in the existing Integration workflow.

Verified locally:

- [x] `uv run pytest` — 13 passed, 1 deselected (integration)
- [x] `uv run ruff check .` — All checks passed
- [x] `ty check` — no new diagnostics in changed files
- [x] Reproduced the original `LocalFileSystem` error and confirmed `temp_directory=''` resolves it (spilling query → clean OOM; small queries unaffected)

## Checklist

- [x] My change is scoped to one concern
- [x] I added or updated tests for new behavior
- [x] I updated docs (README / CONTRIBUTING / module READMEs) if relevant — n/a
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSfFcd8fMRR1kL8iKhsoaW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSfFcd8fMRR1kL8iKhsoaW)_