### PR TITLE
Make the MCP landing page a compact, tabbed layout

### DIFF
--- a/mcp-server/public/index.html
+++ b/mcp-server/public/index.html
@@ -10,7 +10,6 @@
     :root {
       --blue: #1f5ba6;
       --blue-dark: #17457d;
-      --blue-light: #4a7fc0;
       --ink: #16202c;
       --muted: #5b6b7b;
       --line: #e3e8ee;
@@ -18,280 +17,263 @@
       --card: #ffffff;
       --code-bg: #0f1b2a;
       --code-ink: #e6edf6;
-      --radius: 14px;
     }
     * { box-sizing: border-box; }
-    html { -webkit-text-size-adjust: 100%; }
+    html, body { height: 100%; }
     body {
       margin: 0;
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       color: var(--ink);
       background: var(--bg);
-      line-height: 1.55;
+      line-height: 1.5;
+      display: flex;
+      flex-direction: column;
+      min-height: 100vh;
     }
     a { color: var(--blue); }
-    .wrap { max-width: 860px; margin: 0 auto; padding: 0 20px; }
+    .wrap { width: 100%; max-width: 780px; margin: 0 auto; padding: 0 20px; }
 
+    /* ---- header ---- */
     header {
       background: linear-gradient(160deg, var(--blue) 0%, var(--blue-dark) 100%);
       color: #fff;
-      padding: 56px 0 48px;
+      padding: 20px 0 18px;
     }
