### PR TITLE
Make the catalog seed idempotent per agency + raise the full-load timeout

### DIFF
--- a/.github/workflows/seed-comments-catalog.yml
+++ b/.github/workflows/seed-comments-catalog.yml
@@ -41,7 +41,10 @@ on:
 jobs:
   seed:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # The full (all-agency) load copies ~37M rows from R2 into the catalog, so
+    # give it ample headroom. The load is idempotent per agency, so even if it
+    # is interrupted a re-run safely resumes.
+    timeout-minutes: 360
 
     steps:
       - name: Checkout

--- a/scripts/seed_comments_catalog.py
+++ b/scripts/seed_comments_catalog.py
@@ -90,7 +90,9 @@ def main() -> int:
     parser.add_argument("--output-dir", type=Path, default=Path("output"))
     parser.add_argument(
         "--append", action="store_true",
-        help="Allow loading into a non-empty catalog table (default: refuse)",
+        help="Allow loading into a non-empty catalog table (default: refuse). "
+             "The load is idempotent per agency (each agency's rows are replaced), "
+             "so this is safe for resuming an interrupted run.",
     )
     parser.add_argument(
         "--upload-index", action="store_true",
@@ -111,7 +113,8 @@ def main() -> int:
         if existing and not args.append:
             logger.error(
                 "Catalog comments table already has {:,} rows. Re-run with --append "
-                "to add to it, or empty the table first.", existing,
+                "to load anyway — the load is idempotent per agency (each agency's "
+                "rows are replaced), so this is safe.", existing,
             )
             return 1
 
@@ -126,7 +129,12 @@ def main() -> int:
                 "docket_id=*/year=*/month=*/part-0.parquet"
             )
             try:
-                total = iceberg.seed_comments_from_parquet(con, glob, COMMENT)
+                # replace_agency makes each agency load idempotent: a re-run
+                # (resume after a timeout, or over an already-seeded table)
+                # replaces that agency's rows rather than duplicating them.
+                total = iceberg.seed_comments_from_parquet(
+                    con, glob, COMMENT, replace_agency=agency
+                )
             except Exception as exc:  # noqa: BLE001 — keep going, report at the end
                 logger.warning("  [{}/{}] {}: skipped ({})", i, len(agencies), agency, exc)
                 continue

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -228,7 +228,9 @@ def _build_comments_index(con, record_type: RecordType, output_dir: Path) -> Pat
     return index_file
 
 
-def seed_comments_from_parquet(con, source_glob: str, record_type: RecordType) -> int:
+def seed_comments_from_parquet(
+    con, source_glob: str, record_type: RecordType, replace_agency: str | None = None
+) -> int:
     """Bulk-load published comment Parquet into the catalog table; return its count.
 
     One-time cutover helper: the partitioned ``comments/`` tree on R2 is already
@@ -238,6 +240,12 @@ def seed_comments_from_parquet(con, source_glob: str, record_type: RecordType) -
     ``agency_code`` / ``docket_id`` as columns (year/month live only in the path
     and are not table columns).
 
+    When ``replace_agency`` is given, all existing rows for that ``agency_code``
+    are deleted before the insert. The loader runs one agency at a time, so this
+    makes each agency load idempotent — re-running (after a timeout, or over an
+    already-seeded table) replaces that agency's rows instead of duplicating
+    them, since the plain ``INSERT`` does no dedup.
+
     Columns absent from every file in the glob (an older partition written before
     a column was added) are inserted as ``NULL`` — mirroring the schema-evolution
     handling in ``transforms.merge_comments_partitioned`` — so a mixed-vintage
@@ -246,6 +254,11 @@ def seed_comments_from_parquet(con, source_glob: str, record_type: RecordType) -
     """
     columns = list(record_type.schema)
     esc = _sql_str(source_glob)
