### PR TITLE
Stop disabling LocalFileSystem so httpfs can read R2 over HTTPS

### DIFF
--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -163,15 +163,18 @@ def _apply_security_settings(con: duckdb.DuckDBPyConnection) -> None:
     con.execute("SET autoinstall_known_extensions=false")
     con.execute("SET autoload_known_extensions=false")
     con.execute("SET allow_unsigned_extensions=false")
-    # Disabling LocalFileSystem stops user SQL from reading local files, but it
-    # also blocks DuckDB's on-disk spill target: temp_directory defaults to a
-    # local ".tmp", so any query that exceeds memory_limit (e.g. a GROUP BY or
-    # ORDER BY over the larger tables) would otherwise fail with the confusing
-    # "File system LocalFileSystem has been disabled by configuration". An empty
-    # temp_directory disables spilling — queries run in memory or fail with a
-    # clear out-of-memory error instead. Must precede disabling the filesystem.
+    # NB: do NOT disable LocalFileSystem here. It is tempting as a guard against
+    # user SQL reading local files, but httpfs reads the system CA bundle off
+    # the local filesystem for every TLS handshake, so disabling it breaks the
+    # only thing this server does — reading the R2 parquet over HTTPS fails with
+    # "File system LocalFileSystem has been disabled by configuration" the
+    # moment a view binds. See the query_sql docstring for the access model.
+    #
+    # Disable on-disk spilling instead: temp_directory defaults to a local
+    # ".tmp" that is read-only on serverless hosts, so a spilling query (a big
+    # GROUP BY/ORDER BY) would fail there anyway. Empty disables spilling —
+    # queries run in memory or fail with a clear out-of-memory error.
     con.execute("SET temp_directory=''")
-    con.execute("SET disabled_filesystems='LocalFileSystem'")
     # DuckDB has no statement_timeout parameter; the per-query cap is enforced
     # by the _statement_timeout watchdog wrapping each tool's execution.
     con.execute("SET lock_configuration=true")

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -163,15 +163,18 @@ def _apply_security_settings(con: duckdb.DuckDBPyConnection) -> None:
     con.execute("SET autoinstall_known_extensions=false")
     con.execute("SET autoload_known_extensions=false")
     con.execute("SET allow_unsigned_extensions=false")
-    # Disabling LocalFileSystem stops user SQL from reading local files, but it
-    # also blocks DuckDB's on-disk spill target: temp_directory defaults to a
-    # local ".tmp", so any query that exceeds memory_limit (e.g. a GROUP BY or
-    # ORDER BY over the larger tables) would otherwise fail with the confusing
-    # "File system LocalFileSystem has been disabled by configuration". An empty
-    # temp_directory disables spilling — queries run in memory or fail with a
-    # clear out-of-memory error instead. Must precede disabling the filesystem.
+    # NB: do NOT disable LocalFileSystem here. It is tempting as a guard against
+    # user SQL reading local files, but httpfs reads the system CA bundle off
+    # the local filesystem for every TLS handshake, so disabling it breaks the
+    # only thing this server does — reading the R2 parquet over HTTPS fails with
+    # "File system LocalFileSystem has been disabled by configuration" the
+    # moment a view binds. See the query_sql docstring for the access model.
+    #
+    # Disable on-disk spilling instead: temp_directory defaults to a local
+    # ".tmp" that is read-only on serverless hosts, so a spilling query (a big
+    # GROUP BY/ORDER BY) would fail there anyway. Empty disables spilling —
+    # queries run in memory or fail with a clear out-of-memory error.
     con.execute("SET temp_directory=''")
-    con.execute("SET disabled_filesystems='LocalFileSystem'")
     # DuckDB has no statement_timeout parameter; the per-query cap is enforced
     # by the _statement_timeout watchdog wrapping each tool's execution.
     con.execute("SET lock_configuration=true")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -154,20 +154,25 @@ def test_sandbox_survives_temp_spill():
         pytest.fail(f"sandbox crashed a spilling query on local temp: {exc}")
 
 
-def test_sandbox_blocks_local_file_reads(tmp_path):
-    """The local-file sandbox must stay intact (security regression guard)."""
+def test_sandbox_does_not_disable_local_filesystem():
+    """LocalFileSystem must stay enabled, or httpfs HTTPS reads break.
+
+    Regression for ``Permission Error: File system LocalFileSystem has been
+    disabled by configuration`` raised when a view binds: httpfs reads the
+    system CA bundle off the local filesystem for the TLS handshake, so
+    ``disabled_filesystems='LocalFileSystem'`` makes every R2 read fail. Guard
+    against re-adding it.
+    """
     con = _sandboxed_connection()
