### PR TITLE
Serve comments from the Iceberg catalog to fix stale row-level data

### DIFF
--- a/.github/workflows/etl-new-pipeline.yml
+++ b/.github/workflows/etl-new-pipeline.yml
@@ -63,7 +63,7 @@ on:
         default: true
         type: boolean
       use_iceberg:
-        description: 'Route the dockets table through R2 Data Catalog (Iceberg)'
+        description: 'Route dockets + comments through R2 Data Catalog (Iceberg)'
         required: false
         default: false
         type: boolean

--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -8,6 +8,7 @@ the same tool surface (names, parameters, behavior); the test at
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import tempfile
@@ -47,6 +48,17 @@ TABLES = (
     "agency_monthly_volume",
 )
 STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "30s")
+
+logger = logging.getLogger(__name__)
+
+# DuckDB alias the R2 Data Catalog is attached under (mirrors
+# ``spicy_regs.sources.iceberg._CATALOG_ALIAS``). When the catalog is
+# configured, the ``comments`` view is served from it instead of the monolithic
+# ``comments.parquet`` — the comments table is too large to keep republishing as
+# a single file, so the catalog is its read surface. All other tables stay on
+# the public Parquet snapshots.
+CATALOG_ALIAS = "reg_catalog"
+DEFAULT_CATALOG_NAMESPACE = "default"
 
 
 def _parse_timeout_seconds(raw: str) -> float | None:
@@ -131,6 +143,36 @@ def _resolve_home_directory() -> str:
 HOME_DIRECTORY = _resolve_home_directory()
 
 
+def _resolve_catalog_config() -> dict[str, str] | None:
+    """Return R2 Data Catalog connection settings, or ``None`` when unconfigured.
+
+    The catalog is optional: when ``R2_CATALOG_URI`` / ``R2_CATALOG_WAREHOUSE`` /
+    ``R2_CATALOG_TOKEN`` are all present the ``comments`` view is served from the
+    Iceberg catalog; otherwise the server falls back to the monolithic
+    ``comments.parquet`` (the dual model). The token used here should be a
+    read-scoped R2 API token — this is a public, read-only server.
+
+    Values are inlined into ``CREATE SECRET`` / ``ATTACH`` (which take no bind
+    parameters), so any value containing a quote, backslash, or control
+    character is rejected outright rather than escaped.
+    """
+    uri = os.environ.get("R2_CATALOG_URI")
+    warehouse = os.environ.get("R2_CATALOG_WAREHOUSE")
+    token = os.environ.get("R2_CATALOG_TOKEN")
+    if not (uri and warehouse and token):
+        return None
+    config = {
+        "uri": uri,
+        "warehouse": warehouse,
+        "token": token,
+        "namespace": os.environ.get("R2_CATALOG_NAMESPACE", DEFAULT_CATALOG_NAMESPACE),
+    }
+    for key, value in config.items():
+        if any(c in value for c in ("'", "\\", "\x00", "\n", "\r")):
+            raise RuntimeError(f"R2 catalog {key} contains illegal characters")
+    return config
+
+
 def _jsonify(value: Any) -> Any:
     """Coerce DuckDB row values into JSON-serializable forms."""
     if value is None or isinstance(value, (str, int, float, bool)):
@@ -180,6 +222,31 @@ def _apply_security_settings(con: duckdb.DuckDBPyConnection) -> None:
     con.execute("SET lock_configuration=true")
 
 
+def _attach_catalog(con: duckdb.DuckDBPyConnection, config: dict[str, str]) -> bool:
+    """Attach the R2 Data Catalog so the ``comments`` view can read from it.
+
+    Best-effort: if the iceberg extension or the attach fails (bad token,
+    network, catalog down) the server stays up by falling back to the monolithic
+    ``comments.parquet``. Must run before :func:`_apply_security_settings` locks
+    the configuration. Returns ``True`` only when the catalog is attached.
+    """
+    try:
+        con.execute("INSTALL iceberg")
+        con.execute("LOAD iceberg")
+        con.execute(
+            "CREATE OR REPLACE SECRET r2_catalog_secret "
+            f"(TYPE ICEBERG, TOKEN '{config['token']}');"
+        )
+        con.execute(
+            f"ATTACH '{config['warehouse']}' AS {CATALOG_ALIAS} "
+            f"(TYPE ICEBERG, ENDPOINT '{config['uri']}');"
+        )
+        return True
+    except duckdb.Error as exc:
+        logger.warning("R2 catalog attach failed; comments fall back to monolith: %s", exc)
+        return False
+
+
 def _connect() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
     # Must precede INSTALL/LOAD: that step writes the extension under
