### PR TITLE
Fill comment text_content from Mirrulations derived-data extracted text

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Other useful flags (see `uv run run-pipeline --help` for the full list):
 | `--max-workers 8`       | Agencies processed in parallel (default 4)                |
 | `--full-refresh`        | Ignore the existing manifest and rebuild from scratch     |
 | `--no-skip-upload`      | Also publish to R2 (needs credentials in `.env`)          |
+| `--no-enrich-text`      | Skip filling comment `text_content` from Mirrulations' pre-extracted attachment text |
 
 Next steps:
 - Open the runnable example pipeline at `tests/test_example_pipeline.py`.

--- a/data_dictionary/descriptions.yaml
+++ b/data_dictionary/descriptions.yaml
@@ -70,8 +70,8 @@ tables:
       modify_date: "Timestamp the comment was last modified (ISO 8601 string)."
       receive_date: "Date the agency received the comment (ISO 8601 string)."
       attachments_json: "JSON array of any files attached to the comment: `[{title, formats:[{url, format, size}]}]`. Null when there are no attachments."
-      text_content: "Plain text extracted from the comment's PDF attachment(s) by the PDF text-extraction step. Null until that step has run; see `text_extraction_status`."
-      text_extraction_status: "Outcome of PDF text extraction: `ok`, `empty` (no extractable text, e.g. scanned/image-only PDFs — OCR is out of scope), `encrypted` (password-protected), or `error`. Null before extraction has been attempted."
+      text_content: "Plain text of the comment's attachment(s). Filled inline during the ETL from Mirrulations' pre-extracted text (the bucket's `derived-data` prefix); attachments not yet extracted upstream are backfilled by the on-demand PDF text-extraction step. Null when neither has produced text; see `text_extraction_status`."
+      text_extraction_status: "Outcome of attachment text extraction: `ok` (text was filled, from derived-data or PDF extraction), `empty` (no extractable text, e.g. scanned/image-only PDFs — OCR is out of scope), `encrypted` (password-protected), or `error`. Null when no text has been filled yet."
 
   comments_index:
     summary: >-