-    secret = tmp_path / "secret.csv"
-    secret.write_text("a,b\n1,2\n")
-    with pytest.raises(duckdb.PermissionException):
-        con.execute(f"SELECT * FROM read_csv_auto('{secret}')").fetchall()
+    disabled = con.execute("SELECT current_setting('disabled_filesystems')").fetchone()
+    assert disabled[0] == ""
 
 
 def test_sandbox_locks_configuration():
-    """User SQL must not be able to re-enable a disabled filesystem."""
+    """User SQL must not be able to relax the sandbox once it is applied."""
     con = _sandboxed_connection()
     with pytest.raises(duckdb.Error):
-        con.execute("SET disabled_filesystems=''")
+        con.execute("SET allow_unsigned_extensions=true")
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

The deployed MCP server still failed on every real query. Calling `query_sql` or `describe_table` against production returned:

```
Permission Error: File system LocalFileSystem has been disabled by configuration
LINE 1: CREATE VIEW dockets AS SELECT * FROM read_parquet('https://r2.spicy-regs.dev/dockets.parquet')
```

I confirmed this by driving the live production MCP directly (via the connected Spicy Regs MCP server): `list_sources` works, but `describe_table`/`query_sql` both fail.

**Root cause:** the error fires while binding the *first* R2 view inside `_connect()`, before any user query runs. httpfs reads the system CA bundle off the **local** filesystem for the TLS handshake, so `SET disabled_filesystems='LocalFileSystem'` makes every HTTPS read fail — it breaks the one thing this server does. `list_sources` is unaffected only because it never opens a connection.

This setting was added speculatively in the original "harden DuckDB sandbox" commit, alongside the bogus `statement_timeout` SET. Because `statement_timeout` crashed `_connect` first, `disabled_filesystems` was never actually exercised until the earlier fixes (#77, #79) made the code path reachable. My #79 spill fix (`temp_directory=''`) addressed a real but **secondary** symptom — this is the primary breakage, and I'm correcting an incomplete earlier diagnosis.

**Fix:** remove `disabled_filesystems='LocalFileSystem'`. Reading remote parquet is the server's entire purpose, and the dataset and deployment are public, so the local-file-read guard isn't worth a non-functional server. This restores the behavior from before the hardening commit. The rest of the sandbox stays: no extension autoinstall/autoload, no unsigned extensions, locked configuration, and spilling disabled via `temp_directory=''`.

### Security note

Removing `disabled_filesystems` means arbitrary SQL through `query_sql` can again reference local-file functions (e.g. `read_text('/path')`). On the Vercel runtime the function sandbox is ephemeral and contains only the public deployment code — secrets are provided as environment variables, which are not file-readable — so practical exposure is low. If you want the guard back, I can add a narrower one as a follow-up (e.g. pre-binding the CA bundle before locking, or rejecting local-file table functions in `query_sql`); both need a deploy to validate against the live runtime.

## Why the tests didn't catch it

The hermetic suite never exercised httpfs + HTTPS + `disabled_filesystems` together (it used `range()` and an in-memory fsspec filesystem, neither of which does a TLS CA read). The `@pytest.mark.integration` test that *does* call `_connect` apparently passed on the GitHub runner, so this is environment-specific to the Vercel runtime's filesystem/CA layout.

- Replaced the now-invalid "blocks local file reads" test with `test_sandbox_does_not_disable_local_filesystem`, a direct guard asserting `disabled_filesystems` stays empty (re-adding the breaking line fails this test).
- Retargeted the `lock_configuration` test at a setting we actually pin (`allow_unsigned_extensions`).

## Test plan

- [x] `uv run pytest` — 13 passed, 1 deselected (integration)
- [x] `uv run ruff check .` — All checks passed
- [x] Reproduced the failure against the live production MCP and traced it to the exact `read_parquet('https://...')` view-binding line
- [ ] CI green
- [ ] Verify against the live deployment after merge (will confirm `query_sql`/`describe_table` succeed)

## Checklist

- [x] My change is scoped to one concern
- [x] I added or updated tests for new behavior
- [x] I updated docs (README / CONTRIBUTING / module READMEs) if relevant — n/a
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSfFcd8fMRR1kL8iKhsoaW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSfFcd8fMRR1kL8iKhsoaW)_