@@ -188,8 +255,28 @@ def _connect() -> duckdb.DuckDBPyConnection:
     con.execute(f"SET home_directory='{HOME_DIRECTORY.replace(chr(39), chr(39) * 2)}'")
     con.execute("INSTALL httpfs")
     con.execute("LOAD httpfs")
+
+    # Optionally attach the Iceberg catalog (before the config lock) so the
+    # comments view can be served from it.
+    catalog = _resolve_catalog_config()
+    catalog_attached = catalog is not None and _attach_catalog(con, catalog)
+
     _apply_security_settings(con)
     for name in TABLES:
+        if name == "comments" and catalog_attached:
+            namespace = catalog["namespace"]  # type: ignore[index]
+            try:
+                con.execute(
+                    f'CREATE VIEW comments AS SELECT * FROM '
+                    f'{CATALOG_ALIAS}."{namespace}"."comments"'
+                )
+                continue
+            except duckdb.Error as exc:
+                # Catalog reachable but the table isn't there yet — fall back to
+                # the monolith rather than breaking every query on the server.
+                logger.warning(
+                    "comments not available in catalog; falling back to monolith: %s", exc
+                )
         url = f"{R2_BASE_URL}/{name}.parquet"
         con.execute(f"CREATE VIEW {name} AS SELECT * FROM read_parquet('{url}')")
     return con

--- a/plugins/spicyregs/skills/spicyregs/references/data-layout.md
+++ b/plugins/spicyregs/skills/spicyregs/references/data-layout.md
@@ -21,6 +21,14 @@ Use this reference when you need a quick map of the remote or local data files b
 - `feed_summary.parquet`
 - Local-only: `comments/` partitioned comment parquet files may exist instead of a monolithic `comments.parquet`
 
+> **Comments read surface.** `comments_index.parquet` (per-partition counts) is
+> always the source for comment *counts*. The row-level `comments` table is
+> served either from the monolithic `comments.parquet` snapshot or, when the
+> deployment has the R2 Data Catalog configured (`R2_CATALOG_*`), directly from
+> the Iceberg `comments` table in the catalog — which is kept current by the
+> ETL's row-level `MERGE`. Either way you query the `comments` table by name;
+> the MCP server picks the surface.
+
 ## Practical schema hints
 
 These fields are stable enough to start with, but use `--describe` for the actual schema.

