### PR TITLE
Fix connection-pool starvation in concurrent Mirrulations downloads

### DIFF
--- a/src/spicy_regs/sources/mirrulations.py
+++ b/src/spicy_regs/sources/mirrulations.py
@@ -38,9 +38,19 @@ PREFIX = "raw-data"
 DEFAULT_DOWNLOAD_WORKERS = 16
 
 
-def s3_resource() -> Any:
-    """A fresh anonymous S3 resource (one per worker keeps threads independent)."""
-    return boto3.resource("s3", region_name="us-east-1", config=BotoConfig(signature_version=UNSIGNED))
+def s3_resource(max_pool_connections: int = DEFAULT_DOWNLOAD_WORKERS) -> Any:
+    """A fresh anonymous S3 resource (one per worker keeps threads independent).
+
+    The connection pool is sized to the download concurrency: botocore defaults
+    to 10, but the reader fans GETs across ``DEFAULT_DOWNLOAD_WORKERS`` threads.
+    A pool smaller than the thread count oversubscribes — connections churn into
+    CLOSE_WAIT and the run stalls — so the pool must be at least the worker count.
+    """
+    return boto3.resource(
+        "s3",
+        region_name="us-east-1",
+        config=BotoConfig(signature_version=UNSIGNED, max_pool_connections=max_pool_connections),
+    )
 
 
 def s3_client() -> Any:
@@ -323,7 +333,9 @@ def reader_factory(
     cache = _AgencyListingCache(record_types, processed_keys=processed_keys, since_year=since_year, verbose=verbose)
     # Resolve at call time (not as a default arg) so a monkeypatched
     # ``mirrulations.s3_resource`` is honored, and each reader still gets its
-    # own resource — safe to call from the staging worker threads.
+    # own resource — safe to call from the staging worker threads. ``s3_resource``
+    # sizes its connection pool to ``DEFAULT_DOWNLOAD_WORKERS``, which matches the
+    # reader's default ``download_workers`` so the pool is never oversubscribed.
     make_resource = resource_factory or s3_resource
 
     def read(agency: str, record_type: RecordType) -> MirrulationsReader:

--- a/tests/test_mirrulations_reader.py
+++ b/tests/test_mirrulations_reader.py
@@ -216,3 +216,16 @@ def test_reader_factory_scans_each_agency_once() -> None:
     assert len(keys_by_type["dockets"]) == 1
     assert len(keys_by_type["documents"]) == 1
     assert len(keys_by_type["comments"]) == 1
+
+
+def test_s3_resource_connection_pool_fits_download_workers() -> None:
+    """The S3 resource's HTTP connection pool must be at least as large as the
+    download thread pool. Otherwise concurrent GETs oversubscribe a too-small
+    pool: connections churn into CLOSE_WAIT and the run stalls (botocore's
+    default max_pool_connections is 10, below DEFAULT_DOWNLOAD_WORKERS)."""
+    from spicy_regs.sources.mirrulations import DEFAULT_DOWNLOAD_WORKERS, s3_resource
+
+    resource = s3_resource()
+    pool_size = resource.meta.client.meta.config.max_pool_connections
+
+    assert pool_size >= DEFAULT_DOWNLOAD_WORKERS


### PR DESCRIPTION
## Follow-up to #88 (which is already merged)

#88 added concurrent per-agency downloads (`DEFAULT_DOWNLOAD_WORKERS=16`) but the boto3 resource's connection pool defaults to **10**. On a large agency, >10 concurrent GETs oversubscribe the pool: connections churn into `CLOSE_WAIT` and the extract **hangs** (observed: 48 CLOSE_WAIT / 0 ESTABLISHED / ~7% CPU / no progress for ~1h on a B–C agency batch).

This affects `main` now — including the daily `etl-new-pipeline` workflow, whose large-agency batches can stall and hit the 60-min job timeout.

## Fix

- `s3_resource()` sizes `max_pool_connections` to `DEFAULT_DOWNLOAD_WORKERS`, so the HTTP pool is never smaller than the download concurrency. `reader_factory`'s default `download_workers` shares the same constant, so pool and workers match by construction (and a monkeypatched no-arg `s3_resource` in tests still works).
- Regression test asserts `max_pool_connections >= DEFAULT_DOWNLOAD_WORKERS` (was RED at `10 >= 16`).

## Verification

- Full unit suite green (214 passed).
- A 49K-comment agency (BSEE) that reproduced the hang now completes in ~5 min with a stable **16 ESTABLISHED / 0 CLOSE_WAIT** connection profile.