### PR TITLE
Offset the new-pipeline ETL crons off the top of the hour

### DIFF
--- a/.github/workflows/etl-new-pipeline.yml
+++ b/.github/workflows/etl-new-pipeline.yml
@@ -14,22 +14,27 @@ name: ETL (new pipeline)
 # it off deliberately.
 on:
   schedule:
-    # Batch 0: 6 AM UTC, Batch 1: 7 AM UTC, ..., Batch 14: 8 PM UTC
-    - cron: '0 6 * * *'   # Batch 0
-    - cron: '0 7 * * *'   # Batch 1
-    - cron: '0 8 * * *'   # Batch 2
-    - cron: '0 9 * * *'   # Batch 3
-    - cron: '0 10 * * *'  # Batch 4
-    - cron: '0 11 * * *'  # Batch 5
-    - cron: '0 12 * * *'  # Batch 6
-    - cron: '0 13 * * *'  # Batch 7
-    - cron: '0 14 * * *'  # Batch 8
-    - cron: '0 15 * * *'  # Batch 9
-    - cron: '0 16 * * *'  # Batch 10
-    - cron: '0 17 * * *'  # Batch 11
-    - cron: '0 18 * * *'  # Batch 12
-    - cron: '0 19 * * *'  # Batch 13
-    - cron: '0 20 * * *'  # Batch 14
+    # Batch 0: ~6 AM UTC, Batch 1: ~7 AM UTC, ..., Batch 14: ~8 PM UTC.
+    # The minute is offset off the top of the hour (:25) on purpose: GitHub
+    # delays or drops `schedule` events during the high-load window at the
+    # start of every hour, so `:00` crons fire late or not at all. The batch
+    # number is still derived from the UTC hour at runtime, so any minute
+    # within the hour maps to the same batch.
+    - cron: '25 6 * * *'   # Batch 0
+    - cron: '25 7 * * *'   # Batch 1
+    - cron: '25 8 * * *'   # Batch 2
+    - cron: '25 9 * * *'   # Batch 3
+    - cron: '25 10 * * *'  # Batch 4
+    - cron: '25 11 * * *'  # Batch 5
+    - cron: '25 12 * * *'  # Batch 6
+    - cron: '25 13 * * *'  # Batch 7
+    - cron: '25 14 * * *'  # Batch 8
+    - cron: '25 15 * * *'  # Batch 9
+    - cron: '25 16 * * *'  # Batch 10
+    - cron: '25 17 * * *'  # Batch 11
+    - cron: '25 18 * * *'  # Batch 12
+    - cron: '25 19 * * *'  # Batch 13
+    - cron: '25 20 * * *'  # Batch 14
   workflow_dispatch:
     inputs:
       agency:


### PR DESCRIPTION
## Summary

The scheduled ETL (`etl-new-pipeline.yml`) hasn't been firing as expected. Diagnosis:

- The schedule only reached `main` when PR #86 merged at **12:41 UTC on 2026-06-30**. GitHub only triggers `schedule` events from the workflow file on the default branch, so the morning batches (06:00–12:00 UTC, batches 0–6) couldn't run today — their windows had already passed before the merge. This was timing, not a defect, and resolves itself on subsequent days.
- Every cron was set at minute `:00`. GitHub explicitly warns that `schedule` events are delayed or dropped during the high-load window at the **start of every hour**, which makes top-of-hour crons unreliable (the afternoon batches today were also delayed/skipped).

This PR moves all 15 batch crons from `:00` to `:25` within their hour to avoid the top-of-hour congestion. The batch number is derived from the UTC hour at runtime (`date -u +%H`), so shifting only the minute does not change which batch each cron maps to.

No application code changed — schedule timing only.

## Test plan

- [ ] `uv run pytest` — n/a, no Python changed
- [ ] `uv run ruff check .` — n/a, no Python changed
- [x] Verified the cron YAML is valid and each entry stays within its original hour, preserving the hour→batch mapping in the `Determine run parameters` step

## Checklist

- [x] My change is scoped to one concern
- [ ] I added or updated tests for new behavior — n/a (workflow schedule timing)
- [x] I updated docs — updated the inline comment in the workflow explaining the minute offset
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012bmbnCEdC7oZh7BLMRuj3N)_