--- a/scripts/check_comments_freshness.py
+++ b/scripts/check_comments_freshness.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Flag staleness between ``comments_index`` and the row-level ``comments`` surface.
+
+The comment *counts* (``comments_index``, ``feed_summary``, ``agency_stats``) and
+the row-level ``comments`` table are produced by different steps. If they drift —
+the index advertises comments for a month the row data doesn't actually contain —
+then count queries look current while ``SELECT ... FROM comments`` returns nothing
+for recent dockets. That exact gap (OMB-2026-0034 showed ~39k June-2026 comments
+in the index but zero rows in ``comments``) is what this check catches.
+
+It compares, per ``agency_code``, the latest ``(year, month)`` present in
+``comments_index`` against the latest ``posted_date`` month actually materialized
+in the ``comments`` read surface, and reports every agency whose rows lag the
+index (or are missing entirely).
+
+The check runs against whatever the MCP server is configured to read: the R2 Data
+Catalog (Iceberg) when ``R2_CATALOG_*`` is set, otherwise the public monolithic
+``comments.parquet``. So it validates the *actual* surface users query.
+
+Usage:
+    uv run python scripts/check_comments_freshness.py
+    uv run python scripts/check_comments_freshness.py --agency OMB
+    uv run python scripts/check_comments_freshness.py --limit 50
+
+Exit code is 1 when any agency is flagged (so it can drive a cron/CI alert), 0
+otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from spicy_regs import mcp_server
+
+# Per-agency: index's latest (year, month) as YYYYMM vs the latest posted_date
+# month actually present in the comments rows. A frugal aggregation — MAX is
+# streaming and the GROUP BY is ~hundreds of agencies — so it stays well within
+# memory even over tens of millions of comment rows.
+_FRESHNESS_SQL = """
+WITH idx AS (
+    SELECT agency_code,
+           MAX(year * 100 + month) AS idx_max_ym,
+           CAST(SUM(row_count) AS BIGINT) AS idx_rows
+    FROM comments_index
+    {idx_where}
+    GROUP BY agency_code
+),
+rows AS (
+    SELECT agency_code,
+           MAX(
+               EXTRACT(YEAR FROM CAST(posted_date AS TIMESTAMP)) * 100
+               + EXTRACT(MONTH FROM CAST(posted_date AS TIMESTAMP))
+           ) AS rows_max_ym,
+           COUNT(*) AS actual_rows
+    FROM comments
+    WHERE posted_date IS NOT NULL
+    {rows_where}
+    GROUP BY agency_code
+)
+SELECT i.agency_code,
+       i.idx_max_ym,
+       r.rows_max_ym,
+       i.idx_rows,
+       COALESCE(r.actual_rows, 0) AS actual_rows
+FROM idx i
+LEFT JOIN rows r USING (agency_code)
+WHERE r.agency_code IS NULL
+   OR r.rows_max_ym IS NULL
+   OR r.rows_max_ym < i.idx_max_ym
+ORDER BY i.idx_rows DESC
+"""
+
+
+def _fmt_ym(ym: int | None) -> str:
+    if ym is None:
+        return "—"
+    return f"{ym // 100:04d}-{ym % 100:02d}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agency", help="Restrict the check to a single agency_code")
+    parser.add_argument(
+        "--limit", type=int, default=100, help="Max flagged agencies to print (default 100)"
+    )
+    args = parser.parse_args()
+
+    if args.agency:
+        safe = args.agency.replace("'", "''")
+        idx_where = f"WHERE agency_code = '{safe}'"
+        rows_where = f"AND agency_code = '{safe}'"
+    else:
+        idx_where = ""
+        rows_where = ""
+
+    sql = _FRESHNESS_SQL.format(idx_where=idx_where, rows_where=rows_where)
+
+    con = mcp_server._connect()
+    try:
+        flagged = con.execute(sql).fetchall()
+    finally:
+        con.close()
+
+    if not flagged:
+        print("OK: every agency's comment rows are at least as current as the index.")
+        return 0
+
+    print(f"STALE: {len(flagged)} agency partition(s) lag the comments index\n")
+    print(f"{'agency':<10} {'index_to':<9} {'rows_to':<9} {'index_rows':>12} {'actual_rows':>12}")
+    print("-" * 56)
+    for agency, idx_ym, rows_ym, idx_rows, actual_rows in flagged[: args.limit]:
+        print(
+            f"{agency:<10} {_fmt_ym(idx_ym):<9} {_fmt_ym(rows_ym):<9} "
+            f"{idx_rows:>12,} {actual_rows:>12,}"
+        )
+    if len(flagged) > args.limit:
+        print(f"... and {len(flagged) - args.limit} more (raise --limit to see them)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -15,6 +15,7 @@ tool surface (names, parameters, behavior) in sync between the two files;
 
 from __future__ import annotations
 
+import logging
 import os
 import tempfile
 import threading
@@ -47,6 +48,17 @@ TABLES = (
     "agency_monthly_volume",
 )
 STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "30s")
+
+logger = logging.getLogger(__name__)
+
+# DuckDB alias the R2 Data Catalog is attached under (mirrors
+# ``spicy_regs.sources.iceberg._CATALOG_ALIAS``). When the catalog is
+# configured, the ``comments`` view is served from it instead of the monolithic
+# ``comments.parquet`` — the comments table is too large to keep republishing as
+# a single file, so the catalog is its read surface. All other tables stay on
+# the public Parquet snapshots.
+CATALOG_ALIAS = "reg_catalog"
+DEFAULT_CATALOG_NAMESPACE = "default"
 
 
 def _parse_timeout_seconds(raw: str) -> float | None:
@@ -131,6 +143,36 @@ def _resolve_home_directory() -> str:
 HOME_DIRECTORY = _resolve_home_directory()
 
 
+def _resolve_catalog_config() -> dict[str, str] | None:
+    """Return R2 Data Catalog connection settings, or ``None`` when unconfigured.
+
+    The catalog is optional: when ``R2_CATALOG_URI`` / ``R2_CATALOG_WAREHOUSE`` /
+    ``R2_CATALOG_TOKEN`` are all present the ``comments`` view is served from the
+    Iceberg catalog; otherwise the server falls back to the monolithic
+    ``comments.parquet`` (the dual model). The token used here should be a
+    read-scoped R2 API token — this is a public, read-only server.
+
+    Values are inlined into ``CREATE SECRET`` / ``ATTACH`` (which take no bind
+    parameters), so any value containing a quote, backslash, or control
+    character is rejected outright rather than escaped.
+    """
+    uri = os.environ.get("R2_CATALOG_URI")
+    warehouse = os.environ.get("R2_CATALOG_WAREHOUSE")
+    token = os.environ.get("R2_CATALOG_TOKEN")
+    if not (uri and warehouse and token):
+        return None
+    config = {
+        "uri": uri,
+        "warehouse": warehouse,
+        "token": token,
+        "namespace": os.environ.get("R2_CATALOG_NAMESPACE", DEFAULT_CATALOG_NAMESPACE),
+    }
+    for key, value in config.items():
+        if any(c in value for c in ("'", "\\", "\x00", "\n", "\r")):
+            raise RuntimeError(f"R2 catalog {key} contains illegal characters")
+    return config
+
+
 def _jsonify(value: Any) -> Any:
     """Coerce DuckDB row values into JSON-serializable forms."""
     if value is None or isinstance(value, (str, int, float, bool)):
