### PR TITLE
Add derived-data backfill CLI for comment text_content

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ Other useful flags (see `uv run run-pipeline --help` for the full list):
 | `--no-skip-upload`      | Also publish to R2 (needs credentials in `.env`)          |
 | `--no-enrich-text`      | Skip filling comment `text_content` from Mirrulations' pre-extracted attachment text |
 
+### Backfill comment text for already-published data
+
+The ETL fills `text_content` inline only for comments it processes fresh — the
+incremental manifest skips comments ingested before that, so they stay `NULL`.
+To backfill the existing dataset from Mirrulations' pre-extracted text (reading
+straight from the bucket's `derived-data` prefix — no PDF download, no JSON
+re-ingest), download the comments and run:
+
+```bash
+uv run spicy-regs download --types comments     # grab the published parquet
+uv run backfill-comment-text                     # fill text_content in place
+uv run backfill-comment-text --limit 5000        # cap work for a trial run
+uv run backfill-comment-text --upload            # also republish to R2 (needs credentials)
+```
+
+It is incremental and re-runnable (rows that already have a
+`text_extraction_status` are skipped unless you pass `--overwrite`). Document
+text isn't published to `derived-data`; backfill those via
+`uv run enrich-pdf-text --target documents`.
+
 Next steps:
 - Open the runnable example pipeline at `tests/test_example_pipeline.py`.
 - Read [CONTRIBUTING.md](CONTRIBUTING.md) for architecture and how to add your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ docs = [
 etl = "spicy_regs.pipeline.pipeline:app"
 run-pipeline = "spicy_regs.pipelines.regulations:app"
 enrich-pdf-text = "spicy_regs.pipeline.enrich_pdf:main"
+backfill-comment-text = "spicy_regs.pipeline.backfill_derived_text:main"
 embed = "spicy_regs.vectordb.embed:main"
 spicy-regs = "spicy_regs.cli:main"
 spicy-regs-mcp = "spicy_regs.mcp_server:main"

--- a/src/spicy_regs/pipeline/backfill_derived_text.py
+++ b/src/spicy_regs/pipeline/backfill_derived_text.py
@@ -1,0 +1,277 @@
+"""Backfill comment ``text_content`` from Mirrulations derived-data extracted text.
+
+The ETL fills ``text_content`` inline for *new* comments
+(:class:`~spicy_regs.transforms.enrich_derived_text.EnrichCommentText`), but
+every comment published before that wiring still has ``text_content`` NULL. This
+is the one-time / re-runnable backfill: it reads the already-published comment
+Parquet, fills ``text_content`` from the bucket's ``derived-data`` prefix (no PDF
+download, no JSON re-ingest), and writes it back.
+
+It is the derived-data sibling of :mod:`spicy_regs.pipeline.enrich_pdf`: same
+in-place, incremental, partition-aware shape, but the text source is
+Mirrulations' pre-extracted ``.txt`` rather than a downloaded PDF. Rows are
+skipped unless they have an attachment and no ``text_extraction_status`` yet, so
+repeated runs only do new work.
+
+A wrinkle the PDF path doesn't have: the Hive comment partitions drop the
+``agency_code`` column (it is encoded in the ``agency_code=<X>`` directory name),
+but the derived-data S3 path is keyed by agency. So the partition walker reads
+the agency from the directory and passes it in explicitly; the monolithic
+``comments.parquet`` still carries the column and is read per row.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+from loguru import logger
+
+from spicy_regs.sources import mirrulations
+from spicy_regs.sources.derived_text import DerivedCommentText
+from spicy_regs.transforms.pdf_text import PdfTextStatus
+
+ResourceFactory = Callable[[], Any]
+
+_AGENCY_DIR_RE = re.compile(r"agency_code=([^/]+)")
+
+
+def enrich_comments_with_derived_text(
+    df: pl.DataFrame,
+    *,
+    agency: str | None = None,
+    resource_factory: ResourceFactory = mirrulations.s3_resource,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> tuple[pl.DataFrame, dict[str, int]]:
+    """Fill ``text_content`` / ``text_extraction_status`` from derived-data S3.
+
+    Only attachment-bearing comments are candidates; unless ``overwrite`` is set,
+    rows that already have a ``text_extraction_status`` are skipped so repeated
+    runs are incremental. ``agency`` overrides the per-row ``agency_code`` (the
+    Hive partitions don't carry that column); when ``None`` it is read from the
+    frame. Work is grouped by docket and fanned out across ``max_workers`` so
+    each docket's extraction prefix is listed once.
+    """
+    for col in ("text_content", "text_extraction_status"):
+        if col not in df.columns:
+            df = df.with_columns(pl.lit(None, dtype=pl.Utf8).alias(col))
+
+    select_cols = ["comment_id", "docket_id", "attachments_json", "text_extraction_status"]
+    if agency is None:
+        select_cols.append("agency_code")
+    candidates = df.select(select_cols).unique(subset="comment_id", keep="first")
+
+    # Group candidate comment ids by (agency, docket) so each docket's
+    # derived-data prefix is listed exactly once, honoring the row budget.
+    work_by_docket: dict[tuple[str, str], list[str]] = {}
+    selected = 0
+    for row in candidates.iter_rows(named=True):
+        if limit is not None and selected >= limit:
+            break
+        comment_id = row["comment_id"]
+        if comment_id is None or not row["attachments_json"]:
+            continue
+        if not overwrite and row["text_extraction_status"] is not None:
+            continue
+        row_agency = agency or row.get("agency_code")
+        docket_id = row["docket_id"]
+        if not (row_agency and docket_id):
+            continue
+        work_by_docket.setdefault((row_agency, docket_id), []).append(comment_id)
+        selected += 1
+
+    stats = {"selected": selected, "ok": 0, "missing": 0}
+    if not work_by_docket:
+        logger.info("No comments to backfill from derived-data")
+        return df, stats
+
+    logger.info(
+        "Backfilling {} comments across {} dockets from derived-data ({} workers)...",
+        selected, len(work_by_docket), max_workers,
+    )
+
+    def _fetch_docket(item: tuple[tuple[str, str], list[str]]) -> dict[str, str]:
+        (docket_agency, docket_id), comment_ids = item
+        # One fetcher (and S3 resource) per task keeps the per-docket listing
+        # cache thread-local; DerivedCommentText is not shared-safe.
+        fetcher = DerivedCommentText(resource_factory())
+        found: dict[str, str] = {}
+        for comment_id in comment_ids:
+            text = fetcher.text_for(docket_agency, docket_id, comment_id)
+            if text:
+                found[comment_id] = text
+        return found
+
+    ids: list[str] = []
+    texts: list[str] = []
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for found in executor.map(_fetch_docket, work_by_docket.items()):
+            for comment_id, text in found.items():
+                ids.append(comment_id)
+                texts.append(text)
+
+    stats["ok"] = len(ids)
+    stats["missing"] = selected - len(ids)
+
+    if not ids:
+        logger.info("Backfill: 0 ok, {} missing (no derived-data text found)", stats["missing"])
+        return df, stats
+
+    updates = pl.DataFrame(
+        {"comment_id": ids, "_new_text": texts, "_new_status": [PdfTextStatus.OK.value] * len(ids)},
+        schema={"comment_id": pl.Utf8, "_new_text": pl.Utf8, "_new_status": pl.Utf8},
+    )
+    enriched = (
+        df.join(updates, on="comment_id", how="left")
+        .with_columns(
+            text_content=pl.coalesce(["_new_text", "text_content"]),
+            text_extraction_status=pl.coalesce(["_new_status", "text_extraction_status"]),
+        )
+        .drop("_new_text", "_new_status")
+    )
+
+    logger.info("Backfill: {} ok, {} missing", stats["ok"], stats["missing"])
+    return enriched, stats
+
+
+def _backfill_file(
+    path: Path,
+    *,
+    agency: str | None,
+    resource_factory: ResourceFactory,
+    limit: int | None,
+    max_workers: int,
+    overwrite: bool,
+) -> dict[str, int]:
+    df = pl.read_parquet(path)
+    enriched, stats = enrich_comments_with_derived_text(
+        df,
+        agency=agency,
+        resource_factory=resource_factory,
+        limit=limit,
+        max_workers=max_workers,
+        overwrite=overwrite,
+    )
+    if stats["ok"]:
+        enriched.write_parquet(path, compression="zstd")
+        logger.info("Wrote {} ({} rows, {} filled)", path, len(enriched), stats["ok"])
+    return stats
+
+
+def backfill_comments_parquet(
+    comments_path: Path,
+    *,
+    resource_factory: ResourceFactory = mirrulations.s3_resource,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> dict[str, int]:
+    """Backfill the monolithic ``comments.parquet`` (carries ``agency_code``)."""
+    if not comments_path.exists():
+        raise FileNotFoundError(f"{comments_path} not found; download or build the dataset first")
+    return _backfill_file(
+        comments_path,
+        agency=None,
+        resource_factory=resource_factory,
+        limit=limit,
+        max_workers=max_workers,
+        overwrite=overwrite,
+    )
+
+
+def backfill_comment_partitions(
+    partition_dir: Path,
+    *,
+    resource_factory: ResourceFactory = mirrulations.s3_resource,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> tuple[dict[str, int], list[Path]]:
+    """Backfill every ``agency_code=*/*.parquet`` partition; agency comes from the path.
+
+    Returns the aggregate stats and the list of partition files that were
+    actually modified (so a caller can upload only those to R2). ``limit`` (if
+    given) is the total comment budget across all partitions.
+    """
+    parts = sorted(partition_dir.glob("agency_code=*/*.parquet"))
+    if not parts:
+        raise FileNotFoundError(f"No comment partitions found under {partition_dir}")
+
+    totals = {"selected": 0, "ok": 0, "missing": 0}
+    changed: list[Path] = []
+    remaining = limit
+    for part in parts:
+        if remaining is not None and remaining <= 0:
+            logger.info("Reached --limit budget; {} partitions left unprocessed", len(parts) - parts.index(part))
+            break
+        match = _AGENCY_DIR_RE.search(str(part.parent))
+        if not match:
+            logger.warning("Skipping {} — no agency_code in path", part)
+            continue
+        stats = _backfill_file(
+            part,
+            agency=match.group(1),
+            resource_factory=resource_factory,
+            limit=remaining,
+            max_workers=max_workers,
+            overwrite=overwrite,
+        )
+        for key, value in stats.items():
+            totals[key] += value
+        if stats["ok"]:
+            changed.append(part)
+        if remaining is not None:
+            remaining -= stats["selected"]
+
+    logger.info("Backfill totals: {} (changed {} partitions)", totals, len(changed))
+    return totals, changed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill comment text_content from Mirrulations derived-data extracted text."
+    )
+    parser.add_argument("--output-dir", type=Path, default=Path("output"))
+    parser.add_argument("--limit", type=int, default=None, help="Max comments to backfill this run")
+    parser.add_argument("--max-workers", type=int, default=8)
+    parser.add_argument("--overwrite", action="store_true", help="Re-fill rows that already have a status")
+    parser.add_argument(
+        "--upload", action="store_true", help="Upload changed comment partitions + index to R2 (needs credentials)"
+    )
+    args = parser.parse_args()
+
+    # Prefer the Hive-partitioned layout, fall back to the monolithic file.
+    partition_dir = args.output_dir / "comments" / "agency"
+    if partition_dir.exists():
+        _, changed = backfill_comment_partitions(
+            partition_dir,
+            limit=args.limit,
+            max_workers=args.max_workers,
+            overwrite=args.overwrite,
+        )
+        if args.upload and changed:
+            from spicy_regs.pipeline.load import upload_comment_partitions
+
+            upload_comment_partitions(args.output_dir, changed)
+    else:
+        backfill_comments_parquet(
+            args.output_dir / "comments.parquet",
+            limit=args.limit,
+            max_workers=args.max_workers,
+            overwrite=args.overwrite,
+        )
+        if args.upload:
+            from spicy_regs.pipeline.upload_r2 import upload_to_r2 as _upload_r2
+
+            _upload_r2(args.output_dir / "comments.parquet")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backfill_derived_text.py
+++ b/tests/test_backfill_derived_text.py
@@ -1,0 +1,112 @@
+"""Tests for the derived-data comment-text backfill.
+
+Exercises the in-place enrichment over a comments frame, the partition walker
+(which must read agency_code from the directory name), and the incremental /
+limit / overwrite semantics — all against the fake in-memory S3 resource.
+"""
+
+from __future__ import annotations
+
+import json
+
+import polars as pl
+
+from spicy_regs.pipeline.backfill_derived_text import (
+    backfill_comment_partitions,
+    enrich_comments_with_derived_text,
+)
+from tests.conftest import COMMENT_SCHEMA
+
+# Reuse the fake S3 surface from the derived-text unit tests.
+from tests.test_derived_text import _FakeS3Resource, _store
+
+
+def _factory():
+    return lambda: _FakeS3Resource(_store())
+
+
+def _attach() -> str:
+    return json.dumps([{"title": "x", "formats": [{"url": "https://x/a.pdf", "format": "pdf"}]}])
+
+
+def _frame(rows: list[dict]) -> pl.DataFrame:
+    base = {k: None for k in COMMENT_SCHEMA}
+    return pl.DataFrame([{**base, **r} for r in rows], schema=COMMENT_SCHEMA)
+
+
+def test_enrich_fills_from_derived_data_using_agency_column() -> None:
+    df = _frame(
+        [
+            {"comment_id": "ACF-2025-0038-0004", "docket_id": "ACF-2025-0038", "agency_code": "ACF", "attachments_json": _attach()},
+            {"comment_id": "ACF-2025-0038-0015", "docket_id": "ACF-2025-0038", "agency_code": "ACF", "attachments_json": _attach()},
+        ]
+    )
+    out, stats = enrich_comments_with_derived_text(df, resource_factory=_factory())
+    assert stats == {"selected": 2, "ok": 2, "missing": 0}
+    by_id = {r["comment_id"]: r for r in out.iter_rows(named=True)}
+    assert by_id["ACF-2025-0038-0004"]["text_content"] == "Wisconsin DCF comment body"
+    assert by_id["ACF-2025-0038-0015"]["text_content"] == "first attachment\n\nsecond attachment"
+    assert all(r["text_extraction_status"] == "ok" for r in out.iter_rows(named=True))
+
+
+def test_enrich_with_explicit_agency_override() -> None:
+    # Partition files drop agency_code; the agency is supplied explicitly.
+    df = _frame(
+        [{"comment_id": "ACF-2025-0038-0004", "docket_id": "ACF-2025-0038", "attachments_json": _attach()}]
+    ).drop("agency_code")
+    out, stats = enrich_comments_with_derived_text(df, agency="ACF", resource_factory=_factory())
+    assert stats["ok"] == 1
+    assert out.row(0, named=True)["text_content"] == "Wisconsin DCF comment body"
+
+
+def test_enrich_skips_no_attachment_and_already_filled() -> None:
+    df = _frame(
+        [
+            {"comment_id": "ACF-2025-0038-0004", "docket_id": "ACF-2025-0038", "agency_code": "ACF", "attachments_json": None},
+            {"comment_id": "ACF-2025-0038-0015", "docket_id": "ACF-2025-0038", "agency_code": "ACF", "attachments_json": _attach(), "text_extraction_status": "ok", "text_content": "kept"},
+        ]
+    )
+    out, stats = enrich_comments_with_derived_text(df, resource_factory=_factory())
+    assert stats["selected"] == 0
+    assert out.filter(pl.col("comment_id") == "ACF-2025-0038-0015").row(0, named=True)["text_content"] == "kept"
+
+
+def test_enrich_missing_derived_text_counts_as_missing() -> None:
+    df = _frame(
+        [{"comment_id": "ACF-2025-0038-9999", "docket_id": "ACF-2025-0038", "agency_code": "ACF", "attachments_json": _attach()}]
+    )
+    out, stats = enrich_comments_with_derived_text(df, resource_factory=_factory())
+    assert stats == {"selected": 1, "ok": 0, "missing": 1}
+    # Left NULL so the PDF-download fallback can still pick it up.
+    assert out.row(0, named=True)["text_extraction_status"] is None
+
+
+def test_enrich_respects_limit() -> None:
+    df = _frame(
+        [
+            {"comment_id": "ACF-2025-0038-0004", "docket_id": "ACF-2025-0038", "agency_code": "ACF", "attachments_json": _attach()},
+            {"comment_id": "ACF-2025-0038-0015", "docket_id": "ACF-2025-0038", "agency_code": "ACF", "attachments_json": _attach()},
+        ]
+    )
+    _, stats = enrich_comments_with_derived_text(df, resource_factory=_factory(), limit=1)
+    assert stats["selected"] == 1
+    assert stats["ok"] == 1
+
+
+def test_backfill_partitions_reads_agency_from_path(tmp_path) -> None:
+    part_dir = tmp_path / "comments" / "agency" / "agency_code=ACF"
+    part_dir.mkdir(parents=True)
+    # Partition file has NO agency_code column (mirrors production layout).
+    df = _frame(
+        [{"comment_id": "ACF-2025-0038-0004", "docket_id": "ACF-2025-0038", "attachments_json": _attach()}]
+    ).drop("agency_code")
+    df.write_parquet(part_dir / "part-0.parquet")
+
+    totals, changed = backfill_comment_partitions(
+        tmp_path / "comments" / "agency", resource_factory=_factory()
+    )
+    assert totals["ok"] == 1
+    assert len(changed) == 1
+    written = pl.read_parquet(part_dir / "part-0.parquet")
+    assert "agency_code" not in written.columns  # schema preserved
+    assert written.row(0, named=True)["text_content"] == "Wisconsin DCF comment body"


### PR DESCRIPTION
## Summary

Follow-up to #84. The inline enrichment added there fills `text_content` only for comments the ETL processes **fresh** — but the incremental manifest skips comments ingested earlier, so the **millions already published stay `NULL`**. This adds a one-time / re-runnable **backfill** that fills them from Mirrulations' pre-extracted text, reading the bucket's `derived-data` prefix directly — **no PDF download, no JSON re-ingest**.

```bash
uv run spicy-regs download --types comments   # grab the published parquet
uv run backfill-comment-text                   # fill text_content in place
uv run backfill-comment-text --limit 5000      # cap work for a trial run
uv run backfill-comment-text --upload          # also republish to R2 (needs credentials)
```

`backfill-comment-text` walks the published comment Parquet (Hive partitions or the monolithic file), fills `text_content` + `text_extraction_status` in place for attachment-bearing rows with no status yet, and optionally republishes to R2. It's the derived-data sibling of `enrich-pdf-text`: incremental (skips rows that already have a status unless `--overwrite`), `--limit`-budgeted, and partition-aware. Work is grouped by docket and fanned out so each docket's extraction prefix is listed once.

**One wrinkle the PDF path doesn't have:** the Hive comment partitions drop the `agency_code` column (it's encoded in the `agency_code=<X>` directory name), but the derived-data S3 path is keyed by agency — so the partition walker reads the agency from the path and passes it in; the monolithic `comments.parquet` still carries the column and is read per row.

**Documents** are intentionally not covered: Mirrulations doesn't publish document extracted text (verified 0/76 dockets), so document text stays on `enrich-pdf-text --target documents`.

> Note on scope: this does **not** change the production daily ETL. The inline enrichment still lives only in `run-pipeline` (the non-scheduled pipeline); wiring it into the scheduled `etl` job is a separate decision left for later.

## Test plan

- [x] `uv run pytest` — **207 passed, 3 deselected**
- [x] `uv run ruff check .` — clean
- [x] `uv run ty check` on the new module — clean
- [x] Live end-to-end against the real bucket: a small ACF comments partition backfilled — `ACF-2025-0038-0004` filled (4,182 chars), `ACF-2025-0038-0015` filled (57,354 chars, two attachments concatenated), an attachment-less comment correctly skipped, partition schema (no `agency_code`) preserved
- [x] Unit tests (fake S3): agency-from-column vs agency-from-path, skip no-attachment / already-filled, `--limit`, missing-text → stays NULL for the PDF fallback

## Checklist

- [x] My change is scoped to one concern
- [x] I added or updated tests for new behavior
- [x] I updated docs (README)
- [x] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjeuJmpUo2PfpCwCPhVgtp

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjeuJmpUo2PfpCwCPhVgtp)_