--- a/docs/tables/comments.md
+++ b/docs/tables/comments.md
@@ -24,5 +24,5 @@ One row per public comment submitted to a docket — the largest table (tens of 
 | `modify_date` | `VARCHAR` | Timestamp the comment was last modified (ISO 8601 string). |
 | `receive_date` | `VARCHAR` | Date the agency received the comment (ISO 8601 string). |
 | `attachments_json` | `VARCHAR` | JSON array of any files attached to the comment: `[{title, formats:[{url, format, size}]}]`. Null when there are no attachments. |
-| `text_content` | `VARCHAR` | Plain text extracted from the comment's PDF attachment(s) by the PDF text-extraction step. Null until that step has run; see `text_extraction_status`. |
-| `text_extraction_status` | `VARCHAR` | Outcome of PDF text extraction: `ok`, `empty` (no extractable text, e.g. scanned/image-only PDFs — OCR is out of scope), `encrypted` (password-protected), or `error`. Null before extraction has been attempted. |
+| `text_content` | `VARCHAR` | Plain text of the comment's attachment(s). Filled inline during the ETL from Mirrulations' pre-extracted text (the bucket's `derived-data` prefix); attachments not yet extracted upstream are backfilled by the on-demand PDF text-extraction step. Null when neither has produced text; see `text_extraction_status`. |
+| `text_extraction_status` | `VARCHAR` | Outcome of attachment text extraction: `ok` (text was filled, from derived-data or PDF extraction), `empty` (no extractable text, e.g. scanned/image-only PDFs — OCR is out of scope), `encrypted` (password-protected), or `error`. Null when no text has been filled yet. |

--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -36,8 +36,12 @@ from spicy_regs.pipelines.base import Pipeline
 from spicy_regs.pipelines.staging import stage_agencies
 from spicy_regs.schemas import RECORD_TYPES, RecordType
 from spicy_regs.sources import iceberg, mirrulations, r2
+from spicy_regs.sources.derived_text import DerivedCommentText
 from spicy_regs.transforms import (
+    Chain,
+    EnrichCommentText,
     ExtractRecords,
+    Transform,
     build_agency_rollups,
     build_feed_summary,
     merge_comments_partitioned,
@@ -68,6 +72,7 @@ class RegulationsPipeline(Pipeline):
         full_refresh: bool = False,
         max_workers: int = 4,
         use_iceberg: bool = False,
+        enrich_text: bool = True,
         verbose: bool = False,
     ) -> None:
         self.agency = agency
@@ -82,6 +87,7 @@ class RegulationsPipeline(Pipeline):
         self.full_refresh = full_refresh
         self.max_workers = max_workers
         self.use_iceberg = use_iceberg
+        self.enrich_text = enrich_text
         self.verbose = verbose
 
     def run(self) -> None:
@@ -112,7 +118,7 @@ class RegulationsPipeline(Pipeline):
             mirrulations.reader_factory(
                 processed_keys=manifest, since_year=self.since_year, verbose=self.verbose
             ),
-            transform_for=ExtractRecords,
+            transform_for=self._transform_for,
             max_workers=self.max_workers,
         )
         manifest.record(result.consumed_keys)
@@ -141,6 +147,21 @@ class RegulationsPipeline(Pipeline):
         logger.info("Done!")
 
     # -- regulations-specific wiring ---------------------------------------
+
+    def _transform_for(self, record_type: RecordType) -> Transform:
+        """Build the staging transform for one record type.
+
+        Every type is flattened by :class:`ExtractRecords`. Comments are
+        additionally enriched inline with Mirrulations' pre-extracted attachment
+        text (the primary source for ``text_content``); a fresh
+        :class:`DerivedCommentText` — and thus a fresh S3 resource — is built per
+        call so the chain is safe to run from staging's worker threads.
+        """
+        extract = ExtractRecords(record_type)
+        if record_type.name == "comments" and self.enrich_text:
+            fetcher = DerivedCommentText(mirrulations.s3_resource())
+            return Chain(extract, EnrichCommentText(fetcher))
+        return extract
 
     def _record_types(self) -> list[RecordType]:
         """The record types to process, honoring skip/only-comments."""
@@ -241,6 +262,12 @@ def main(
     use_iceberg: Annotated[
         bool, Parameter(help="Route the dockets table through R2 Data Catalog (Iceberg)")
     ] = False,
+    enrich_text: Annotated[
+        bool,
+        Parameter(
+            help="Fill comment text_content inline from Mirrulations derived-data extracted text"
+        ),
+    ] = True,
     verbose: Annotated[bool, Parameter(name=["--verbose", "-v"], help="Verbose logging")] = False,
 ) -> None:
     """Run the regulations.gov ETL pipeline."""
@@ -257,6 +284,7 @@ def main(
         full_refresh=full_refresh,
         max_workers=max_workers,
         use_iceberg=use_iceberg,
+        enrich_text=enrich_text,
         verbose=verbose,
     ).run()
 

--- a/src/spicy_regs/schemas/regulations.py
+++ b/src/spicy_regs/schemas/regulations.py
@@ -44,8 +44,10 @@ def _extract_comment(d: dict) -> dict:
         "modify_date": attrs.get("modifyDate"),
         "receive_date": attrs.get("receiveDate"),
         "attachments_json": json_dumps(attachments) if attachments else None,
-        # Populated out-of-band by the PDF text-extraction step
-        # (spicy_regs.pipeline.enrich_pdf) from any PDF attachments.
+        # Left None here; filled downstream. The run-pipeline ETL fills it inline
+        # from Mirrulations' pre-extracted text (transforms.EnrichCommentText),
+        # with the PDF text-extraction step (spicy_regs.pipeline.enrich_pdf) as
+        # the backfill for attachments not yet extracted upstream.
         "text_content": None,
         "text_extraction_status": None,
     }

--- a/src/spicy_regs/sources/__init__.py
+++ b/src/spicy_regs/sources/__init__.py
@@ -1,7 +1,17 @@
 from spicy_regs.sources import iceberg, r2
 from spicy_regs.sources.base import Reader, Writer
+from spicy_regs.sources.derived_text import DerivedCommentText
 from spicy_regs.sources.mirrulations import MirrulationsReader
 from spicy_regs.sources.parquet import StagingWriter
 from spicy_regs.sources.pdf import fetch_pdf_bytes
 