@@ -180,6 +222,31 @@ def _apply_security_settings(con: duckdb.DuckDBPyConnection) -> None:
     con.execute("SET lock_configuration=true")
 
 
+def _attach_catalog(con: duckdb.DuckDBPyConnection, config: dict[str, str]) -> bool:
+    """Attach the R2 Data Catalog so the ``comments`` view can read from it.
+
+    Best-effort: if the iceberg extension or the attach fails (bad token,
+    network, catalog down) the server stays up by falling back to the monolithic
+    ``comments.parquet``. Must run before :func:`_apply_security_settings` locks
+    the configuration. Returns ``True`` only when the catalog is attached.
+    """
+    try:
+        con.execute("INSTALL iceberg")
+        con.execute("LOAD iceberg")
+        con.execute(
+            "CREATE OR REPLACE SECRET r2_catalog_secret "
+            f"(TYPE ICEBERG, TOKEN '{config['token']}');"
+        )
+        con.execute(
+            f"ATTACH '{config['warehouse']}' AS {CATALOG_ALIAS} "
+            f"(TYPE ICEBERG, ENDPOINT '{config['uri']}');"
+        )
+        return True
+    except duckdb.Error as exc:
+        logger.warning("R2 catalog attach failed; comments fall back to monolith: %s", exc)
+        return False
+
+
 def _connect() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
     # Must precede INSTALL/LOAD: that step writes the extension under
@@ -188,8 +255,28 @@ def _connect() -> duckdb.DuckDBPyConnection:
     con.execute(f"SET home_directory='{HOME_DIRECTORY.replace(chr(39), chr(39) * 2)}'")
     con.execute("INSTALL httpfs")
     con.execute("LOAD httpfs")
+
+    # Optionally attach the Iceberg catalog (before the config lock) so the
+    # comments view can be served from it.
+    catalog = _resolve_catalog_config()
+    catalog_attached = catalog is not None and _attach_catalog(con, catalog)
+
     _apply_security_settings(con)
     for name in TABLES:
+        if name == "comments" and catalog_attached:
+            namespace = catalog["namespace"]  # type: ignore[index]
+            try:
+                con.execute(
+                    f'CREATE VIEW comments AS SELECT * FROM '
+                    f'{CATALOG_ALIAS}."{namespace}"."comments"'
+                )
+                continue
+            except duckdb.Error as exc:
+                # Catalog reachable but the table isn't there yet — fall back to
+                # the monolith rather than breaking every query on the server.
+                logger.warning(
+                    "comments not available in catalog; falling back to monolith: %s", exc
+                )
         url = f"{R2_BASE_URL}/{name}.parquet"
         con.execute(f"CREATE VIEW {name} AS SELECT * FROM read_parquet('{url}')")
     return con

--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -156,6 +156,14 @@ class RegulationsPipeline(Pipeline):
             if changed_comments:
                 logger.info("Uploading {} changed comment partitions...", len(changed_comments))
                 r2.upload_comment_partitions(output_dir, changed_comments)
+            # Iceberg comments path: the MERGE wrote the rows through the catalog
+            # (not under the public comments/ prefix), so there are no partition
+            # files to push — only the refreshed index needs publishing.
+            elif self.use_iceberg and staged.get("comments", 0) > 0:
+                index_file = output_dir / "comments_index.parquet"
+                if index_file.exists():
+                    logger.info("Uploading refreshed comments index (Iceberg path)...")
+                    r2.upload_file(index_file, remote_key="comments_index.parquet")
             # Publish the search index when this run rebuilt it (dockets changed).
             search_index = output_dir / INDEX_FILENAME
             if not self.skip_post_process and staged.get("dockets", 0) > 0 and search_index.exists():
@@ -224,12 +232,15 @@ class RegulationsPipeline(Pipeline):
 
         When ``use_iceberg`` is set, the ``dockets`` table is routed through the
         R2 Data Catalog (Iceberg ``MERGE INTO`` + public Parquet export) instead
