### PR TITLE
Speed up Mirrulations extract: concurrent downloads + single-pass listing

### DIFF
--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -111,14 +111,19 @@ class RegulationsPipeline(Pipeline):
         # 2. Extract → stage: fan agencies out, pumping each source into staging.
         logger.info(
             "Processing {} agencies × {} record types ({} workers)",
-            len(agencies), len(record_types), self.max_workers,
+            len(agencies),
+            len(record_types),
+            self.max_workers,
         )
         result = stage_agencies(
             agencies,
             record_types,
             staging_dir,
             mirrulations.reader_factory(
-                processed_keys=manifest, since_year=self.since_year, verbose=self.verbose
+                record_types,
+                processed_keys=manifest,
+                since_year=self.since_year,
+                verbose=self.verbose,
             ),
             transform_for=self._transform_for,
             max_workers=self.max_workers,
@@ -282,14 +287,10 @@ def main(
     skip_post_process: Annotated[bool, Parameter(help="Skip feed summary build")] = False,
     full_refresh: Annotated[bool, Parameter(help="Ignore manifest + existing output")] = False,
     max_workers: Annotated[int, Parameter(help="Agencies processed in parallel")] = 4,
-    use_iceberg: Annotated[
-        bool, Parameter(help="Route the dockets table through R2 Data Catalog (Iceberg)")
-    ] = False,
+    use_iceberg: Annotated[bool, Parameter(help="Route the dockets table through R2 Data Catalog (Iceberg)")] = False,
     enrich_text: Annotated[
         bool,
-        Parameter(
-            help="Fill comment text_content inline from Mirrulations derived-data extracted text"
-        ),
+        Parameter(help="Fill comment text_content inline from Mirrulations derived-data extracted text"),
     ] = True,
     verbose: Annotated[bool, Parameter(name=["--verbose", "-v"], help="Verbose logging")] = False,
 ) -> None:

--- a/src/spicy_regs/sources/mirrulations.py
+++ b/src/spicy_regs/sources/mirrulations.py
@@ -13,7 +13,9 @@ into schema-shaped records is the job of the
 
 import re
 from collections.abc import Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from json import loads
+from threading import Lock
 from typing import Any
 
 import boto3
@@ -28,6 +30,12 @@ from spicy_regs.sources.base import Reader
 # that uses them, not in the pipeline.
 BUCKET = "mirrulations"
 PREFIX = "raw-data"
+
+# Downloads are tiny JSON GETs against S3 — I/O-bound, so a pool of threads per
+# agency turns thousands of serial round-trips into concurrent ones. The single
+# anonymous resource is shared across the pool: unsigned read-only GetObject has
+# no credential-refresh race, and botocore's connection pool is thread-safe.
+DEFAULT_DOWNLOAD_WORKERS = 16
 
 
 def s3_resource() -> Any:
@@ -96,9 +104,57 @@ def list_json_files(
 
     if verbose:
         year_msg = f", filtered_by_year {filtered_by_year}" if since_year else ""
-        tqdm.write(f"    [{agency}] {data_type}: scanned {total_scanned}, skipped {skipped}{year_msg}, new {len(files)}")
+        tqdm.write(
+            f"    [{agency}] {data_type}: scanned {total_scanned}, skipped {skipped}{year_msg}, new {len(files)}"
+        )
 
     return files
+
+
+def list_agency_files_by_type(
+    s3_resource: Any,
+    bucket_name: str,
+    prefix: str,
+    agency: str,
+    record_types: list[RecordType],
+    processed_keys: Any = None,
+    verbose: bool = False,
+    since_year: int | None = None,
+) -> dict[str, list[str]]:
+    """List one agency's JSON files in a single pass, bucketed by record type.
+
+    The Mirrulations layout nests every record type under the same agency
+    prefix, so calling :func:`list_json_files` once per type re-scans the whole
+    (potentially millions of objects) prefix N times. This scans it once and
+    classifies each key by which record type's ``path_pattern`` it contains —
+    the patterns (``/docket/``, ``/documents/``, ``/comments/``) are mutually
+    exclusive, so each key maps to at most one type.
+    """
+    year_pattern = re.compile(rf"{re.escape(prefix)}/{re.escape(agency)}/{re.escape(agency)}-(\d{{4}})-")
+    patterns = [(rt.name, rt.path_pattern) for rt in record_types if rt.path_pattern]
+    result: dict[str, list[str]] = {rt.name: [] for rt in record_types}
+
+    bucket = s3_resource.Bucket(bucket_name)
+    for obj in bucket.objects.filter(Prefix=f"{prefix}/{agency}/"):
+        key = obj.key
+        if "/text-" not in key or not key.endswith(".json"):
+            continue
+        matched = next((name for name, pattern in patterns if pattern in key), None)
+        if matched is None:
+            continue
+        if since_year:
+            m = year_pattern.search(key)
+            if m and int(m.group(1)) < since_year:
+                continue
+        if processed_keys and key in processed_keys:
+            continue
+        result[matched].append(key)
+
+    if verbose:
+        summary = ", ".join(f"{name} {len(keys)}" for name, keys in result.items())
+        tqdm.write(f"    [{agency}] single-scan listing: {summary}")
+
+    return result
 
 
 def download_and_parse(
@@ -127,7 +183,6 @@ def _identity(payload: dict) -> dict:
     return payload
 
 
-
 class MirrulationsReader(Reader):
     """Reads one agency's records of a single record type from Mirrulations S3.
 
@@ -146,6 +201,8 @@ class MirrulationsReader(Reader):
         processed_keys: Any = None,
         since_year: int | None = None,
         verbose: bool = False,
+        download_workers: int = DEFAULT_DOWNLOAD_WORKERS,
+        key_lister: Callable[[], list[str]] | None = None,
     ) -> None:
         self.s3_resource = s3_resource
         self.bucket = bucket
@@ -155,6 +212,10 @@ class MirrulationsReader(Reader):
         self.processed_keys = processed_keys
         self.since_year = since_year
         self.verbose = verbose
+        self.download_workers = download_workers
+        # When set, supplies this record type's keys (e.g. from a shared
+        # single-scan listing); otherwise the reader lists them itself.
+        self.key_lister = key_lister
         self.last_keys: list[str] = []
 
     def iter_records(self) -> Iterator[dict]:
@@ -163,41 +224,121 @@ class MirrulationsReader(Reader):
                 f"MirrulationsReader requires a path-addressable record type, "
                 f"but {self.record_type.name!r} has no path_pattern."
             )
-        self.last_keys = list_json_files(
-            self.s3_resource,
-            self.bucket,
-            self.prefix,
-            self.agency,
-            self.record_type.name,
-            self.record_type.path_pattern,
-            self.processed_keys,
-            self.verbose,
-            self.since_year,
-        )
-        for key in self.last_keys:
-            payload = download_and_parse(self.s3_resource, self.bucket, key, _identity)
-            if payload is not None:
-                yield payload
+        if self.key_lister is not None:
+            self.last_keys = self.key_lister()
+        else:
+            self.last_keys = list_json_files(
+                self.s3_resource,
+                self.bucket,
+                self.prefix,
+                self.agency,
+                self.record_type.name,
+                self.record_type.path_pattern,
+                self.processed_keys,
+                self.verbose,
+                self.since_year,
+            )
+        # Fan the per-file GETs out across a thread pool — they are independent,
+        # I/O-bound round trips. Order is irrelevant (dedup happens later by key).
+        workers = max(1, min(self.download_workers, len(self.last_keys)))
+        if workers <= 1:
+            for key in self.last_keys:
+                payload = download_and_parse(self.s3_resource, self.bucket, key, _identity)
+                if payload is not None:
+                    yield payload
+            return
+
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = [
+                executor.submit(download_and_parse, self.s3_resource, self.bucket, key, _identity)
+                for key in self.last_keys
+            ]
+            for future in as_completed(futures):
+                payload = future.result()
+                if payload is not None:
+                    yield payload
+
+
+class _AgencyListingCache:
+    """Memoizes one single-scan listing per agency, shared across its readers.
+
+    ``stage_agencies`` builds a reader per (agency, record type) and runs an
+    agency's record types sequentially within one worker thread, so the first
+    reader for an agency triggers the scan and the rest read from the cache.
+    Different agencies populate different keys concurrently, guarded by a lock.
+    """
+
+    def __init__(
+        self,
+        record_types: list[RecordType],
+        *,
+        processed_keys: Any,
+        since_year: int | None,
+        verbose: bool,
+    ) -> None:
+        self._record_types = record_types
+        self._processed_keys = processed_keys
+        self._since_year = since_year
+        self._verbose = verbose
+        self._by_agency: dict[str, dict[str, list[str]]] = {}
+        self._lock = Lock()
+
+    def keys_for(self, s3_resource: Any, agency: str, record_type: RecordType) -> list[str]:
+        with self._lock:
+            listed = self._by_agency.get(agency)
+        if listed is None:
+            scanned = list_agency_files_by_type(
+                s3_resource,
+                BUCKET,
+                PREFIX,
+                agency,
+                self._record_types,
+                processed_keys=self._processed_keys,
+                verbose=self._verbose,
+                since_year=self._since_year,
+            )
+            with self._lock:
+                listed = self._by_agency.setdefault(agency, scanned)
+        return listed.get(record_type.name, [])
 
 
 def reader_factory(
+    record_types: list[RecordType],
     *,
     processed_keys: Any = None,
     since_year: int | None = None,
     verbose: bool = False,
+    download_workers: int = DEFAULT_DOWNLOAD_WORKERS,
+    resource_factory: Callable[[], Any] | None = None,
 ) -> Callable[[str, RecordType], MirrulationsReader]:
     """Build a ``read(agency, record_type) -> MirrulationsReader`` factory.
 
     The shared options (manifest membership test, year filter, verbosity) are
     bound once; the orchestrator just supplies the agency and record type. Each
     reader gets its own S3 resource so the factory is safe to call from worker
-    threads.
+    threads. The full set of ``record_types`` is bound so each agency's prefix
+    is scanned once and the keys bucketed by type, rather than re-scanned per
+    record type.
     """
+    cache = _AgencyListingCache(record_types, processed_keys=processed_keys, since_year=since_year, verbose=verbose)
+    # Resolve at call time (not as a default arg) so a monkeypatched
+    # ``mirrulations.s3_resource`` is honored, and each reader still gets its
+    # own resource — safe to call from the staging worker threads.
+    make_resource = resource_factory or s3_resource
 
     def read(agency: str, record_type: RecordType) -> MirrulationsReader:
+        resource = make_resource()
         return MirrulationsReader(
-            s3_resource(), BUCKET, PREFIX, agency, record_type,
-            processed_keys=processed_keys, since_year=since_year, verbose=verbose,
+            resource,
+            BUCKET,
+            PREFIX,
+            agency,
+            record_type,
+            processed_keys=processed_keys,
+            since_year=since_year,
+            verbose=verbose,
+            download_workers=download_workers,
+            key_lister=lambda: cache.keys_for(resource, agency, record_type),
         )
 
     return read

--- a/tests/test_mirrulations_reader.py
+++ b/tests/test_mirrulations_reader.py
@@ -2,7 +2,7 @@
 
 from json import dumps
 
-from spicy_regs.schemas import DOCKET
+from spicy_regs.schemas import COMMENT, DOCKET, DOCUMENT
 from spicy_regs.sources import MirrulationsReader
 
 BUCKET = "mirrulations"
@@ -109,3 +109,110 @@ def test_since_year_filters_older_dockets() -> None:
     reader = MirrulationsReader(_FakeS3Resource(_make_store()), BUCKET, PREFIX, AGENCY, DOCKET, since_year=2025)
     records = list(reader.iter_records())
     assert [_raw_id(r) for r in records] == ["EPA-2025-0002"]
+
+
+def test_iter_records_downloads_concurrently() -> None:
+    """Downloads for one agency run in parallel, not one-at-a-time.
+
+    A Barrier that only releases once all N downloads are simultaneously in
+    flight is a deterministic proof of concurrency: a serial implementation
+    can never gather N parties, so the barrier times out, those downloads
+    raise, and nothing is yielded. Concurrent downloads all rendezvous and
+    every payload comes back.
+    """
+    import threading
+
+    n = 4
+    store = {_docket_key(f"EPA-2024-{i:04d}"): dumps(_docket_payload(f"EPA-2024-{i:04d}")).encode() for i in range(n)}
+    barrier = threading.Barrier(n, timeout=5)
+
+    class _BarrierObj(_FakeObj):
+        def get(self) -> dict:
+            barrier.wait()  # blocks until all N downloads are concurrently in flight
+            return super().get()
+
+    class _BarrierResource(_FakeS3Resource):
+        def Object(self, name: str, key: str) -> _BarrierObj:  # noqa: N802
+            return _BarrierObj(key, self._store[key])
+
+    reader = MirrulationsReader(_BarrierResource(store), BUCKET, PREFIX, AGENCY, DOCKET, download_workers=n)
+    records = list(reader.iter_records())
+
+    assert len(records) == n
+
+
+class _CountingObjects(_FakeObjects):
+    """Counts how many times the agency prefix is scanned."""
+
+    def __init__(self, store: dict[str, bytes], scans: list[int]) -> None:
+        super().__init__(store)
+        self._scans = scans
+
+    def filter(self, Prefix: str):  # noqa: N803 — mirrors boto3 kwarg
+        self._scans[0] += 1
+        return super().filter(Prefix=Prefix)
+
+
+class _CountingResource(_FakeS3Resource):
+    def __init__(self, store: dict[str, bytes], scans: list[int]) -> None:
+        super().__init__(store)
+        self._scans = scans
+
+    def Bucket(self, name: str):  # noqa: N802
+        bucket = super().Bucket(name)
+        bucket.objects = _CountingObjects(self._store, self._scans)
+        return bucket
+
+
+def _typed_store() -> dict[str, bytes]:
+    base = f"{PREFIX}/{AGENCY}/EPA-2024-0001/text-EPA-2024-0001"
+    return {
+        f"{base}/docket/EPA-2024-0001.json": dumps(_docket_payload("EPA-2024-0001")).encode(),
+        f"{base}/documents/EPA-2024-0001-0001.json": b'{"data": {}}',
+        f"{base}/comments/EPA-2024-0001-0002.json": b'{"data": {}}',
+        # Non-JSON / binary — must be ignored.
+        f"{base}/binary-EPA-2024-0001/docket/x.pdf": b"x",
+    }
+
+
+def test_single_scan_buckets_keys_by_record_type() -> None:
+    """One prefix scan classifies an agency's keys for all record types.
+
+    Replaces the prior behavior of scanning the whole agency prefix once per
+    record type (3x). A counting fake proves exactly one scan happens.
+    """
+    from spicy_regs.sources.mirrulations import list_agency_files_by_type
+
+    scans = [0]
+    resource = _CountingResource(_typed_store(), scans)
+
+    result = list_agency_files_by_type(resource, BUCKET, PREFIX, AGENCY, [DOCKET, DOCUMENT, COMMENT])
+
+    assert scans[0] == 1
+    assert result["dockets"] == [f"{PREFIX}/{AGENCY}/EPA-2024-0001/text-EPA-2024-0001/docket/EPA-2024-0001.json"]
+    assert result["documents"] == [
+        f"{PREFIX}/{AGENCY}/EPA-2024-0001/text-EPA-2024-0001/documents/EPA-2024-0001-0001.json"
+    ]
+    assert result["comments"] == [
+        f"{PREFIX}/{AGENCY}/EPA-2024-0001/text-EPA-2024-0001/comments/EPA-2024-0001-0002.json"
+    ]
+
+
+def test_reader_factory_scans_each_agency_once() -> None:
+    """The readers a factory builds for one agency share a single prefix scan."""
+    from spicy_regs.sources.mirrulations import reader_factory
+
+    scans = [0]
+    resource = _CountingResource(_typed_store(), scans)
+    read = reader_factory([DOCKET, DOCUMENT, COMMENT], resource_factory=lambda: resource)
+
+    keys_by_type = {}
+    for record_type in (DOCKET, DOCUMENT, COMMENT):
+        reader = read(AGENCY, record_type)
+        list(reader.iter_records())
+        keys_by_type[record_type.name] = reader.last_keys
+
+    assert scans[0] == 1  # one scan for the agency, not one per record type
+    assert len(keys_by_type["dockets"]) == 1
+    assert len(keys_by_type["documents"]) == 1
+    assert len(keys_by_type["comments"]) == 1


### PR DESCRIPTION
## Problem

The extract stage was the ETL's wall-clock bottleneck:
- Within an agency, files were downloaded **one at a time** (`MirrulationsReader.iter_records` looped serial GETs); parallelism existed only *across* agencies (`--max-workers`).
- The whole agency prefix was re-scanned **once per record type** (3×) — `list_json_files` paginates every object under `raw-data/{agency}/` and filters in Python.

For a large agency (EPA), this meant ~tens of minutes before the first row was staged.

## Changes

- **Concurrent downloads** — `MirrulationsReader` fans per-file GETs across a thread pool (`DEFAULT_DOWNLOAD_WORKERS=16`). The single anonymous resource is shared across the pool (unsigned read-only GetObject has no credential-refresh race; botocore's connection pool is thread-safe). Order is irrelevant — dedup happens later by primary key.
- **Single-pass listing** — new `list_agency_files_by_type` scans an agency's prefix once and buckets keys by record type. `reader_factory` now takes the active `record_types` and shares one scan across an agency's readers via a per-agency cache. The path_patterns (`/docket/`, `/documents/`, `/comments/`) are mutually exclusive, so each key maps to exactly one type.

## Tests

- New hermetic tests: download concurrency (Barrier-based proof), single-scan classification, and the factory's shared-scan behavior.
- Full unit suite green (213 passed). Validated end-to-end against a real agency.

## Notes

- `reader_factory`'s `resource_factory` resolves `s3_resource` at call time (not as a default arg) so monkeypatched tests still work.
- A remaining floor: a single S3 LIST of a giant agency's prefix is still slow (inherent to pagination); a future `Delimiter`-based docket-level listing could push `--since-year` into the scan.