-__all__ = ["Reader", "Writer", "MirrulationsReader", "StagingWriter", "fetch_pdf_bytes", "r2", "iceberg"]
+__all__ = [
+    "Reader",
+    "Writer",
+    "MirrulationsReader",
+    "DerivedCommentText",
+    "StagingWriter",
+    "fetch_pdf_bytes",
+    "r2",
+    "iceberg",
+]

--- a/src/spicy_regs/sources/derived_text.py
+++ b/src/spicy_regs/sources/derived_text.py
@@ -1,0 +1,112 @@
+"""Reader-side helper for the Mirrulations *derived-data* extracted text.
+
+regulations.gov comments frequently carry their substance in an attachment
+("See attached file(s)") rather than the inline ``comment`` field. Mirrulations
+already runs text extraction over every attachment and publishes the result to
+the same public S3 bucket the ETL reads, under the ``derived-data`` prefix::
+
+    derived-data/<agency>/<docket>/mirrulations/extracted_txt/
+        comments_extracted_text/<tool>/<comment_id>_attachment_<n>_extracted.txt
+
+This module reads that pre-extracted text so the pipeline can fill a comment's
+``text_content`` straight from S3 — no PDF download, no local parsing. The
+extraction ``<tool>`` (``pypdf``, ``pdfminer``, ...) varies by docket, so it is
+discovered by listing rather than hardcoded; a comment with several attachments
+has one ``_attachment_<n>_`` file each, concatenated in attachment order.
+
+Network access lives here in ``sources`` (a Reader concern); the
+:class:`~spicy_regs.transforms.enrich_derived_text.EnrichCommentText` transform
+that uses it stays a thin stream-mapper.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from loguru import logger
+
+BUCKET = "mirrulations"
+DERIVED_PREFIX = "derived-data"
+
+# Multiple attachments on one comment are joined with a blank line — the same
+# separator the PDF-text path uses (``transforms.pdf_text.PAGE_SEPARATOR``) so
+# stored ``text_content`` reads consistently regardless of which source filled
+# it. Defined locally to keep ``sources`` independent of ``transforms``.
+PART_SEPARATOR = "\n\n"
+
+# <comment_id>_attachment_<n>_extracted.txt — comment ids never contain the
+# literal "_attachment_", so a greedy id capture up to the last such marker is
+# unambiguous.
+_EXTRACTED_RE = re.compile(r"(?P<comment_id>.+)_attachment_\d+_extracted\.txt$")
+
+
+def comments_extracted_prefix(agency: str, docket_id: str) -> str:
+    """S3 prefix holding one docket's comment-attachment extractions (all tools)."""
+    return (
+        f"{DERIVED_PREFIX}/{agency}/{docket_id}/mirrulations/"
+        f"extracted_txt/comments_extracted_text/"
+    )
+
+
+class DerivedCommentText:
+    """Fetches Mirrulations pre-extracted comment-attachment text from S3.
+
+    Each docket's extraction prefix is listed once (lazily, on first access) and
+    cached as a ``comment_id -> [object keys]`` map, so enriching a whole
+    docket's comments costs one ``list_objects`` plus one ``GET`` per attachment.
+    Build one per worker thread — the listing cache is plain dict state and is
+    not shared-safe across threads.
+    """
+
+    def __init__(self, s3_resource: Any, bucket: str = BUCKET) -> None:
+        self._resource = s3_resource
+        self._bucket_name = bucket
+        self._bucket = s3_resource.Bucket(bucket)
+        self._docket_index: dict[str, dict[str, list[str]]] = {}
+
+    def _index_for(self, agency: str, docket_id: str) -> dict[str, list[str]]:
+        """Lazily build + cache the ``comment_id -> [keys]`` map for one docket."""
+        cached = self._docket_index.get(docket_id)
+        if cached is not None:
+            return cached
+
+        index: dict[str, list[str]] = {}
+        prefix = comments_extracted_prefix(agency, docket_id)
+        try:
+            for obj in self._bucket.objects.filter(Prefix=prefix):
+                match = _EXTRACTED_RE.search(obj.key.rsplit("/", 1)[-1])
+                if match:
+                    index.setdefault(match.group("comment_id"), []).append(obj.key)
+        except Exception as exc:  # noqa: BLE001 — listing failure must not abort staging
+            logger.warning("derived-data listing failed for {}: {}", prefix, exc)
+
+        for keys in index.values():
+            keys.sort()  # attachment_1 before attachment_2, ...
+        self._docket_index[docket_id] = index
+        return index
+
+    def text_for(
+        self, agency: str | None, docket_id: str | None, comment_id: str | None
+    ) -> str | None:
+        """Concatenated extracted text for one comment, or ``None`` if none exists."""
+        if not (agency and docket_id and comment_id):
+            return None
+
+        keys = self._index_for(agency, docket_id).get(comment_id)
+        if not keys:
+            return None
+
+        parts: list[str] = []
+        for key in keys:
+            try:
+                body = self._resource.Object(self._bucket_name, key).get()["Body"].read()
+            except Exception as exc:  # noqa: BLE001 — one bad object shouldn't sink the rest
+                logger.warning("derived-data read failed for {}: {}", key, exc)
+                continue
+            text = body.decode("utf-8", "replace") if isinstance(body, bytes) else str(body)
+            text = text.strip()
+            if text:
+                parts.append(text)
+
+        return PART_SEPARATOR.join(parts) if parts else None