-        of the whole-file ``merge_staging_files`` rewrite. This is the
-        proof-of-concept scope — documents and comments stay on the existing
-        path until the Iceberg flow is vetted.
+        of the whole-file ``merge_staging_files`` rewrite, and ``comments`` are
+        routed through :func:`iceberg.merge_comments` (row-level upsert into the
+        catalog + index rebuild, no monolithic export) instead of the
+        partitioned ``merge_comments_partitioned`` path. ``documents`` stay on
+        the existing whole-file path until the Iceberg flow is vetted for them.
 
         Returns the comment partition files changed this run (empty when no
-        comments were staged), so the caller can publish exactly those to R2.
+        comments were staged or when comments went through Iceberg), so the
+        caller can publish exactly those to R2.
         """
         names = [rt.name for rt in record_types]
 
@@ -252,14 +263,21 @@ class RegulationsPipeline(Pipeline):
 
         changed_comments: list[Path] = []
         if "comments" in names and staged.get("comments", 0) > 0:
-            changed_comments = merge_comments_partitioned(
-                staging_dir,
-                output_dir,
-                schema=RECORD_TYPES["comments"].schema,
-                dedup_key=RECORD_TYPES["comments"].dedup_key,
-            )
-            if changed_comments:
-                update_comments_index(output_dir, changed_comments)
+            if self.use_iceberg:
+                # Row-level upsert into the catalog table (the read surface) and
+                # rebuild the index. No partition files are produced, so
+                # changed_comments stays empty and the caller publishes only the
+                # refreshed index.
+                iceberg.merge_comments(staging_dir, output_dir, RECORD_TYPES["comments"])
+            else:
+                changed_comments = merge_comments_partitioned(
+                    staging_dir,
+                    output_dir,
+                    schema=RECORD_TYPES["comments"].schema,
+                    dedup_key=RECORD_TYPES["comments"].dedup_key,
+                )
+                if changed_comments:
+                    update_comments_index(output_dir, changed_comments)
         return changed_comments
 
 

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -18,6 +18,13 @@ of :mod:`spicy_regs.sources.r2`:
 * :func:`merge_and_export` — ensure the table exists, MERGE the per-agency
   staging Parquet in, then export a public ``{name}.parquet`` snapshot so the
   no-credentials CLI / MCP read path keeps working (the "dual model").
+* :func:`merge_comments` — the comments variant. Comments are tens of millions
+  of rows, so there is no monolithic ``comments.parquet`` snapshot to keep
+  fresh; the catalog table *is* the read surface (the MCP server queries it
+  directly when the catalog is configured). Instead of exporting the whole
+  table, this MERGEs the staged rows and rebuilds the tiny
+  ``comments_index.parquet`` (per-partition row counts) that the feed summary
+  and agency rollups read for comment counts.
 
 Credentials are read from the environment, alongside the existing ``R2_*`` vars:
 
@@ -177,6 +184,76 @@ def _export_parquet(con, record_type: RecordType, output_dir: Path) -> Path:
         """
     )
     return out_file
+
+
+def _build_comments_index(con, record_type: RecordType, output_dir: Path) -> Path:
+    """Rebuild ``comments_index.parquet`` from the catalog comments table.
+
+    The index is the small per-``(agency_code, docket_id, year, month)`` row-count
+    artifact that ``build_feed_summary`` / ``build_agency_rollups`` read instead
+    of scanning the full comments table. With comments living in the catalog
+    there is no partitioned ``comments/`` tree to count, so the index is derived
+    straight from the table — keeping the same schema (agency_code, docket_id,
+    year, month, row_count) ``transforms.update_comments_index`` produces.
+
+    ``year`` / ``month`` come from ``posted_date`` to match the partitioning the
+    legacy path used; ``docket_id`` is trimmed of stray quotes for the same
+    reason. Written atomically via a temp file so a crashed rebuild can't leave a
+    half-written index in place.
+    """
+    index_file = output_dir / "comments_index.parquet"
+    tmp_file = index_file.with_suffix(".tmp.parquet")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    con.execute(
+        f"""
+        COPY (
+            SELECT
+                agency_code,
+                TRIM(docket_id, '"') AS docket_id,
+                EXTRACT(YEAR FROM CAST(posted_date AS TIMESTAMP))::BIGINT AS year,
+                EXTRACT(MONTH FROM CAST(posted_date AS TIMESTAMP))::BIGINT AS month,
+                CAST(COUNT(*) AS BIGINT) AS row_count
+            FROM {_qualified(record_type)}
+            WHERE posted_date IS NOT NULL
+              AND agency_code IS NOT NULL
+              AND docket_id IS NOT NULL
+            GROUP BY 1, 2, 3, 4
+        ) TO '{_sql_str(str(tmp_file))}' (FORMAT PARQUET, COMPRESSION ZSTD);
+        """
+    )
+    tmp_file.replace(index_file)
+    return index_file
+
+
+def merge_comments(staging_dir: Path, output_dir: Path, record_type: RecordType) -> Path | None:
+    """Upsert staged comments into the catalog, then rebuild the comments index.
+
+    Unlike :func:`merge_and_export`, this does **not** write a monolithic
+    ``comments.parquet`` — the comments table is too large to re-export on every
+    run, and the catalog is the read surface. Returns the path to the refreshed
+    ``comments_index.parquet`` (which the pipeline publishes to R2), or ``None``
+    when there was nothing staged.
+    """
+    staging_files = _staging_files(staging_dir, record_type)
+    if not staging_files:
+        logger.info("iceberg: no staging files for {}; skipping merge", record_type.name)
+        return None
+
+    con = _connect()
+    try:
+        _ensure_table(con, record_type)
+        logger.info(
+            "iceberg: MERGE {} staging file(s) into {}",
+            len(staging_files), _qualified(record_type),
+        )
+        _merge(con, staging_files, record_type)
+        total = con.execute(f"SELECT count(*) FROM {_qualified(record_type)}").fetchone()[0]
+        logger.info("iceberg: {} now holds {:,} rows", record_type.name, total)
+        index_file = _build_comments_index(con, record_type, output_dir)
+        logger.info("iceberg: rebuilt comments index at {}", index_file)
+        return index_file
+    finally:
+        con.close()
 
 
 def merge_and_export(staging_dir: Path, output_dir: Path, record_type: RecordType) -> Path | None:

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -16,7 +16,7 @@ import duckdb
 import polars as pl
 import pytest
 