-    .brand { display: flex; align-items: center; gap: 18px; }
-    .brand img {
-      width: 72px; height: 72px; border-radius: 18px;
-      box-shadow: 0 8px 24px rgba(0,0,0,0.25);
-      flex: 0 0 auto;
-    }
-    .brand h1 { margin: 0; font-size: 2rem; letter-spacing: -0.02em; }
-    .brand p { margin: 4px 0 0; color: #cfe0f4; font-size: 1.02rem; }
-    header .lead {
-      margin: 26px 0 0; max-width: 620px; color: #e7effa; font-size: 1.06rem;
-    }
+    .topbar { display: flex; align-items: center; gap: 14px; }
+    .topbar img { width: 46px; height: 46px; border-radius: 12px; flex: 0 0 auto; box-shadow: 0 4px 14px rgba(0,0,0,0.25); }
+    .topbar h1 { margin: 0; font-size: 1.3rem; letter-spacing: -0.02em; }
+    .topbar p { margin: 1px 0 0; color: #cfe0f4; font-size: 0.88rem; }
+    .topbar .links { margin-left: auto; display: flex; gap: 14px; font-size: 0.86rem; }
+    .topbar .links a { color: #d6e4f6; text-decoration: none; white-space: nowrap; }
+    .topbar .links a:hover { color: #fff; text-decoration: underline; }
     .endpoint {
-      margin-top: 26px; display: inline-flex; align-items: center; gap: 10px;
-      background: rgba(255,255,255,0.12); border: 1px solid rgba(255,255,255,0.25);
-      padding: 10px 14px; border-radius: 10px; font-size: 0.95rem;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      margin-top: 14px; display: flex; align-items: center; gap: 10px;
+      background: rgba(255,255,255,0.12); border: 1px solid rgba(255,255,255,0.22);
+      padding: 8px 8px 8px 12px; border-radius: 10px; font-size: 0.9rem;
     }
-    .endpoint .label { color: #bcd2ee; font-family: inherit; }
+    .endpoint .label { color: #bcd2ee; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    .endpoint code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: #fff; flex: 1; overflow-x: auto; }
+    .endpoint .copy { flex: 0 0 auto; }
 
-    main { padding: 40px 0 64px; }
-    section { margin-top: 14px; }
-    h2 {
-      font-size: 1.35rem; letter-spacing: -0.01em; margin: 40px 0 6px;
-      padding-top: 8px;
+    /* ---- main / tabs ---- */
+    main { flex: 1 0 auto; padding: 20px 0 14px; }
+    .tabs {
+      display: flex; gap: 4px; border-bottom: 2px solid var(--line);
+      overflow-x: auto; -webkit-overflow-scrolling: touch; scrollbar-width: none;
     }
-    .section-sub { color: var(--muted); margin: 0 0 18px; }
+    .tabs::-webkit-scrollbar { display: none; }
+    .tab {
+      appearance: none; background: none; border: none; cursor: pointer;
+      font: inherit; font-size: 0.92rem; font-weight: 600; color: var(--muted);
+      padding: 9px 14px; white-space: nowrap; border-bottom: 2px solid transparent;
+      margin-bottom: -2px; border-radius: 8px 8px 0 0;
+    }
+    .tab:hover { color: var(--ink); background: #eef2f7; }
+    .tab[aria-selected="true"] { color: var(--blue-dark); border-bottom-color: var(--blue); }
 
-    .card {
-      background: var(--card); border: 1px solid var(--line);
-      border-radius: var(--radius); padding: 22px 22px 8px; margin-bottom: 18px;
-      box-shadow: 0 1px 2px rgba(16,32,48,0.04);
+    .panel { display: none; padding: 18px 2px 0; }
+    .panel[data-active] { display: block; }
+    .panel .req { font-size: 0.85rem; color: var(--muted); margin: 0 0 12px; }
+    .panel .req .badge {
+      font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
+      color: var(--blue-dark); background: #e8f0fa; border-radius: 999px; padding: 2px 8px; margin-right: 6px;
     }
-    .card h3 {
-      margin: 0 0 4px; font-size: 1.12rem; display: flex; align-items: center; gap: 9px;
-    }
-    .card .req { font-size: 0.85rem; color: var(--muted); margin: 0 0 14px; }
-    .badge {
-      font-size: 0.72rem; font-weight: 600; text-transform: uppercase;
-      letter-spacing: 0.04em; color: var(--blue-dark); background: #e8f0fa;
-      border-radius: 999px; padding: 3px 9px; vertical-align: middle;
-    }
+    .steps { margin: 0; padding-left: 20px; }
+    .steps li { margin: 5px 0; font-size: 0.95rem; }
+    .panel .hint { font-size: 0.85rem; color: var(--muted); margin: 0 0 3px; }
+    .pathline { color: var(--muted); font-size: 0.8rem; margin: 0 0 4px; font-family: ui-monospace, monospace; }
 
-    ol { margin: 0 0 16px; padding-left: 22px; }
-    ol li { margin: 6px 0; }
-
-    .codeblock {
-      position: relative; background: var(--code-bg); color: var(--code-ink);
-      border-radius: 10px; margin: 12px 0 18px; overflow: hidden;
-    }
+    .codeblock { position: relative; background: var(--code-bg); color: var(--code-ink); border-radius: 9px; margin: 6px 0 14px; overflow: hidden; }
     .codeblock pre {
-      margin: 0; padding: 16px 64px 16px 16px; overflow-x: auto;
+      margin: 0; padding: 13px 60px 13px 14px; overflow-x: auto;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: 0.86rem; line-height: 1.5;
+      font-size: 0.84rem; line-height: 1.45;
     }
-    .codeblock .copy {
-      position: absolute; top: 8px; right: 8px;
-      background: #24364a; color: #cfe0f4;
-      border: 1px solid rgba(255,255,255,0.18); border-radius: 7px;
-      font-size: 0.74rem; padding: 5px 10px; cursor: pointer;
-      font-family: inherit; box-shadow: -8px 0 10px 4px var(--code-bg);
+    .copy {
+      background: #24364a; color: #cfe0f4; border: 1px solid rgba(255,255,255,0.18);
+      border-radius: 7px; font: inherit; font-size: 0.74rem; padding: 5px 10px; cursor: pointer;
     }
-    .codeblock .copy:hover { background: #324863; color: #fff; }
-    .codeblock .copy.copied { color: #aef0c4; border-color: rgba(174,240,196,0.5); }
+    .copy:hover { background: #324863; color: #fff; }
+    .copy.copied { color: #aef0c4; border-color: rgba(174,240,196,0.5); }
+    .codeblock .copy { position: absolute; top: 7px; right: 7px; box-shadow: -8px 0 10px 4px var(--code-bg); }
 
-    .pathline { color: #8aa4c2; font-size: 0.8rem; margin: -6px 0 0; font-family: ui-monospace, monospace; }
-
-    .tools-table { width: 100%; border-collapse: collapse; margin: 4px 0 18px; font-size: 0.95rem; }
-    .tools-table th, .tools-table td { text-align: left; padding: 9px 10px; border-bottom: 1px solid var(--line); }
-    .tools-table th { color: var(--muted); font-weight: 600; }
-    .tools-table code { background: #eef2f7; padding: 1px 6px; border-radius: 5px; font-size: 0.86em; }
-
-    footer { border-top: 1px solid var(--line); padding: 26px 0 50px; color: var(--muted); font-size: 0.9rem; }
-    footer a { text-decoration: none; }
-    footer a:hover { text-decoration: underline; }
+    /* ---- footer ---- */
+    footer { flex: 0 0 auto; border-top: 1px solid var(--line); padding: 12px 0; font-size: 0.83rem; color: var(--muted); }
+    footer .wrap { display: flex; flex-wrap: wrap; gap: 6px 10px; align-items: baseline; }
+    footer code { background: #eef2f7; padding: 1px 5px; border-radius: 5px; font-size: 0.92em; }
+    footer .tools strong { color: var(--ink); font-weight: 600; }
 
     @media (max-width: 560px) {
-      header { padding: 40px 0 36px; }
-      .brand { flex-direction: column; align-items: flex-start; gap: 14px; }
-      .brand h1 { font-size: 1.6rem; }
-      .endpoint { font-size: 0.82rem; flex-wrap: wrap; }
+      .topbar .links { display: none; }
+      .topbar h1 { font-size: 1.15rem; }
     }
   </style>
 </head>
 <body>
   <header>
     <div class="wrap">
-      <div class="brand">
+      <div class="topbar">
         <img src="/icon.png" alt="Spicy Regs logo" />
         <div>
           <h1>Spicy Regs MCP Server</h1>
           <p>A regulations.gov mirror, queryable from your AI tools.</p>
         </div>
+        <nav class="links">
+          <a href="https://docs.spicy-regs.dev/">Data dictionary</a>
+          <a href="https://github.com/civictechdc/spicy-regs">GitHub</a>
+          <a href="https://modelcontextprotocol.io">About MCP</a>
+        </nav>
       </div>
-      <p class="lead">
-        A remote <a href="https://modelcontextprotocol.io" style="color:#fff;text-decoration:underline">Model Context Protocol</a>
-        server that exposes the Spicy Regs regulatory dataset — dockets, documents,
-        and public comments — to any MCP-compatible client. It runs DuckDB queries
-        against a public Cloudflare R2 parquet bucket; no API key, no local install required.
-      </p>
       <div class="endpoint">
         <span class="label">Endpoint</span>
-        <strong>https://mcp.spicy-regs.dev/mcp</strong>
+        <code id="endpoint">https://mcp.spicy-regs.dev/mcp</code>
+        <button class="copy" type="button" data-copy="https://mcp.spicy-regs.dev/mcp">Copy</button>
       </div>
     </div>
   </header>
 
   <main>
     <div class="wrap">
-
-      <h2>Set up in your AI tool</h2>
-      <p class="section-sub">Pick your client below. Most accept the remote HTTP endpoint directly; for local-process clients there's a <code>uvx</code> stdio option too.</p>
-
-      <!-- Claude.ai -->
-      <div class="card">
-        <h3>Claude.ai <span class="badge">web &amp; desktop</span></h3>
-        <p class="req">Requires a Pro, Max, Team, or Enterprise plan.</p>
-        <ol>
-          <li>Open <strong>Settings → Connectors → Add custom connector</strong>.</li>
-          <li>Name it <strong>Spicy Regs</strong>.</li>
-          <li>Set the URL to <strong>https://mcp.spicy-regs.dev/mcp</strong>.</li>
-          <li>Leave authentication as <strong>None</strong> (the dataset is public).</li>
-          <li>Save, then toggle the connector on in any conversation.</li>
-        </ol>
+      <div class="tabs" role="tablist" aria-label="Setup instructions by tool">
+        <button class="tab" role="tab" aria-selected="true" data-tab="claude-ai">Claude.ai</button>
+        <button class="tab" role="tab" aria-selected="false" data-tab="claude-code">Claude Code</button>
+        <button class="tab" role="tab" aria-selected="false" data-tab="cursor">Cursor</button>
+        <button class="tab" role="tab" aria-selected="false" data-tab="vscode">VS Code</button>
+        <button class="tab" role="tab" aria-selected="false" data-tab="windsurf">Windsurf</button>
+        <button class="tab" role="tab" aria-selected="false" data-tab="other">Other clients</button>
       </div>
 
+      <!-- Claude.ai -->
+      <section class="panel" id="panel-claude-ai" role="tabpanel" data-active>
+        <p class="req"><span class="badge">Pro · Max · Team · Enterprise</span>web &amp; desktop</p>
+        <ol class="steps">
+          <li>Open <strong>Settings → Connectors → Add custom connector</strong>.</li>
+          <li>Name it <strong>Spicy Regs</strong>.</li>
+          <li>Set the URL to the endpoint above.</li>
+          <li>Leave authentication as <strong>None</strong> — the dataset is public.</li>
+          <li>Save, then toggle the connector on in any conversation.</li>
+        </ol>
+      </section>
+
       <!-- Claude Code -->
-      <div class="card">
-        <h3>Claude Code</h3>
-        <p class="req">Two transports work — pick one.</p>
-        <p style="margin:0 0 2px;font-size:0.9rem;color:var(--muted)">Remote HTTP:</p>
+      <section class="panel" id="panel-claude-code" role="tabpanel">
+        <p class="hint">Remote HTTP:</p>
         <div class="codeblock">
           <button class="copy" type="button">Copy</button>
           <pre><code>claude mcp add --transport http spicy-regs https://mcp.spicy-regs.dev/mcp</code></pre>
         </div>
-        <p style="margin:0 0 2px;font-size:0.9rem;color:var(--muted)">Local stdio via <code>uvx</code> (no remote dependency):</p>
+        <p class="hint">Local stdio via <code style="background:#eef2f7;padding:1px 5px;border-radius:5px">uvx</code> (no remote dependency):</p>
         <div class="codeblock">
           <button class="copy" type="button">Copy</button>
           <pre><code>claude mcp add spicy-regs -- uvx --from "spicy-regs @ git+https://github.com/civictechdc/spicy-regs" spicy-regs-mcp</code></pre>
         </div>
-      </div>
+      </section>
 
       <!-- Cursor -->
-      <div class="card">
-        <h3>Cursor</h3>
-        <p class="req">Add to your MCP config, then enable it under Settings → MCP.</p>
-        <p class="pathline">~/.cursor/mcp.json &nbsp;(global) &nbsp;·&nbsp; .cursor/mcp.json &nbsp;(per-project)</p>
+      <section class="panel" id="panel-cursor" role="tabpanel">
+        <p class="hint">Add to your MCP config, then enable it under <strong>Settings → MCP</strong>.</p>
+        <p class="pathline">~/.cursor/mcp.json (global) · .cursor/mcp.json (per-project)</p>
         <div class="codeblock">
           <button class="copy" type="button">Copy</button>
           <pre><code>{
   "mcpServers": {
-    "spicy-regs": {
-      "url": "https://mcp.spicy-regs.dev/mcp"
-    }
+    "spicy-regs": { "url": "https://mcp.spicy-regs.dev/mcp" }
   }
 }</code></pre>
         </div>
-      </div>
+      </section>
 
       <!-- VS Code -->
-      <div class="card">
-        <h3>VS Code <span class="badge">Copilot</span></h3>
-        <p class="req">Add a workspace MCP config (Agent mode required).</p>
+      <section class="panel" id="panel-vscode" role="tabpanel">
+        <p class="hint">Add a workspace MCP config (Copilot Agent mode required).</p>
         <p class="pathline">.vscode/mcp.json</p>
         <div class="codeblock">
           <button class="copy" type="button">Copy</button>
           <pre><code>{
   "servers": {
-    "spicy-regs": {
-      "type": "http",
-      "url": "https://mcp.spicy-regs.dev/mcp"
-    }
+    "spicy-regs": { "type": "http", "url": "https://mcp.spicy-regs.dev/mcp" }
   }
 }</code></pre>
         </div>
-      </div>
+      </section>
 
       <!-- Windsurf -->
-      <div class="card">
-        <h3>Windsurf</h3>
-        <p class="req">Add to the Cascade MCP config, then refresh the server list.</p>
+      <section class="panel" id="panel-windsurf" role="tabpanel">
+        <p class="hint">Add to the Cascade MCP config, then refresh the server list.</p>
         <p class="pathline">~/.codeium/windsurf/mcp_config.json</p>
         <div class="codeblock">
           <button class="copy" type="button">Copy</button>
           <pre><code>{
   "mcpServers": {
-    "spicy-regs": {
-      "serverUrl": "https://mcp.spicy-regs.dev/mcp"
-    }
+    "spicy-regs": { "serverUrl": "https://mcp.spicy-regs.dev/mcp" }
   }
 }</code></pre>
         </div>
-      </div>
+      </section>
 
-      <!-- Generic -->
-      <div class="card">
-        <h3>Any other MCP client</h3>
-        <p class="req">Most clients accept either a remote streamable-HTTP URL or a local stdio command.</p>
-        <p style="margin:0 0 2px;font-size:0.9rem;color:var(--muted)">Remote (streamable HTTP):</p>
+      <!-- Other -->
+      <section class="panel" id="panel-other" role="tabpanel">
+        <p class="hint">Most clients accept a remote streamable-HTTP URL:</p>
         <div class="codeblock">
           <button class="copy" type="button">Copy</button>
           <pre><code>https://mcp.spicy-regs.dev/mcp</code></pre>
         </div>
-        <p style="margin:0 0 2px;font-size:0.9rem;color:var(--muted)">Local (stdio) — runs the published console script with <code>uvx</code>:</p>
+        <p class="hint">Or run it locally over stdio with <code style="background:#eef2f7;padding:1px 5px;border-radius:5px">uvx</code>:</p>
         <div class="codeblock">
           <button class="copy" type="button">Copy</button>
           <pre><code>uvx --from "spicy-regs @ git+https://github.com/civictechdc/spicy-regs" spicy-regs-mcp</code></pre>
         </div>
-      </div>
-
-      <h2>Tools exposed</h2>
-      <p class="section-sub">Three read-only tools over the R2 dataset.</p>
-      <table class="tools-table">
-        <thead>
-          <tr><th>Tool</th><th>Purpose</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><code>list_sources</code></td><td>List the logical tables in the R2 dataset.</td></tr>
-          <tr><td><code>describe_table(table)</code></td><td>Get the column schema for one table.</td></tr>
-          <tr><td><code>query_sql(sql, max_rows=25)</code></td><td>Run a read-only SQL query against the R2 views.</td></tr>
-        </tbody>
-      </table>
-      <p class="section-sub" style="margin-top:2px">
-        Available views: <code>dockets</code>, <code>documents</code>, <code>comments</code>,
-        <code>comments_index</code>, <code>feed_summary</code>, <code>agency_stats</code>,
-        <code>agency_monthly_volume</code>. Full schemas live in the
-        <a href="https://docs.spicy-regs.dev/">data dictionary</a>.
-      </p>
-
+      </section>
     </div>
   </main>
 
   <footer>
     <div class="wrap">
-      <a href="https://github.com/civictechdc/spicy-regs">GitHub</a>
-      &nbsp;·&nbsp;
-      <a href="https://docs.spicy-regs.dev/">Data dictionary</a>
-      &nbsp;·&nbsp;
-      <a href="https://modelcontextprotocol.io">About MCP</a>
-      <p style="margin:14px 0 0">A <a href="https://www.civictechdc.org/">Civic Tech DC</a> project. Data sourced from regulations.gov.</p>
+      <span class="tools"><strong>Tools:</strong> <code>list_sources</code> · <code>describe_table</code> · <code>query_sql</code></span>
+      <span>·</span>
+      <span><strong>Views:</strong> dockets, documents, comments, comments_index, feed_summary, agency_stats, agency_monthly_volume</span>
     </div>
   </footer>
 
   <script>
-    document.querySelectorAll(".codeblock .copy").forEach(function (btn) {
+    var tabs = Array.prototype.slice.call(document.querySelectorAll(".tab"));
+    var panels = {
+      "claude-ai": "panel-claude-ai", "claude-code": "panel-claude-code",
+      "cursor": "panel-cursor", "vscode": "panel-vscode",
+      "windsurf": "panel-windsurf", "other": "panel-other"
+    };
+    function select(name) {
+      tabs.forEach(function (t) {
+        var on = t.dataset.tab === name;
+        t.setAttribute("aria-selected", on ? "true" : "false");
+      });
+      Object.keys(panels).forEach(function (k) {
+        var el = document.getElementById(panels[k]);
+        if (k === name) el.setAttribute("data-active", ""); else el.removeAttribute("data-active");
+      });
+    }
+    tabs.forEach(function (t, i) {
+      t.addEventListener("click", function () { select(t.dataset.tab); });
+      t.addEventListener("keydown", function (e) {
+        if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+        e.preventDefault();
+        var next = (i + (e.key === "ArrowRight" ? 1 : tabs.length - 1)) % tabs.length;
+        tabs[next].focus(); select(tabs[next].dataset.tab);
+      });
+    });
+
+    document.querySelectorAll(".copy").forEach(function (btn) {
       btn.addEventListener("click", function () {
-        var code = btn.parentElement.querySelector("code");
-        var text = code ? code.innerText : "";
+        var text = btn.dataset.copy;
+        if (!text) {
+          var code = btn.parentElement.querySelector("code");
+          text = code ? code.innerText : "";
+        }
         navigator.clipboard.writeText(text).then(function () {
           var prev = btn.textContent;
           btn.textContent = "Copied";
           btn.classList.add("copied");
-          setTimeout(function () {
-            btn.textContent = prev;
-            btn.classList.remove("copied");
-          }, 1600);
+          setTimeout(function () { btn.textContent = prev; btn.classList.remove("copied"); }, 1500);
         });
       });
     });


### PR DESCRIPTION
## Summary

Follow-up to #78. Reworks the MCP server landing page (`mcp-server/public/index.html`) from a long stack of cards into a **compact, tabbed layout** that fits on one screen without scrolling.

- One **tab per tool**: Claude.ai, Claude Code, Cursor, VS Code, Windsurf, Other clients — only the selected tool's instructions are shown.
- The **endpoint** moves to a copyable pill in the header (referenced by every tab).
- The tool/view reference collapses into a **slim footer** instead of a full-height section.
- Tabs are keyboard-navigable (left/right arrows) with proper `role="tablist"`/`tab`/`tabpanel` and `aria-selected` semantics.
- All `Copy` buttons retained (endpoint + each code block).

No change to `vercel.json` or either Python server copy — still a static asset served from `public/`, so the `/mcp` rewrite and `test_vercel_copy_in_sync` are unaffected.

## Test plan

- [x] Served `mcp-server/public/` locally and rendered headless (Chromium/Playwright)
- [x] Confirmed **no vertical page scroll** at 1366×768 and 1440×900, including the tallest tab (Claude Code)
- [x] Verified tab switching shows the right panel and the endpoint/code `Copy` buttons work
- [ ] `uv run pytest` — n/a (no Python change)
- [ ] `uv run ruff check .` — n/a (no Python change)

## Checklist

- [x] My change is scoped to one concern (landing-page layout)
- [ ] I added or updated tests — none; static asset, existing sync test stays green
- [x] Docs — the existing `mcp-server/README.md` "Landing page" section still describes the page accurately (same tools, same file path)
- [ ] CI is green — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY8BiKpzL63RcxUS5Nwu6V

---
_Generated by [Claude Code](https://claude.ai/code/session_01KY8BiKpzL63RcxUS5Nwu6V)_