### PR TITLE
Fix Iceberg comment upsert: DELETE+INSERT instead of unsupported MERGE INTO

### DIFF
--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -82,9 +82,7 @@ def _connect():
 
     if not is_configured():
         missing = [var for var in _REQUIRED_ENV if not getenv(var)]
-        raise RuntimeError(
-            "R2 Data Catalog is not configured; missing env var(s): " + ", ".join(missing)
-        )
+        raise RuntimeError("R2 Data Catalog is not configured; missing env var(s): " + ", ".join(missing))
 
     uri = getenv("R2_CATALOG_URI", "")
     warehouse = getenv("R2_CATALOG_WAREHOUSE", "")
@@ -94,10 +92,7 @@ def _connect():
     con.execute("INSTALL iceberg; LOAD iceberg;")
     con.execute("INSTALL httpfs; LOAD httpfs;")
     con.execute(f"CREATE OR REPLACE SECRET r2_catalog_secret (TYPE ICEBERG, TOKEN '{_sql_str(token)}');")
-    con.execute(
-        f"ATTACH '{_sql_str(warehouse)}' AS {_CATALOG_ALIAS} "
-        f"(TYPE ICEBERG, ENDPOINT '{_sql_str(uri)}');"
-    )
+    con.execute(f"ATTACH '{_sql_str(warehouse)}' AS {_CATALOG_ALIAS} (TYPE ICEBERG, ENDPOINT '{_sql_str(uri)}');")
     return con
 
 
@@ -127,41 +122,65 @@ def _staging_files(staging_dir: Path, record_type: RecordType) -> list[Path]:
 
 
 def _merge(con, staging_files: list[Path], record_type: RecordType) -> None:
-    """Row-level upsert of the staged rows into the Iceberg table via ``MERGE INTO``.
+    """Row-level upsert of the staged rows into the Iceberg table.
+
+    Expressed as ``DELETE`` + ``INSERT`` rather than ``MERGE INTO``: the R2 Data
+    Catalog is an Iceberg table, and DuckDB's iceberg engine raises
+    ``NotImplementedException`` for ``MERGE INTO``/``ON CONFLICT`` — only plain
+    ``DELETE``/``INSERT`` are supported (the same DML :func:`seed_comments_from_parquet`
+    uses).
 
     Mirrors the dedup semantics of ``transforms.merge_staging_files``: collapse
-    the staging rows to one per key (latest ``modify_date`` wins), then merge
-    that against the table — updating only when the incoming row is newer and
-    inserting brand-new keys. ``modify_date`` is an ISO-8601 string, so the
-    lexical ``>`` comparison orders chronologically.
+    the staging rows to one per key (latest ``modify_date`` wins), keep only the
+    keys whose incoming row is brand-new or strictly newer than the table's, then
+    replace exactly those keys. Deleting by key (not by agency) is essential — a
+    since-year-filtered run stages only a slice, so an agency-wide delete would
+    drop the rows it isn't re-inserting. ``modify_date`` is an ISO-8601 string,
+    so the lexical ``>`` comparison orders chronologically.
     """
     cols = list(record_type.schema)
     key = record_type.dedup_key
+    tbl = _qualified(record_type)
+    # Temp names are per-record-type so a dockets + comments run on one
+    # connection can't collide.
+    staged = f"_staged_{record_type.name}"
+    winners = f"_winners_{record_type.name}"
 
     files_sql = ", ".join(f"'{_sql_str(str(p))}'" for p in staging_files)
     col_select = ", ".join(f'CAST("{c}" AS VARCHAR) AS "{c}"' for c in cols)
-    set_clause = ", ".join(f'"{c}" = s."{c}"' for c in cols if c != key)
-    insert_cols = ", ".join(f'"{c}"' for c in cols)
-    insert_vals = ", ".join(f's."{c}"' for c in cols)
+    col_list = ", ".join(f'"{c}"' for c in cols)
 
+    # 1. Collapse staging to one row per key (latest modify_date wins).
     con.execute(
         f"""