-from spicy_regs.schemas import DOCKET
+from spicy_regs.schemas import COMMENT, DOCKET
 from spicy_regs.sources import iceberg
 
 
@@ -25,6 +25,25 @@ def _write_staging(staging_dir: Path, agency: str, rows: list[dict]) -> None:
     type_dir = staging_dir / DOCKET.name
     type_dir.mkdir(parents=True, exist_ok=True)
     pl.DataFrame(rows, schema=DOCKET.schema).write_parquet(type_dir / f"{agency}.parquet")
+
+
+def _write_comment_staging(staging_dir: Path, agency: str, rows: list[dict]) -> None:
+    """Mimic transforms.write_staging: staging_dir/comments/{agency}.parquet."""
+    type_dir = staging_dir / COMMENT.name
+    type_dir.mkdir(parents=True, exist_ok=True)
+    pl.DataFrame(rows, schema=COMMENT.schema).write_parquet(type_dir / f"{agency}.parquet")
+
+
+def _comment(comment_id: str, docket_id: str, agency: str, posted_date: str, modify_date: str | None = None) -> dict:
+    row = {col: None for col in COMMENT.schema}
+    row.update(
+        comment_id=comment_id,
+        docket_id=docket_id,
+        agency_code=agency,
+        posted_date=posted_date,
+        modify_date=modify_date or posted_date,
+    )
+    return row
 
 
 @pytest.fixture
@@ -146,3 +165,82 @@ def test_export_parquet_matches_published_shape(tmp_path, local_catalog) -> None
 def test_merge_and_export_noop_without_staging(tmp_path) -> None:
     # No staging files for dockets -> returns None and never touches the catalog.
     assert iceberg.merge_and_export(tmp_path / "empty", tmp_path / "out", DOCKET) is None