--- a/src/spicy_regs/transforms/__init__.py
+++ b/src/spicy_regs/transforms/__init__.py
@@ -1,6 +1,8 @@
 from spicy_regs.transforms.base import Transform
 from spicy_regs.transforms.build_agency_rollups import build_agency_rollups
 from spicy_regs.transforms.build_feed_summary import build_feed_summary
+from spicy_regs.transforms.chain import Chain
+from spicy_regs.transforms.enrich_derived_text import EnrichCommentText
 from spicy_regs.transforms.extract import ExtractRecords
 from spicy_regs.transforms.merge_comments_partitioned import merge_comments_partitioned
 from spicy_regs.transforms.merge_staging_files import merge_staging_files
@@ -16,7 +18,9 @@ from spicy_regs.transforms.write_staging import write_staging
 
 __all__ = [
     "Transform",
+    "Chain",
     "ExtractRecords",
+    "EnrichCommentText",
     "write_staging",
     "merge_staging_files",
     "merge_comments_partitioned",

--- a/src/spicy_regs/transforms/chain.py
+++ b/src/spicy_regs/transforms/chain.py
@@ -1,0 +1,26 @@
+"""Compose several transforms into one, applied left-to-right.
+
+``Chain(a, b)`` is the record-stream equivalent of ``b(a(records))`` — each
+transform's lazy output stream feeds the next, so the chain buffers nothing.
+Used by pipelines that need more than one shaping step per record type (e.g.
+flatten *then* enrich) while ``stage_agencies`` still takes a single
+``Transform`` per record type.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+
+from spicy_regs.transforms.base import Transform
+
+
+class Chain(Transform):
+    """Applies ``transforms`` in order over a single record stream."""
+
+    def __init__(self, *transforms: Transform) -> None:
+        self.transforms = transforms
+
+    def apply(self, records: Iterable[dict]) -> Iterator[dict]:
+        for transform in self.transforms:
+            records = transform.apply(records)
+        yield from records

--- a/src/spicy_regs/transforms/enrich_derived_text.py
+++ b/src/spicy_regs/transforms/enrich_derived_text.py
@@ -1,0 +1,49 @@
+"""Transform: fill comment ``text_content`` from Mirrulations derived-data.
+
+Sits after :class:`~spicy_regs.transforms.extract.ExtractRecords` in the comment
+stream. For each flattened comment that has an attachment but no text yet, it
+pulls the attachment text Mirrulations already extracted (via
+:class:`~spicy_regs.sources.derived_text.DerivedCommentText`) and sets
+``text_content`` / ``text_extraction_status``.
+
+This is the *primary* source of comment attachment text: it is free (the same
+anonymous S3 bucket the ETL already reads), needs no PDF download or parsing,
+and runs inline during staging — so ``comments.parquet`` ships with attachment
+text already populated. Comments whose attachment text is absent from
+derived-data are left untouched (``text_extraction_status`` stays ``None``) so
+the on-demand PDF-download fallback (:mod:`spicy_regs.pipeline.enrich_pdf`) can
+still backfill them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+
+from spicy_regs.sources.derived_text import DerivedCommentText
+from spicy_regs.transforms.base import Transform
+from spicy_regs.transforms.pdf_text import PdfTextStatus
+
+
+class EnrichCommentText(Transform):
+    """Fills ``text_content`` from Mirrulations pre-extracted attachment text."""
+
+    def __init__(self, fetcher: DerivedCommentText) -> None:
+        self.fetcher = fetcher
+
+    def apply(self, records: Iterable[dict]) -> Iterator[dict]:
+        for record in records:
+            # Only attachment-bearing comments have extractable text; comments
+            # that already carry text (e.g. a re-run) are left as-is.
+            if record.get("attachments_json") and record.get("text_content") is None:
+                text = self.fetcher.text_for(
+                    record.get("agency_code"),
+                    record.get("docket_id"),
+                    record.get("comment_id"),
+                )
+                if text:
+                    record = {
+                        **record,
+                        "text_content": text,
+                        "text_extraction_status": PdfTextStatus.OK.value,
+                    }
+            yield record

--- a/tests/test_derived_text.py
+++ b/tests/test_derived_text.py
@@ -1,0 +1,234 @@
+"""Tests for the Mirrulations derived-data comment-text enrichment.
+
+Covers the S3 fetcher (:class:`DerivedCommentText`), the streaming transform
+(:class:`EnrichCommentText`), and the :class:`Chain` combinator, all against a
+fake in-memory S3 resource (same shape as ``test_mirrulations_reader``).
+"""
+
+from __future__ import annotations
+
+import json
+
+from spicy_regs.sources.derived_text import DerivedCommentText, comments_extracted_prefix
+from spicy_regs.transforms import Chain, EnrichCommentText, ExtractRecords
+from spicy_regs.transforms.base import Transform
+
+BUCKET = "mirrulations"
+
+
+# --- fake S3 (mirrors the boto3 resource surface the fetcher uses) -----------
+
+
+class _FakeBody:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+
+class _FakeObj:
+    def __init__(self, key: str, content: bytes) -> None:
+        self.key = key
+        self._content = content
+
+    def get(self) -> dict:
+        return {"Body": _FakeBody(self._content)}
+
+
+class _FakeObjects:
+    def __init__(self, store: dict[str, bytes]) -> None:
+        self._store = store
+
+    def filter(self, Prefix: str):  # noqa: N803 — mirrors boto3 kwarg
+        for key, content in self._store.items():
+            if key.startswith(Prefix):
+                yield _FakeObj(key, content)
+
+
+class _FakeBucket:
+    def __init__(self, store: dict[str, bytes]) -> None:
+        self.objects = _FakeObjects(store)
+
+
+class _FakeS3Resource:
+    def __init__(self, store: dict[str, bytes]) -> None:
+        self._store = store
+
+    def Bucket(self, name: str) -> _FakeBucket:  # noqa: N802 — mirrors boto3 API
+        return _FakeBucket(self._store)
+
+    def Object(self, name: str, key: str) -> _FakeObj:  # noqa: N802 — mirrors boto3 API
+        return _FakeObj(key, self._store[key])
+
+
+def _extracted_key(agency: str, docket: str, tool: str, filename: str) -> str:
+    return comments_extracted_prefix(agency, docket) + f"{tool}/{filename}"
+
+
+def _store() -> dict[str, bytes]:
+    # ACF docket: comment 0004 has one attachment; comment 0015 has two
+    # (pypdf tool). EPA docket: comment 0009 uses a different tool (pdfminer).
+    return {
+        _extracted_key("ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0004_attachment_1_extracted.txt"): b"Wisconsin DCF comment body",
+        _extracted_key("ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0015_attachment_1_extracted.txt"): b"first attachment",
+        _extracted_key("ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0015_attachment_2_extracted.txt"): b"second attachment",
+        # An empty extraction (e.g. a scanned/image PDF) — should not count as text.
+        _extracted_key("ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0020_attachment_1_extracted.txt"): b"   \n  ",
+        _extracted_key("EPA", "EPA-HQ-OA-2024-0001", "pdfminer", "EPA-HQ-OA-2024-0001-0009_attachment_1_extracted.txt"): b"EPA comment text",
+    }
+
+
+# --- DerivedCommentText ------------------------------------------------------
+
+
+def test_text_for_single_attachment() -> None:
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    assert fetcher.text_for("ACF", "ACF-2025-0038", "ACF-2025-0038-0004") == "Wisconsin DCF comment body"
+
+
+def test_text_for_concatenates_multiple_attachments_in_order() -> None:
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    text = fetcher.text_for("ACF", "ACF-2025-0038", "ACF-2025-0038-0015")
+    assert text == "first attachment\n\nsecond attachment"
+
+
+def test_text_for_tool_subfolder_is_discovered_not_hardcoded() -> None:
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    # EPA's docket uses pdfminer rather than pypdf — still found.
+    assert fetcher.text_for("EPA", "EPA-HQ-OA-2024-0001", "EPA-HQ-OA-2024-0001-0009") == "EPA comment text"
+
+
+def test_text_for_empty_extraction_returns_none() -> None:
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    assert fetcher.text_for("ACF", "ACF-2025-0038", "ACF-2025-0038-0020") is None
+
+
+def test_text_for_missing_comment_returns_none() -> None:
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    assert fetcher.text_for("ACF", "ACF-2025-0038", "ACF-2025-0038-9999") is None
+
+
+def test_text_for_handles_missing_identifiers() -> None:
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    assert fetcher.text_for(None, "ACF-2025-0038", "ACF-2025-0038-0004") is None
+    assert fetcher.text_for("ACF", None, "ACF-2025-0038-0004") is None
+    assert fetcher.text_for("ACF", "ACF-2025-0038", None) is None
+
+
+def test_docket_listing_is_cached() -> None:
+    calls = {"n": 0}
+
+    class _CountingObjects(_FakeObjects):
+        def filter(self, Prefix: str):  # noqa: N803
+            calls["n"] += 1
+            return super().filter(Prefix)
+
+    class _CountingBucket(_FakeBucket):
+        def __init__(self, store: dict[str, bytes]) -> None:
+            self.objects = _CountingObjects(store)
+
+    class _CountingResource(_FakeS3Resource):
+        def Bucket(self, name: str) -> _CountingBucket:  # noqa: N802
+            return _CountingBucket(self._store)
+
+    fetcher = DerivedCommentText(_CountingResource(_store()), BUCKET)
+    fetcher.text_for("ACF", "ACF-2025-0038", "ACF-2025-0038-0004")
+    fetcher.text_for("ACF", "ACF-2025-0038", "ACF-2025-0038-0015")
+    assert calls["n"] == 1, "same docket should be listed only once"
+
+
+# --- EnrichCommentText transform --------------------------------------------
+
+
+def _comment_record(comment_id: str, *, attachments: bool, text: str | None = None) -> dict:
+    return {
+        "comment_id": comment_id,
+        "docket_id": "ACF-2025-0038",
+        "agency_code": "ACF",
+        "comment": "See attached file(s)",
+        "attachments_json": json.dumps([{"title": "x"}]) if attachments else None,
+        "text_content": text,
+        "text_extraction_status": "ok" if text else None,
+    }
+
+
+def test_enrich_fills_text_content_and_status() -> None:
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    records = [_comment_record("ACF-2025-0038-0004", attachments=True)]
+    (out,) = list(EnrichCommentText(fetcher).apply(records))
+    assert out["text_content"] == "Wisconsin DCF comment body"
+    assert out["text_extraction_status"] == "ok"
+
+
+def test_enrich_skips_comments_without_attachments() -> None:
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    # No attachments: even if a stray extraction existed, we don't look it up.
+    records = [_comment_record("ACF-2025-0038-0004", attachments=False)]
+    (out,) = list(EnrichCommentText(fetcher).apply(records))
+    assert out["text_content"] is None
+    assert out["text_extraction_status"] is None
+
+
+def test_enrich_leaves_status_none_when_no_derived_text() -> None:
+    # An attachment-bearing comment with no derived-data extraction stays
+    # untouched so the PDF-download fallback can backfill it later.
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    records = [_comment_record("ACF-2025-0038-9999", attachments=True)]
+    (out,) = list(EnrichCommentText(fetcher).apply(records))
+    assert out["text_content"] is None
+    assert out["text_extraction_status"] is None
+
+
+def test_enrich_does_not_overwrite_existing_text() -> None:
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    records = [_comment_record("ACF-2025-0038-0004", attachments=True, text="already here")]
+    (out,) = list(EnrichCommentText(fetcher).apply(records))
+    assert out["text_content"] == "already here"
+
+
+# --- Chain -------------------------------------------------------------------
+
+
+class _AddOne(Transform):
+    def apply(self, records):
+        for r in records:
+            yield {**r, "n": r.get("n", 0) + 1}
+
+
+def test_chain_applies_transforms_in_order() -> None:
+    out = list(Chain(_AddOne(), _AddOne()).apply([{"n": 0}, {"n": 5}]))
+    assert [r["n"] for r in out] == [2, 7]
+
+
+def test_chain_extract_then_enrich_end_to_end() -> None:
+    """The exact composition the pipeline wires for comments."""
+    from spicy_regs.schemas import COMMENT
+
+    payload = {
+        "data": {
+            "id": "ACF-2025-0038-0004",
+            "attributes": {
+                "docketId": "ACF-2025-0038",
+                "agencyId": "ACF",
+                "comment": "See attached file(s)",
+            },
+            "relationships": {"attachments": {"data": [{"id": "a", "type": "attachments"}]}},
+        },
+        "included": [
+            {
+                "id": "a",
+                "type": "attachments",
+                "attributes": {
+                    "title": "t",
+                    "fileFormats": [{"fileUrl": "https://x/a.pdf", "format": "pdf", "size": 10}],
+                },
+            }
+        ],
+    }
+    fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
+    chain = Chain(ExtractRecords(COMMENT), EnrichCommentText(fetcher))
+    (out,) = list(chain.apply([payload]))
+    assert out["comment_id"] == "ACF-2025-0038-0004"
+    assert out["text_content"] == "Wisconsin DCF comment body"
+    assert out["text_extraction_status"] == "ok"

--- a/tests/test_integration_derived_text.py
+++ b/tests/test_integration_derived_text.py
@@ -1,0 +1,64 @@
+"""Live integration test for Mirrulations derived-data comment text.
+
+Reads a real comment JSON from the public Mirrulations S3 mirror, flattens it,
+then runs the production ``ExtractRecords -> EnrichCommentText`` chain and
+asserts the comment's attachment text was pulled straight from the bucket's
+``derived-data`` prefix (no PDF download).
+
+ACF-2025-0038-0004 is a Public Submission whose inline ``comment`` is just
+"See attached file(s)"; its substance lives in an attachment that Mirrulations
+has already extracted. Posted comments are immutable, so the identifiers are
+stable.
+
+Marked ``integration`` so it is excluded from the default hermetic suite (see
+``addopts`` in pyproject.toml); the "Integration (live data)" workflow runs it
+via ``pytest -m integration``. Needs outbound access to the anonymous S3 bucket.
+"""
+
+import boto3
+import pytest
+from botocore import UNSIGNED
+from botocore.config import Config as BotoConfig
+from loguru import logger
+
+from spicy_regs.pipeline.extract import download_and_parse
+from spicy_regs.schemas import COMMENT
+from spicy_regs.sources.derived_text import DerivedCommentText
+from spicy_regs.transforms import Chain, EnrichCommentText, ExtractRecords
+
+BUCKET = "mirrulations"
+
+COMMENT_KEY = (
+    "raw-data/ACF/ACF-2025-0038/text-ACF-2025-0038/"
+    "comments/ACF-2025-0038-0004.json"
+)
+EXPECTED_COMMENT_ID = "ACF-2025-0038-0004"
+EXPECTED_DOCKET_ID = "ACF-2025-0038"
+
+
+@pytest.mark.integration
+def test_real_comment_text_filled_from_derived_data() -> None:
+    s3 = boto3.resource(
+        "s3", region_name="us-east-1", config=BotoConfig(signature_version=UNSIGNED)
+    )
+
+    logger.info("Fetching live comment s3://{}/{}", BUCKET, COMMENT_KEY)
+    payload = download_and_parse(s3, BUCKET, COMMENT_KEY, lambda d: d)
+    assert payload is not None, f"could not fetch {COMMENT_KEY} from s3://{BUCKET}"
+
+    fetcher = DerivedCommentText(s3)
+    chain = Chain(ExtractRecords(COMMENT), EnrichCommentText(fetcher))
+    (record,) = list(chain.apply([payload]))
+
+    assert record["comment_id"] == EXPECTED_COMMENT_ID
+    assert record["docket_id"] == EXPECTED_DOCKET_ID
+    # Inline body is just the placeholder; the real content comes from the
+    # extracted attachment text.
+    assert record["text_extraction_status"] == "ok"
+    assert record["text_content"]
+    assert len(record["text_content"]) > 200
+    logger.success(
+        "Filled text_content from derived-data for {} ({} chars)",
+        record["comment_id"],
+        len(record["text_content"]),
+    )


### PR DESCRIPTION
## Summary

regulations.gov comments frequently carry their substance in an **attachment** — the inline `comment` field is just `"See attached file(s)"`. Mirrulations already runs text extraction over every attachment and publishes the plain text to the **same public S3 bucket** the ETL already reads, under a `derived-data` prefix that the pipeline was ignoring entirely:

```
derived-data/<agency>/<docket>/mirrulations/extracted_txt/
    comments_extracted_text/<tool>/<comment_id>_attachment_<n>_extracted.txt
```

This is live and broad — **174 agencies** have `derived-data`. Until now the only thing that filled the comments' `text_content` column was the on-demand `enrich_pdf` step, which re-downloads each PDF from `downloads.regulations.gov` and re-parses it locally (slow, network-heavy, rate-limit-prone, frequently `empty`/`encrypted`/`error`).

This PR makes Mirrulations' pre-extracted text the **primary source** for comment attachment text, pulled **inline during the comments ETL** — so `comments.parquet` ships with `text_content` already populated, with no PDF download or parsing. `enrich_pdf` stays as the backfill for the few attachments not yet extracted upstream (those rows keep `text_extraction_status = NULL` so it still picks them up).

### What changed
- **`sources/derived_text.py`** — `DerivedCommentText` fetcher. Lists each docket's extraction prefix once (cached `comment_id → [keys]`), concatenates multiple attachments in order. The extraction `<tool>` subfolder (`pypdf`, `pdfminer`, …) varies by docket, so it's **discovered by listing, not hardcoded**.
- **`transforms/enrich_derived_text.py`** — `EnrichCommentText` stream transform; fills `text_content` + `text_extraction_status="ok"` for attachment-bearing comments, leaves others untouched.
- **`transforms/chain.py`** — `Chain` combinator to compose `ExtractRecords` → enrichment as a single staging transform.
- **`pipelines/regulations.py`** — wires the chain for comments behind `--enrich-text` (default on; `--no-enrich-text` to skip). A fresh fetcher / S3 resource is built per worker so staging stays threadsafe.
- Data dictionary + README + schema comments updated to reflect the new source.

## Test plan

- [x] `uv run pytest` — **201 passed, 3 deselected**
- [x] `uv run ruff check .` — clean
- [x] `uv run ty check` on changed files — clean
- [x] Live integration test against the real bucket (`pytest -m integration tests/test_integration_derived_text.py`) — fills `text_content` for `ACF-2025-0038-0004` straight from `derived-data`, no PDF download
- [x] Added unit tests (fake in-memory S3) covering single/multi attachment, tool-subfolder discovery, empty extraction, caching, and the no-overwrite / fallback semantics

## Checklist

- [x] My change is scoped to one concern
- [x] I added or updated tests for new behavior
- [x] I updated docs (README, data dictionary, schema comments)
- [x] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjeuJmpUo2PfpCwCPhVgtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjeuJmpUo2PfpCwCPhVgtp)_