### PR TITLE
Default the catalog namespace when the env var is empty

### DIFF
--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -165,7 +165,9 @@ def _resolve_catalog_config() -> dict[str, str] | None:
         "uri": uri,
         "warehouse": warehouse,
         "token": token,
-        "namespace": os.environ.get("R2_CATALOG_NAMESPACE", DEFAULT_CATALOG_NAMESPACE),
+        # `or DEFAULT` (not get's default arg) so an env var set to an empty
+        # string falls back to the default namespace rather than "".
+        "namespace": os.environ.get("R2_CATALOG_NAMESPACE") or DEFAULT_CATALOG_NAMESPACE,
     }
     for key, value in config.items():
         if any(c in value for c in ("'", "\\", "\x00", "\n", "\r")):

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -165,7 +165,9 @@ def _resolve_catalog_config() -> dict[str, str] | None:
         "uri": uri,
         "warehouse": warehouse,
         "token": token,
-        "namespace": os.environ.get("R2_CATALOG_NAMESPACE", DEFAULT_CATALOG_NAMESPACE),
+        # `or DEFAULT` (not get's default arg) so an env var set to an empty
+        # string falls back to the default namespace rather than "".
+        "namespace": os.environ.get("R2_CATALOG_NAMESPACE") or DEFAULT_CATALOG_NAMESPACE,
     }
     for key, value in config.items():
         if any(c in value for c in ("'", "\\", "\x00", "\n", "\r")):

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -54,7 +54,10 @@ def is_configured() -> bool:
 
 
 def _namespace() -> str:
-    return getenv("R2_CATALOG_NAMESPACE", "default")
+    # `or "default"` (not getenv's default arg) so an env var set to an empty
+    # string — e.g. a GitHub Actions `${{ secrets.R2_CATALOG_NAMESPACE }}` that
+    # resolves to "" when the secret is unset — still falls back to "default".
+    return getenv("R2_CATALOG_NAMESPACE") or "default"
 
 
 def _schema_ref() -> str:

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -73,6 +73,16 @@ def test_is_configured(monkeypatch) -> None:
     assert iceberg.is_configured() is True
 
 
+def test_namespace_empty_defaults(monkeypatch) -> None:
+    # Unset -> default; explicitly empty (e.g. an unset GH secret) -> default too.
+    monkeypatch.delenv("R2_CATALOG_NAMESPACE", raising=False)
+    assert iceberg._namespace() == "default"
+    monkeypatch.setenv("R2_CATALOG_NAMESPACE", "")
+    assert iceberg._namespace() == "default"
+    monkeypatch.setenv("R2_CATALOG_NAMESPACE", "custom")
+    assert iceberg._namespace() == "custom"
+
+
 def test_connect_raises_when_unconfigured(monkeypatch) -> None:
     for var in iceberg._REQUIRED_ENV:
         monkeypatch.delenv(var, raising=False)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -134,6 +134,19 @@ def test_resolve_catalog_config_full(module_name, monkeypatch):
 
 
 @pytest.mark.parametrize("module_name", ["canonical", "vercel"])
+def test_resolve_catalog_config_empty_namespace_defaults(module_name, monkeypatch):
+    """An empty R2_CATALOG_NAMESPACE (e.g. an unset GH secret -> "") -> default."""
+    module = mcp_server if module_name == "canonical" else _load_vercel_copy()
+    monkeypatch.setenv("R2_CATALOG_URI", "https://catalog.example/x")
+    monkeypatch.setenv("R2_CATALOG_WAREHOUSE", "wh")
+    monkeypatch.setenv("R2_CATALOG_TOKEN", "t")
+    monkeypatch.setenv("R2_CATALOG_NAMESPACE", "")
+    config = module._resolve_catalog_config()
+    assert config is not None
+    assert config["namespace"] == module.DEFAULT_CATALOG_NAMESPACE
+
+
+@pytest.mark.parametrize("module_name", ["canonical", "vercel"])
 def test_resolve_catalog_config_rejects_injection(module_name, monkeypatch):
     """Values are inlined into CREATE SECRET / ATTACH, so quotes are rejected."""
     module = mcp_server if module_name == "canonical" else _load_vercel_copy()


### PR DESCRIPTION
## Summary

Surfaced while running the seed workflow: `R2_CATALOG_NAMESPACE` is optional, but a GitHub Actions `${{ secrets.R2_CATALOG_NAMESPACE }}` referencing an **unset** secret is passed to the process as an **empty string**, not absent. `getenv(name, "default")` only falls back when the var is *absent*, so the namespace would resolve to `""` — breaking the catalog table reference (`reg_catalog.""."comments"`) on the next run even once the three required catalog secrets are added.

Fix: treat an empty value as the default.
- `iceberg._namespace()` → `getenv("R2_CATALOG_NAMESPACE") or "default"`
- both MCP servers' `_resolve_catalog_config()` → `... or DEFAULT_CATALOG_NAMESPACE`

Adds regression tests for unset / empty / explicit namespace.

## Context

The seed workflow run (after #91 merged) failed fast and safely — the guard caught that the `R2_CATALOG_*` secrets are still empty in the repo (the S3 group is set; the catalog group isn't), so nothing was written. This PR just removes a foot-gun that would have caused a *second* confusing failure after those secrets are added but the optional namespace one is left blank.

## Test plan

- [x] `uv run pytest tests/test_iceberg.py tests/test_mcp_server.py` — 35 passed
- [x] `uv run ruff check .` / `uv run ty check` — clean

## Checklist

- [x] My change is scoped to one concern
- [x] I added or updated tests for new behavior
- [x] Docs n/a (internal helper behavior)
- [ ] CI is green (pending)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYfkX8CKUCgbbmAfzNRXjQ)_