+    if replace_agency is not None:
+        con.execute(
+            f"DELETE FROM {_qualified(record_type)} "
+            f"WHERE agency_code = '{_sql_str(replace_agency)}';"
+        )
     present = {
         row[0]
         for row in con.execute(

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -306,6 +306,43 @@ def test_seed_comments_from_parquet_loads_partition_tree(tmp_path, local_catalog
     ]
 
 
+def test_seed_comments_replace_agency_is_idempotent(tmp_path, local_catalog) -> None:
+    """Loading the same agency twice with replace_agency must not duplicate rows."""
+    con = local_catalog
+    iceberg._ensure_table(con, COMMENT)
+
+    comments_dir = tmp_path / "comments"
+    _write_partition(
+        comments_dir, "EPA", "EPA-1", 2025, 1,
+        [
+            _comment("c1", "EPA-1", "EPA", "2025-01-15T00:00:00Z"),
+            _comment("c2", "EPA-1", "EPA", "2025-01-20T00:00:00Z"),
+        ],
+    )
+    glob = str(comments_dir / "agency_code=EPA/docket_id=*/year=*/month=*/part-0.parquet")
+
+    first = iceberg.seed_comments_from_parquet(con, glob, COMMENT, replace_agency="EPA")
+    assert first == 2
+    # Re-running the same agency replaces, not appends.
+    second = iceberg.seed_comments_from_parquet(con, glob, COMMENT, replace_agency="EPA")
+    assert second == 2
+
+    # A different agency present in the table is untouched by replacing EPA.
+    _write_partition(
+        comments_dir, "DOL", "DOL-1", 2025, 3,
+        [_comment("d1", "DOL-1", "DOL", "2025-03-01T00:00:00Z")],
+    )
+    dol_glob = str(comments_dir / "agency_code=DOL/docket_id=*/year=*/month=*/part-0.parquet")
+    iceberg.seed_comments_from_parquet(con, dol_glob, COMMENT, replace_agency="DOL")
+    iceberg.seed_comments_from_parquet(con, glob, COMMENT, replace_agency="EPA")  # again
+    counts = dict(
+        con.execute(
+            f'SELECT agency_code, count(*) FROM {iceberg._qualified(COMMENT)} GROUP BY agency_code'
+        ).fetchall()
+    )
+    assert counts == {"EPA": 2, "DOL": 1}
+
+
 def test_seed_comments_tolerates_missing_columns(tmp_path, local_catalog) -> None:
     """An older partition missing a later-added column loads with NULLs, not an error."""
     con = local_catalog


### PR DESCRIPTION
## Summary

The OMB smoke run (workflow run #2) succeeded — it loaded **382,202** OMB rows into the catalog and rebuilt the index, validating the whole path (catalog `ATTACH` → S3 partition read → `INSERT` → index rebuild). This PR hardens the loader before the full all-agency run.

The seed uses a plain `INSERT` (no dedup), so re-running it would duplicate rows — a problem because (a) the OMB smoke test already populated the table, and (b) a full ~37M-row load could hit the workflow timeout mid-run with no clean resume.

- **Idempotent per agency**: `seed_comments_from_parquet` now takes `replace_agency`, deleting that `agency_code`'s existing rows before inserting. The loader already runs one agency at a time, so a re-run (resume after a timeout, or over an already-seeded table) **replaces** an agency rather than duplicating it. Other agencies are untouched.
- **Timeout 120 → 360 min** on the seed workflow, since the full load copies ~37M rows from R2. With idempotency, an interrupted run is safe to resume.
- Updated `--append` help + the non-empty-table guard message to reflect the idempotent semantics.

## Test plan

- [x] `uv run pytest tests/test_iceberg.py` — 13 passed (new: re-running an agency replaces, doesn't duplicate; other agencies untouched)
- [x] `uv run ruff check .` / `uv run ty check` — clean
- [x] script `--help` + workflow YAML parse

## Next step after merge

Dispatch the workflow with `full_load: true` + `append: true` (OMB is already present) to seed all agencies, then run `check_comments_freshness.py`.

## Checklist

- [x] Scoped to one concern
- [x] Added tests for new behavior
- [ ] CI green (pending)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYfkX8CKUCgbbmAfzNRXjQ)_