+
+
+# --- comments path (catalog table + derived index) -------------------------
+
+
+def test_build_comments_index_counts_per_partition(tmp_path, local_catalog) -> None:
+    """The index derived from the catalog must hold one row per
+    (agency, docket, year, month) with the right counts and schema."""
+    con = local_catalog
+    iceberg._ensure_table(con, COMMENT)
+
+    staging = tmp_path / "staging"
+    _write_comment_staging(
+        staging,
+        "EPA",
+        [
+            # Two comments in the same partition (EPA, EPA-1, 2025-01).
+            _comment("c1", "EPA-1", "EPA", "2025-01-15T00:00:00Z"),
+            _comment("c2", "EPA-1", "EPA", "2025-01-20T00:00:00Z"),
+            # A different month -> its own partition.
+            _comment("c3", "EPA-1", "EPA", "2025-02-03T00:00:00Z"),
+            # A different docket.
+            _comment("c4", "EPA-2", "EPA", "2025-01-09T00:00:00Z"),
+        ],
+    )
+    iceberg._merge(con, iceberg._staging_files(staging, COMMENT), COMMENT)
+
+    out = tmp_path / "output"
+    index_file = iceberg._build_comments_index(con, COMMENT, out)
+    assert index_file == out / "comments_index.parquet"
+
+    df = pl.read_parquet(index_file)
+    assert set(df.columns) == {"agency_code", "docket_id", "year", "month", "row_count"}
+    got = {
+        (r["agency_code"], r["docket_id"], r["year"], r["month"]): r["row_count"]
+        for r in df.iter_rows(named=True)
+    }
+    assert got == {
+        ("EPA", "EPA-1", 2025, 1): 2,
+        ("EPA", "EPA-1", 2025, 2): 1,
+        ("EPA", "EPA-2", 2025, 1): 1,
+    }
+
+
+def test_build_comments_index_rebuilds_after_merge(tmp_path, local_catalog) -> None:
+    """A second merge (new rows + a dedup'd update) must be reflected in a
+    full index rebuild — the index always mirrors the current table."""
+    con = local_catalog
+    iceberg._ensure_table(con, COMMENT)
+    out = tmp_path / "output"
+
+    s1 = tmp_path / "s1"
+    _write_comment_staging(s1, "EPA", [_comment("c1", "EPA-1", "EPA", "2025-01-15T00:00:00Z")])
+    iceberg._merge(con, iceberg._staging_files(s1, COMMENT), COMMENT)
+    iceberg._build_comments_index(con, COMMENT, out)
+
+    s2 = tmp_path / "s2"
+    _write_comment_staging(
+        s2,
+        "EPA",
+        [
+            # Re-posted c1 (same id) must not inflate the count.
+            _comment("c1", "EPA-1", "EPA", "2025-01-15T00:00:00Z", modify_date="2025-03-01T00:00:00Z"),
+            _comment("c5", "EPA-1", "EPA", "2025-01-25T00:00:00Z"),
+        ],
+    )
+    iceberg._merge(con, iceberg._staging_files(s2, COMMENT), COMMENT)
+    index_file = iceberg._build_comments_index(con, COMMENT, out)
+
+    df = pl.read_parquet(index_file)
+    assert df.height == 1
+    row = next(df.iter_rows(named=True))
+    assert (row["agency_code"], row["docket_id"], row["year"], row["month"]) == ("EPA", "EPA-1", 2025, 1)
+    assert row["row_count"] == 2  # c1 (deduped) + c5
+
+
+def test_merge_comments_noop_without_staging(tmp_path) -> None:
+    # No staged comments -> returns None and never touches the catalog.
+    assert iceberg.merge_comments(tmp_path / "empty", tmp_path / "out", COMMENT) is None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -89,6 +89,59 @@ def test_vercel_copy_in_sync():
     assert vercel.TABLES == mcp_server.TABLES
     assert vercel.INSTRUCTIONS == mcp_server.INSTRUCTIONS
     assert vercel.DEFAULT_R2_BASE_URL == mcp_server.DEFAULT_R2_BASE_URL
+    # The catalog-backed comments path must stay identical across the two copies.
+    assert vercel.CATALOG_ALIAS == mcp_server.CATALOG_ALIAS
+    assert vercel.DEFAULT_CATALOG_NAMESPACE == mcp_server.DEFAULT_CATALOG_NAMESPACE
+
+
+# --- catalog config resolution ----------------------------------------------
+
+_CATALOG_ENV = ("R2_CATALOG_URI", "R2_CATALOG_WAREHOUSE", "R2_CATALOG_TOKEN")
+
+
+@pytest.mark.parametrize("module_name", ["canonical", "vercel"])
+def test_resolve_catalog_config_none_when_unset(module_name, monkeypatch):
+    module = mcp_server if module_name == "canonical" else _load_vercel_copy()
+    for var in (*_CATALOG_ENV, "R2_CATALOG_NAMESPACE"):
+        monkeypatch.delenv(var, raising=False)
+    assert module._resolve_catalog_config() is None
+
+
+@pytest.mark.parametrize("module_name", ["canonical", "vercel"])
+def test_resolve_catalog_config_partial_is_none(module_name, monkeypatch):
+    """Missing any one of the three required vars => disabled (fall back)."""
+    module = mcp_server if module_name == "canonical" else _load_vercel_copy()
+    monkeypatch.setenv("R2_CATALOG_URI", "https://catalog.example/x")
+    monkeypatch.setenv("R2_CATALOG_WAREHOUSE", "wh")
+    monkeypatch.delenv("R2_CATALOG_TOKEN", raising=False)
+    assert module._resolve_catalog_config() is None
+
+
+@pytest.mark.parametrize("module_name", ["canonical", "vercel"])
+def test_resolve_catalog_config_full(module_name, monkeypatch):
+    module = mcp_server if module_name == "canonical" else _load_vercel_copy()
+    monkeypatch.setenv("R2_CATALOG_URI", "https://catalog.example/x")
+    monkeypatch.setenv("R2_CATALOG_WAREHOUSE", "wh")
+    monkeypatch.setenv("R2_CATALOG_TOKEN", "secret-token")
+    monkeypatch.delenv("R2_CATALOG_NAMESPACE", raising=False)
+    config = module._resolve_catalog_config()
+    assert config == {
+        "uri": "https://catalog.example/x",
+        "warehouse": "wh",
+        "token": "secret-token",
+        "namespace": module.DEFAULT_CATALOG_NAMESPACE,
+    }
+
+
+@pytest.mark.parametrize("module_name", ["canonical", "vercel"])
+def test_resolve_catalog_config_rejects_injection(module_name, monkeypatch):
+    """Values are inlined into CREATE SECRET / ATTACH, so quotes are rejected."""
+    module = mcp_server if module_name == "canonical" else _load_vercel_copy()
+    monkeypatch.setenv("R2_CATALOG_URI", "https://catalog.example/x")
+    monkeypatch.setenv("R2_CATALOG_WAREHOUSE", "wh'); DROP")
+    monkeypatch.setenv("R2_CATALOG_TOKEN", "t")
+    with pytest.raises(RuntimeError, match="illegal characters"):
+        module._resolve_catalog_config()
 
 
 # --- Connection sandbox -----------------------------------------------------