-        MERGE INTO {_qualified(record_type)} AS t
-        USING (
-            SELECT {col_select}
-            FROM read_parquet([{files_sql}], union_by_name=true)
-            QUALIFY ROW_NUMBER() OVER (
-                PARTITION BY "{key}"
-                ORDER BY modify_date DESC NULLS LAST
-            ) = 1
-        ) AS s
-        ON t."{key}" = s."{key}"
-        WHEN MATCHED AND (t.modify_date IS NULL OR s.modify_date > t.modify_date)
-            THEN UPDATE SET {set_clause}
-        WHEN NOT MATCHED
-            THEN INSERT ({insert_cols}) VALUES ({insert_vals});
+        CREATE OR REPLACE TEMP TABLE {staged} AS
+        SELECT {col_select}
+        FROM read_parquet([{files_sql}], union_by_name=true)
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY "{key}"
+            ORDER BY modify_date DESC NULLS LAST
+        ) = 1;
         """
     )
+    # 2. Keep only rows that should win over the table: a new key, or one whose
+    #    incoming modify_date is strictly newer (matching the old MERGE guard).
+    con.execute(
+        f"""
+        CREATE OR REPLACE TEMP TABLE {winners} AS
+        SELECT s.*
+        FROM {staged} s
+        LEFT JOIN {tbl} t ON t."{key}" = s."{key}"
+        WHERE t."{key}" IS NULL
+           OR t.modify_date IS NULL
+           OR s.modify_date > t.modify_date;
+        """
+    )
+    # 3. Upsert = delete exactly the winning keys, then insert their rows.
+    con.execute(f'DELETE FROM {tbl} WHERE "{key}" IN (SELECT "{key}" FROM {winners});')
+    con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM {winners};")
+
+    con.execute(f"DROP TABLE IF EXISTS {staged};")
+    con.execute(f"DROP TABLE IF EXISTS {winners};")
 
 
 def _export_parquet(con, record_type: RecordType, output_dir: Path) -> Path:
@@ -255,20 +274,15 @@ def seed_comments_from_parquet(
     columns = list(record_type.schema)
     esc = _sql_str(source_glob)
     if replace_agency is not None:
-        con.execute(
-            f"DELETE FROM {_qualified(record_type)} "
-            f"WHERE agency_code = '{_sql_str(replace_agency)}';"
-        )
+        con.execute(f"DELETE FROM {_qualified(record_type)} WHERE agency_code = '{_sql_str(replace_agency)}';")
     present = {
         row[0]
         for row in con.execute(
-            f"DESCRIBE SELECT * FROM read_parquet('{esc}', "
-            "union_by_name=true, hive_partitioning=false)"
+            f"DESCRIBE SELECT * FROM read_parquet('{esc}', union_by_name=true, hive_partitioning=false)"
         ).fetchall()
     }
     projection = ", ".join(
-        f'CAST("{c}" AS VARCHAR) AS "{c}"' if c in present else f'CAST(NULL AS VARCHAR) AS "{c}"'
-        for c in columns
+        f'CAST("{c}" AS VARCHAR) AS "{c}"' if c in present else f'CAST(NULL AS VARCHAR) AS "{c}"' for c in columns
     )
     col_list = ", ".join(f'"{c}"' for c in columns)
     con.execute(
@@ -300,7 +314,8 @@ def merge_comments(staging_dir: Path, output_dir: Path, record_type: RecordType)
         _ensure_table(con, record_type)
         logger.info(
             "iceberg: MERGE {} staging file(s) into {}",
-            len(staging_files), _qualified(record_type),
+            len(staging_files),
+            _qualified(record_type),
         )
         _merge(con, staging_files, record_type)
         total = con.execute(f"SELECT count(*) FROM {_qualified(record_type)}").fetchone()[0]
@@ -329,7 +344,8 @@ def merge_and_export(staging_dir: Path, output_dir: Path, record_type: RecordTyp
         _ensure_table(con, record_type)
         logger.info(
             "iceberg: MERGE {} staging file(s) into {}",
-            len(staging_files), _qualified(record_type),
+            len(staging_files),
+            _qualified(record_type),
         )
         _merge(con, staging_files, record_type)
         total = con.execute(f"SELECT count(*) FROM {_qualified(record_type)}").fetchone()[0]

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -121,11 +121,7 @@ def test_merge_inserts_then_dedups(tmp_path, local_catalog) -> None:
     )
     iceberg._merge(con, iceberg._staging_files(staging2, DOCKET), DOCKET)
 
-    rows = dict(
-        con.execute(
-            f'SELECT docket_id, title FROM {iceberg._qualified(DOCKET)} ORDER BY docket_id'
-        ).fetchall()
-    )
+    rows = dict(con.execute(f"SELECT docket_id, title FROM {iceberg._qualified(DOCKET)} ORDER BY docket_id").fetchall())
     assert rows == {"EPA-1": "First UPDATED", "EPA-2": "Second", "EPA-3": "Third"}
 
 
@@ -142,10 +138,42 @@ def test_merge_keeps_existing_when_incoming_is_older(tmp_path, local_catalog) ->
     _write_staging(staging2, "EPA", [_docket("EPA-1", "EPA", "Older", "2025-01-01")])
     iceberg._merge(con, iceberg._staging_files(staging2, DOCKET), DOCKET)
 
-    title = con.execute(
-        f'SELECT title FROM {iceberg._qualified(DOCKET)} WHERE docket_id = \'EPA-1\''
-    ).fetchone()[0]
+    title = con.execute(f"SELECT title FROM {iceberg._qualified(DOCKET)} WHERE docket_id = 'EPA-1'").fetchone()[0]
     assert title == "Newer"
+
+
+def test_merge_upserts_without_merge_into(tmp_path) -> None:
+    """The R2 Data Catalog (Iceberg) rejects ``MERGE INTO`` — DuckDB raises
+    ``NotImplementedException`` against an iceberg table — so ``_merge`` must
+    express the upsert as ``DELETE`` + ``INSERT`` (the DML the seed loader uses).
+
+    The in-memory test catalog is a native DuckDB table that *does* accept
+    ``MERGE INTO`` (which is exactly why the original bug escaped the suite), so
+    this asserts on the emitted SQL rather than the row result. The
+    ``local_catalog`` behavior tests above cover the upsert semantics.
+    """
+    _write_staging(tmp_path / "s", "EPA", [_docket("EPA-1", "EPA", "T", "2025-01-01")])
+    files = iceberg._staging_files(tmp_path / "s", DOCKET)
+
+    executed: list[str] = []
+
+    class _RecordingCon:
+        def execute(self, sql, *args, **kwargs):
+            executed.append(sql)
+            return self
+
+        def fetchall(self):
+            return []
+
+        def fetchone(self):
+            return [0]
+
+    iceberg._merge(_RecordingCon(), files, DOCKET)
+
+    sql = " ".join(executed).upper()
+    assert "MERGE INTO" not in sql, "Iceberg catalog does not support MERGE INTO"
+    assert "DELETE FROM" in sql
+    assert "INSERT INTO" in sql
 
 
 def test_export_parquet_matches_published_shape(tmp_path, local_catalog) -> None:
@@ -208,10 +236,7 @@ def test_build_comments_index_counts_per_partition(tmp_path, local_catalog) -> N
 
     df = pl.read_parquet(index_file)
     assert set(df.columns) == {"agency_code", "docket_id", "year", "month", "row_count"}
-    got = {
-        (r["agency_code"], r["docket_id"], r["year"], r["month"]): r["row_count"]
-        for r in df.iter_rows(named=True)
-    }
+    got = {(r["agency_code"], r["docket_id"], r["year"], r["month"]): r["row_count"] for r in df.iter_rows(named=True)}
     assert got == {
         ("EPA", "EPA-1", 2025, 1): 2,
         ("EPA", "EPA-1", 2025, 2): 1,
@@ -261,13 +286,7 @@ def test_merge_comments_noop_without_staging(tmp_path) -> None:
 
 def _write_partition(comments_dir: Path, agency: str, docket: str, year: int, month: int, rows: list[dict]) -> None:
     """Write a published-layout partition file: agency_code=/docket_id=/year=/month=/part-0.parquet."""
-    part = (
-        comments_dir
-        / f"agency_code={agency}"
-        / f"docket_id={docket}"
-        / f"year={year}"
-        / f"month={month}"
-    )
+    part = comments_dir / f"agency_code={agency}" / f"docket_id={docket}" / f"year={year}" / f"month={month}"
     part.mkdir(parents=True, exist_ok=True)
     pl.DataFrame(rows, schema=COMMENT.schema).write_parquet(part / "part-0.parquet")
 
@@ -279,14 +298,22 @@ def test_seed_comments_from_parquet_loads_partition_tree(tmp_path, local_catalog
 
     comments_dir = tmp_path / "comments"
     _write_partition(
-        comments_dir, "EPA", "EPA-1", 2025, 1,
+        comments_dir,
+        "EPA",
+        "EPA-1",
+        2025,
+        1,
         [
             _comment("c1", "EPA-1", "EPA", "2025-01-15T00:00:00Z"),
             _comment("c2", "EPA-1", "EPA", "2025-01-20T00:00:00Z"),
         ],
     )
     _write_partition(
-        comments_dir, "EPA", "EPA-1", 2025, 2,
+        comments_dir,
+        "EPA",
+        "EPA-1",
+        2025,
+        2,
         [_comment("c3", "EPA-1", "EPA", "2025-02-03T00:00:00Z")],
     )
 
@@ -296,8 +323,7 @@ def test_seed_comments_from_parquet_loads_partition_tree(tmp_path, local_catalog
 
     # agency_code / docket_id survive as real columns (read with hive off).
     rows = con.execute(
-        f'SELECT comment_id, agency_code, docket_id FROM {iceberg._qualified(COMMENT)} '
-        "ORDER BY comment_id"
+        f"SELECT comment_id, agency_code, docket_id FROM {iceberg._qualified(COMMENT)} ORDER BY comment_id"
     ).fetchall()
     assert rows == [
         ("c1", "EPA", "EPA-1"),
@@ -313,7 +339,11 @@ def test_seed_comments_replace_agency_is_idempotent(tmp_path, local_catalog) -> 
 
     comments_dir = tmp_path / "comments"
     _write_partition(
-        comments_dir, "EPA", "EPA-1", 2025, 1,
+        comments_dir,
+        "EPA",
+        "EPA-1",
+        2025,
+        1,
         [
             _comment("c1", "EPA-1", "EPA", "2025-01-15T00:00:00Z"),
             _comment("c2", "EPA-1", "EPA", "2025-01-20T00:00:00Z"),
@@ -329,16 +359,18 @@ def test_seed_comments_replace_agency_is_idempotent(tmp_path, local_catalog) -> 
 
     # A different agency present in the table is untouched by replacing EPA.
     _write_partition(
-        comments_dir, "DOL", "DOL-1", 2025, 3,
+        comments_dir,
+        "DOL",
+        "DOL-1",
+        2025,
+        3,
         [_comment("d1", "DOL-1", "DOL", "2025-03-01T00:00:00Z")],
     )
     dol_glob = str(comments_dir / "agency_code=DOL/docket_id=*/year=*/month=*/part-0.parquet")
     iceberg.seed_comments_from_parquet(con, dol_glob, COMMENT, replace_agency="DOL")
     iceberg.seed_comments_from_parquet(con, glob, COMMENT, replace_agency="EPA")  # again
     counts = dict(
-        con.execute(
-            f'SELECT agency_code, count(*) FROM {iceberg._qualified(COMMENT)} GROUP BY agency_code'
-        ).fetchall()
+        con.execute(f"SELECT agency_code, count(*) FROM {iceberg._qualified(COMMENT)} GROUP BY agency_code").fetchall()
     )
     assert counts == {"EPA": 2, "DOL": 1}
 


### PR DESCRIPTION
## Bug

Any `--use-iceberg` run that stages records fails at the merge step:

```
_duckdb.NotImplementedException: Not implemented Error: Database type "iceberg"
does not support MERGE INTO or ON CONFLICT
```

`iceberg._merge` upserts via `MERGE INTO`, but DuckDB's iceberg engine doesn't implement it against the R2 Data Catalog. So the incremental comments path (`merge_comments`) is unusable — which is why the scheduled ETL still defaults `use_iceberg=false`. Hit while running a targeted `--use-iceberg` comment re-ingest; the statement errors before writing, so no partial catalog state results.

## Fix

Rewrite the upsert as **DELETE + INSERT** — the same DML `seed_comments_from_parquet` already uses successfully against the live catalog. Semantics are preserved exactly:
1. Collapse staging to one row per key (latest `modify_date` wins).
2. `LEFT JOIN` the table to keep only **winners** — keys that are new or whose incoming `modify_date` is strictly newer (matching the old MERGE guard).
3. `DELETE` those keys, then `INSERT` their rows.

Deleting **by key** (not by `agency_code`) is essential: a `--since-year` run stages only a slice, so an agency-wide delete would drop rows it isn't re-inserting.

## Tests

- Existing behavior tests (insert/update/dedup, keep-newer-wins) still pass — but note they run against a **native in-memory DuckDB table that *does* accept `MERGE INTO`**, which is exactly why the bug escaped the suite (test-fidelity gap vs. a real iceberg table).
- Added `test_merge_upserts_without_merge_into` to guard the emitted SQL directly (no `MERGE INTO`; uses `DELETE`/`INSERT`).
- Full suite green (233 passed).

Follow-up worth considering: an integration test against a real R2 catalog would close the fidelity gap that let this through.