### PR TITLE
Prime comments index from R2 so incremental ETL batches don't shrink it

### DIFF
--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -218,9 +218,24 @@ class RegulationsPipeline(Pipeline):
         return agencies
 
     def _download_existing(self, output_dir: Path, record_types: list[RecordType]) -> None:
-        """Fetch existing monolithic output from R2 so the merge appends to it."""
+        """Fetch existing output from R2 so an incremental run appends to it.
+
+        Monolithic ``{type}.parquet`` files are pulled whole. Comment
+        *partitions* are large and fetched on demand during the merge, but the
+        global comment index must be primed here: ``update_comments_index``
+        rebuilds the index by keeping the existing rows for partitions this run
+        didn't touch, reading them from the local ``comments_index.parquet``.
+        Without the remote index on disk, a batch that stages new comments
+        rewrites the index down to only its own ~21 agencies' partitions — and
+        the upload shrink-guard then (correctly) aborts the run.
+        """
         for rt in record_types:
-            if rt.name == "comments":  # comments are partitioned, fetched on demand at merge
+            if rt.name == "comments":
+                # Partitions are fetched on demand at merge, but the index is
+                # global — prime it so the rebuild keeps untouched partitions.
+                index_file = output_dir / "comments_index.parquet"
+                if not index_file.exists():
+                    r2.download("comments_index.parquet", index_file)
                 continue
             local = output_dir / f"{rt.name}.parquet"
             if not local.exists():

--- a/tests/test_regulations_pipeline.py
+++ b/tests/test_regulations_pipeline.py
@@ -311,6 +311,68 @@ def test_run_skips_partition_upload_when_no_comments(
     assert "partitions" not in calls
 
 
+def test_run_primes_comments_index_from_r2_before_merge(
+    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An incremental comments run must download the existing global index.
+
+    ``update_comments_index`` keeps the rows for partitions this batch didn't
+    touch by reading the local ``comments_index.parquet``. If that file is
+    never fetched from R2, the rebuilt index collapses to only this batch's
+    partitions and the upload shrink-guard aborts the run. Guard against the
+    regression by asserting the index is requested during the prime step and
+    that pre-existing rows survive the rebuild.
+    """
+    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)  # keep merge's partition fetch offline
+    store = {
+        _comment_key("c1", "EPA-2024-0001"): dumps(
+            _comment_payload("c1", "EPA-2024-0001", "2024-01-01T00:00:00Z")
+        ).encode(),
+    }
+    monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
+    monkeypatch.setattr(regulations.r2, "upload_dataset", lambda out, types: None)
+    monkeypatch.setattr(regulations.r2, "upload_comment_partitions", lambda out, changed: None)
+
+    # A pre-existing remote index covering a partition this batch won't touch.
+    prior = pl.DataFrame(
+        {
+            "agency_code": ["NOAA"],
+            "docket_id": ["NOAA-2020-0009"],
+            "year": [2020],
+            "month": [5],
+            "row_count": [42],
+        },
+        schema={
+            "agency_code": pl.Utf8, "docket_id": pl.Utf8,
+            "year": pl.Int64, "month": pl.Int64, "row_count": pl.Int64,
+        },
+    )
+
+    requested: list[str] = []
+
+    def fake_download(remote_key: str, local_path: Path) -> bool:
+        requested.append(remote_key)
+        if remote_key == "comments_index.parquet":
+            prior.write_parquet(local_path)
+            return True
+        return False  # partitions are absent on R2 in this test
+
+    monkeypatch.setattr(regulations.r2, "download", fake_download)
+
+    RegulationsPipeline(
+        agency=AGENCY, output_dir=tmp_output, only_comments=True,
+        enrich_text=False, skip_post_process=True, skip_upload=False,
+    ).run()
+
+    assert "comments_index.parquet" in requested, "existing comment index was never fetched from R2"
+
+    index = pl.read_parquet(tmp_output / "comments_index.parquet")
+    keys = set(zip(index["agency_code"].to_list(), index["docket_id"].to_list()))
+    # The untouched NOAA partition survives the rebuild alongside the new EPA one.
+    assert ("NOAA", "NOAA-2020-0009") in keys
+    assert ("EPA", "EPA-2024-0001") in keys
+
+
 # --- CLI -------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Two scheduled **ETL (new pipeline)** runs on 2026-06-30 failed (batches 12 @ 18:25 UTC and 14 @ 20:35 UTC), both with the same error:

```
RuntimeError: Refusing to upload comments_index.parquet: new file would shrink
remote from 0.7 MB to 0.0 MB (ratio 0.003 < threshold 0.5). Set R2_ALLOW_SHRINK=1 to override.
```

**Root cause.** `update_comments_index` rebuilds the *global* `comments_index.parquet` by keeping the rows for partitions a run didn't touch — and it reads those "kept" rows from the **local** index file. But `_download_existing` skipped comments entirely, so on a fresh CI runner the index was never on disk. `kept_rows` came back empty and the index collapsed to only the current batch's ~21 agencies (~2 KB vs the 0.7 MB remote). The upload shrink-guard — added after the March 2026 data-loss incident — then correctly aborted the run.

This only surfaced on batches that actually staged new comments (the index is rebuilt + uploaded only when `changed_comments` is non-empty), which is why most batches passed. The guard did its job: without it, the first comments-bearing batch each day would have silently truncated the production index.

**Fix.** Prime the global index from R2 during the prime step (`_download_existing`), mirroring how the monolithic `{type}.parquet` files are fetched, so the rebuild preserves untouched partitions.

Comment partition *data* was never at risk — `merge_comments_partitioned` already downloads each affected partition on demand; only the index rebuild was lossy.

## Test plan

- [x] `uv run pytest tests/test_regulations_pipeline.py tests/test_r2.py tests/test_transforms.py tests/test_transform.py tests/test_load.py` — 71 passed
- [x] `uv run ruff check` on changed files — clean
- [x] Added `test_run_primes_comments_index_from_r2_before_merge`: asserts the index is fetched from R2 during prime and that a pre-existing untouched partition's rows survive the rebuild alongside the newly staged one. (Fails without the fix.)

## Checklist

- [x] My change is scoped to one concern
- [x] I added or updated tests for new behavior
- [ ] I updated docs (no doc changes needed — internal pipeline wiring)
- [ ] CI is green (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJEPQdGdpAwk7wXeN1RSGj

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJEPQdGdpAwk7wXeN1RSGj)_