### PR DESCRIPTION
## Summary

The row-level `comments` read surface had drifted months behind its counts. `comments_index` (and the rollups built from it — `feed_summary`, `agency_stats`) were current, but the `comments` view in both MCP servers reads the **monolithic `comments.parquet`**, which the new partitioned pipeline no longer rebuilds. So comment *counts* looked current while `SELECT ... FROM comments` returned stale data.

**Confirmed against live R2** (docket OMB-2026-0034): `comments_index` reports ~39,275 comments for 2026-05/06 and the partition file `comments/agency_code=OMB/.../year=2026/month=6/part-0.parquet` exists with 39,173 rows — but `comments` returns **0** for OMB in 2026 (its monolith froze at 2025-10-15). The lag is **global**, not OMB-only: nearly every active agency's `max(posted_date)` in the monolith trails the index (most ~2026-04-03, the new-pipeline cutover).

Row materialization is **not** failing — the partitions are fine. The bug is the read path. A glob over the partitioned tree can't fix it because the public HTTPS R2 surface has no directory listing (`Globs for generic HTTP file are not supported`), which is exactly why a monolith existed.

This PR makes the **R2 Data Catalog (Iceberg)** the comments read surface, eliminating the two-surface drift at its root:

- **`iceberg.merge_comments`** — row-level `MERGE` of staged comments into the catalog table + a full rebuild of `comments_index.parquet` from the catalog (no monolithic export). The full rebuild also removes the latent per-batch index-clobber risk of the partition path.
- **`RegulationsPipeline`** routes comments through `iceberg.merge_comments` when `--use-iceberg` is set, publishing only the refreshed index (rows are written through the catalog, not the public `comments/` prefix).
- **Both MCP servers** (canonical `src/spicy_regs/mcp_server.py` + the Vercel copy `mcp-server/api/index.py`) serve the `comments` view from the catalog when `R2_CATALOG_*` is configured, with **resilient fallback** to the monolith if the catalog is absent, unreachable, or the table doesn't exist yet — so a deploy without the catalog can't break the public read server.
- **`scripts/check_comments_freshness.py`** — monitoring check that flags agencies whose comment rows lag the index's latest month, against whichever surface the server is configured to read.

### Cutover (deliberately gated — no behavior change on merge)

This delivers the capability + a safe fallback; it does not flip production. To activate:
1. Run the ETL with `--use-iceberg` (catalog credentials present) so the `comments` table is populated and the index is rebuilt from it.
2. Deploy a **read-scoped** `R2_CATALOG_TOKEN` (+ `R2_CATALOG_URI` / `R2_CATALOG_WAREHOUSE`) to the MCP read servers.
3. Validate big scans fit the 30s statement cap and add Iceberg file compaction before high query volume.

⚠️ I could not validate the live catalog path from this environment (no R2 Data Catalog credentials). The catalog read/merge paths are exercised by unit tests against a local in-memory DuckDB catalog; an end-to-end run against R2 still needs a manual `--use-iceberg` vetting run.

## Test plan

- [x] `uv run pytest` — 221 passed, 3 deselected
- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ty check` — All checks passed
- [x] New unit tests: catalog-derived `comments_index` counts + dedup (`test_iceberg.py`), catalog config resolution/injection-rejection + Vercel-copy parity (`test_mcp_server.py`)
- [x] `scripts/check_comments_freshness.py --help` runs; query verified by hand against live R2 (reproduces the per-agency staleness)
- [ ] End-to-end `--use-iceberg` comments run against the live R2 Data Catalog (needs credentials — see cutover notes)

## Checklist

- [x] My change is scoped to one concern
- [x] I added or updated tests for new behavior
- [x] I updated docs (data-layout reference + ETL workflow input) where relevant
- [ ] CI is green (pending)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYfkX8CKUCgbbmAfzNRXjQ)_