### PR TITLE
Decouple rollups into per-rollup pipelines on independent crons

### DIFF
--- a/.github/workflows/_rollup.yml
+++ b/.github/workflows/_rollup.yml
@@ -1,0 +1,68 @@
+name: Rollup (reusable)
+
+# Reusable workflow that runs one decoupled rollup pipeline (`run-rollup-*`).
+# Each rollup has its own thin caller workflow (rollup-*.yml) with its own cron;
+# they all delegate here so the build/publish steps live in one place.
+#
+# The `run-rollup-*` console scripts default to --skip-upload (vetting), so this
+# passes --no-skip-upload for real runs; callers can flip it back for dry runs.
+on:
+  workflow_call:
+    inputs:
+      command:
+        description: 'The run-rollup-* console script to run (e.g. run-rollup-feed-summary)'
+        required: true
+        type: string
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  rollup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run rollup
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          # Passed via env (not interpolated into the command) to keep the run
+          # step free of any templated string in an executable position.
+          COMMAND: ${{ inputs.command }}
+          SKIP_UPLOAD: ${{ inputs.skip_upload }}
+        run: |
+          if [ "$SKIP_UPLOAD" = "true" ]; then
+            UPLOAD_ARG="--skip-upload"
+          else
+            UPLOAD_ARG="--no-skip-upload"
+          fi
+          echo "Running: uv run $COMMAND $UPLOAD_ARG"
+          uv run "$COMMAND" "$UPLOAD_ARG"
+
+      - name: Upload artifacts (for debugging)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rollup-output
+          path: output/
+          retention-days: 7

--- a/.github/workflows/etl-new-pipeline.yml
+++ b/.github/workflows/etl-new-pipeline.yml
@@ -6,8 +6,9 @@ name: ETL (new pipeline)
 # removed.
 #
 # On `schedule`: 15 batches (21 agencies each = 315) spread across the day; the
-# batch number is derived from the UTC hour, upload to R2 is ON, and the feed
-# summary / agency rollups are built only on the final batch.
+# batch number is derived from the UTC hour and upload to R2 is ON. Rollups
+# (feed_summary, agency_stats, ...) are built by separate `rollup-*.yml`
+# workflows, each on its own cron reading the base tables this ETL publishes.
 #
 # On `workflow_dispatch`: inputs drive a one-off run. `skip_upload` still
 # defaults to true so a manual vetting run cannot write to production R2 — flip
@@ -84,17 +85,10 @@ jobs:
             echo "batch_number=$BATCH" >> $GITHUB_OUTPUT
             # Scheduled runs publish to R2.
             echo "skip_upload=false" >> $GITHUB_OUTPUT
-            # Build feed summary + agency rollups only on the final batch.
-            if [ "$BATCH" != "14" ]; then
-              echo "skip_post_process=true" >> $GITHUB_OUTPUT
-            else
-              echo "skip_post_process=false" >> $GITHUB_OUTPUT
-            fi
             echo "Running scheduled batch $BATCH (hour $HOUR UTC)"
           else
             echo "batch_number=${{ inputs.batch_number }}" >> $GITHUB_OUTPUT
             echo "skip_upload=${{ inputs.skip_upload }}" >> $GITHUB_OUTPUT
-            echo "skip_post_process=false" >> $GITHUB_OUTPUT
             echo "Running manual dispatch (skip_upload=${{ inputs.skip_upload }})"
           fi
 
@@ -135,9 +129,6 @@ jobs:
           fi
           if [ -n "${{ steps.params.outputs.batch_number }}" ]; then
             ARGS="$ARGS --batch-number ${{ steps.params.outputs.batch_number }} --batch-size 21"
-          fi
-          if [ "${{ steps.params.outputs.skip_post_process }}" = "true" ]; then
-            ARGS="$ARGS --skip-post-process"
           fi
           if [ "${{ inputs.full_refresh }}" = "true" ]; then
             ARGS="$ARGS --full-refresh"

--- a/.github/workflows/rollup-agency-monthly-volume.yml
+++ b/.github/workflows/rollup-agency-monthly-volume.yml
@@ -1,0 +1,22 @@
+name: Rollup — agency_monthly_volume
+
+# Decoupled rollup: rebuilds agency_monthly_volume.parquet from documents.parquet.
+# Runs after the ETL's final batch (20:25 UTC) window closes.
+on:
+  schedule:
+    - cron: '50 22 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  run:
+    uses: ./.github/workflows/_rollup.yml
+    secrets: inherit
+    with:
+      command: run-rollup-agency-monthly-volume
+      skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}

--- a/.github/workflows/rollup-agency-stats.yml
+++ b/.github/workflows/rollup-agency-stats.yml
@@ -1,0 +1,22 @@
+name: Rollup — agency_stats
+
+# Decoupled rollup: rebuilds agency_stats.parquet from the base tables the main
+# ETL publishes. Runs after the ETL's final batch (20:25 UTC) window closes.
+on:
+  schedule:
+    - cron: '40 22 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  run:
+    uses: ./.github/workflows/_rollup.yml
+    secrets: inherit
+    with:
+      command: run-rollup-agency-stats
+      skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}

--- a/.github/workflows/rollup-discovery-signals.yml
+++ b/.github/workflows/rollup-discovery-signals.yml
@@ -1,0 +1,22 @@
+name: Rollup — discovery_signals
+
+# Decoupled rollup: rebuilds discovery_signals.parquet (per-agency document-output
+# spike signal) from documents.parquet. Runs after the ETL's final batch.
+on:
+  schedule:
+    - cron: '20 23 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  run:
+    uses: ./.github/workflows/_rollup.yml
+    secrets: inherit
+    with:
+      command: run-rollup-discovery-signals
+      skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}

--- a/.github/workflows/rollup-docket-search.yml
+++ b/.github/workflows/rollup-docket-search.yml
@@ -1,0 +1,22 @@
+name: Rollup — docket_search
+
+# Decoupled rollup: rebuilds docket_search.json.gz (browser MiniSearch index)
+# from dockets.parquet. Runs after the ETL's final batch (20:25 UTC) closes.
+on:
+  schedule:
+    - cron: '0 23 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  run:
+    uses: ./.github/workflows/_rollup.yml
+    secrets: inherit
+    with:
+      command: run-rollup-docket-search
+      skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}

--- a/.github/workflows/rollup-feed-summary.yml
+++ b/.github/workflows/rollup-feed-summary.yml
@@ -1,0 +1,22 @@
+name: Rollup — feed_summary
+
+# Decoupled rollup: rebuilds feed_summary.parquet from the base tables the main
+# ETL publishes. Runs after the ETL's final batch (20:25 UTC) window closes.
+on:
+  schedule:
+    - cron: '30 22 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  run:
+    uses: ./.github/workflows/_rollup.yml
+    secrets: inherit
+    with:
+      command: run-rollup-feed-summary
+      skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}

--- a/.github/workflows/rollup-fr-docket-links.yml
+++ b/.github/workflows/rollup-fr-docket-links.yml
@@ -1,0 +1,23 @@
+name: Rollup — fr_docket_links
+
+# Decoupled rollup: rebuilds fr_docket_links.parquet by exploding
+# federal_register.parquet's docket_ids_json. federal_register.parquet is
+# produced by a separate ingestion path; this reads it from R2 as a base input.
+on:
+  schedule:
+    - cron: '30 23 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  run:
+    uses: ./.github/workflows/_rollup.yml
+    secrets: inherit
+    with:
+      command: run-rollup-fr-docket-links
+      skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}

--- a/.github/workflows/rollup-lifecycles.yml
+++ b/.github/workflows/rollup-lifecycles.yml
@@ -1,0 +1,22 @@
+name: Rollup — rulemaking_lifecycles
+
+# Decoupled rollup: rebuilds rulemaking_lifecycles.parquet (Proposed→Rule pairs
+# + stuck proposals) from documents.parquet. Runs after the ETL's final batch.
+on:
+  schedule:
+    - cron: '10 23 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  run:
+    uses: ./.github/workflows/_rollup.yml
+    secrets: inherit
+    with:
+      command: run-rollup-lifecycles
+      skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,13 @@ docs = [
 
 [project.scripts]
 run-pipeline = "spicy_regs.pipelines.regulations:app"
+run-rollup-feed-summary = "spicy_regs.pipelines.rollups.feed_summary:app"
+run-rollup-agency-stats = "spicy_regs.pipelines.rollups.agency_stats:app"
+run-rollup-agency-monthly-volume = "spicy_regs.pipelines.rollups.agency_monthly_volume:app"
+run-rollup-docket-search = "spicy_regs.pipelines.rollups.docket_search:app"
+run-rollup-lifecycles = "spicy_regs.pipelines.rollups.rulemaking_lifecycles:app"
+run-rollup-discovery-signals = "spicy_regs.pipelines.rollups.discovery_signals:app"
+run-rollup-fr-docket-links = "spicy_regs.pipelines.rollups.fr_docket_links:app"
 enrich-pdf-text = "spicy_regs.enrich_pdf:main"
 backfill-comment-text = "spicy_regs.backfill_derived_text:main"
 embed = "spicy_regs.vectordb.embed:main"

--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -38,14 +38,10 @@ from spicy_regs.schemas import RECORD_TYPES, RecordType
 from spicy_regs.sources import iceberg, mirrulations, r2
 from spicy_regs.sources.derived_text import DerivedCommentText
 from spicy_regs.transforms import (
-    INDEX_FILENAME,
     Chain,
     EnrichCommentText,
     ExtractRecords,
     Transform,
-    build_agency_rollups,
-    build_feed_summary,
-    build_search_index,
     merge_comments_partitioned,
     merge_staging_files,
     update_comments_index,
@@ -70,7 +66,6 @@ class RegulationsPipeline(Pipeline):
         only_comments: bool = False,
         batch_number: int | None = None,
         batch_size: int = 45,
-        skip_post_process: bool = False,
         full_refresh: bool = False,
         max_workers: int = 4,
         use_iceberg: bool = False,
@@ -85,7 +80,6 @@ class RegulationsPipeline(Pipeline):
         self.only_comments = only_comments
         self.batch_number = batch_number
         self.batch_size = batch_size
-        self.skip_post_process = skip_post_process
         self.full_refresh = full_refresh
         self.max_workers = max_workers
         self.use_iceberg = use_iceberg
@@ -136,16 +130,11 @@ class RegulationsPipeline(Pipeline):
         if any(staged.values()):
             changed_comments = self._merge(staging_dir, output_dir, record_types, staged)
             rmtree(staging_dir, ignore_errors=True)
-            if not self.skip_post_process:
-                logger.info("Building feed summary...")
-                build_feed_summary(output_dir)
-                logger.info("Building agency rollups...")
-                build_agency_rollups(output_dir)
-                # Only rebuild the docket search index when dockets changed — the
-                # gzipped blob is served from CDN, so avoid churning it needlessly.
-                if staged.get("dockets", 0) > 0:
-                    logger.info("Building docket search index...")
-                    build_search_index(output_dir)
+            # Rollups (feed_summary, agency_stats, agency_monthly_volume,
+            # docket_search, rulemaking_lifecycles, discovery_signals,
+            # fr_docket_links) are no longer built here. Each is materialized by
+            # its own decoupled pipeline (`run-rollup-*`) on an independent cron,
+            # reading the base tables this ETL publishes below.
         else:
             logger.info("No new records staged; skipping merge.")
 
@@ -169,11 +158,6 @@ class RegulationsPipeline(Pipeline):
                 if index_file.exists():
                     logger.info("Uploading refreshed comments index (Iceberg path)...")
                     r2.upload_file(index_file, remote_key="comments_index.parquet")
-            # Publish the search index when this run rebuilt it (dockets changed).
-            search_index = output_dir / INDEX_FILENAME
-            if not self.skip_post_process and staged.get("dockets", 0) > 0 and search_index.exists():
-                logger.info("Uploading search index...")
-                r2.upload_file(search_index)
 
         logger.info("Done!")
 
@@ -317,7 +301,6 @@ def main(
     only_comments: Annotated[bool, Parameter(help="Only process comments")] = False,
     batch_number: Annotated[int | None, Parameter(help="Batch number (0-indexed)")] = None,
     batch_size: Annotated[int, Parameter(help="Agencies per batch")] = 45,
-    skip_post_process: Annotated[bool, Parameter(help="Skip feed summary build")] = False,
     full_refresh: Annotated[bool, Parameter(help="Ignore manifest + existing output")] = False,
     max_workers: Annotated[int, Parameter(help="Agencies processed in parallel")] = 4,
     use_iceberg: Annotated[bool, Parameter(help="Route the dockets table through R2 Data Catalog (Iceberg)")] = False,
@@ -337,7 +320,6 @@ def main(
         only_comments=only_comments,
         batch_number=batch_number,
         batch_size=batch_size,
-        skip_post_process=skip_post_process,
         full_refresh=full_refresh,
         max_workers=max_workers,
         use_iceberg=use_iceberg,

--- a/src/spicy_regs/pipelines/rollups/__init__.py
+++ b/src/spicy_regs/pipelines/rollups/__init__.py
@@ -1,0 +1,5 @@
+"""Decoupled, per-rollup pipelines (one artifact each, own cron workflow)."""
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+
+__all__ = ["RollupPipeline", "make_rollup_app"]

--- a/src/spicy_regs/pipelines/rollups/agency_monthly_volume.py
+++ b/src/spicy_regs/pipelines/rollups/agency_monthly_volume.py
@@ -1,0 +1,24 @@
+"""Rollup pipeline: agency_monthly_volume.parquet (per-agency monthly document counts)."""
+
+from pathlib import Path
+from typing import ClassVar
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.transforms import build_agency_monthly_volume
+
+
+class AgencyMonthlyVolumeRollup(RollupPipeline):
+    """Per-agency monthly document volume by type — directory sparklines + profile activity."""
+
+    name: ClassVar[str] = "agency-monthly-volume"
+    inputs: ClassVar[tuple[str, ...]] = ("documents.parquet",)
+    output: ClassVar[str] = "agency_monthly_volume.parquet"
+
+    def build(self, output_dir: Path) -> Path:
+        return build_agency_monthly_volume(output_dir)
+
+
+app = make_rollup_app(AgencyMonthlyVolumeRollup)
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/pipelines/rollups/agency_stats.py
+++ b/src/spicy_regs/pipelines/rollups/agency_stats.py
@@ -1,0 +1,24 @@
+"""Rollup pipeline: agency_stats.parquet (per-agency docket/document/comment counts)."""
+
+from pathlib import Path
+from typing import ClassVar
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.transforms import build_agency_stats
+
+
+class AgencyStatsRollup(RollupPipeline):
+    """Per-agency dimension table for the directory + profile pages."""
+
+    name: ClassVar[str] = "agency-stats"
+    inputs: ClassVar[tuple[str, ...]] = ("dockets.parquet", "comments_index.parquet", "documents.parquet")
+    output: ClassVar[str] = "agency_stats.parquet"
+
+    def build(self, output_dir: Path) -> Path:
+        return build_agency_stats(output_dir)
+
+
+app = make_rollup_app(AgencyStatsRollup)
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/pipelines/rollups/base.py
+++ b/src/spicy_regs/pipelines/rollups/base.py
@@ -1,0 +1,116 @@
+"""Base class for decoupled, per-rollup pipelines.
+
+Each rollup (``feed_summary``, ``agency_stats``, ``rulemaking_lifecycles``, ...)
+is materialized by its own :class:`RollupPipeline` subclass with its own console
+entry (``run-rollup-*``) and its own GitHub Actions workflow on an independent
+cron. This keeps rollup logic out of the extract/merge ETL: a rollup can be
+re-run or backfilled on its own, and a failure is isolated to a single artifact.
+
+``run()`` reads top-to-bottom as the data flow:
+
+    1. Prime — download the base tables this rollup reads from R2 (skipping any
+       already present locally, so local dev and re-runs don't re-download).
+    2. Build — materialize the rollup artifact via a transform.
+    3. Load  — publish the single artifact to R2 (shrink-guarded), off by
+       default while vetting.
+
+**Contract:** a rollup reads only the ETL's *published base tables*
+(``dockets``, ``documents``, ``comments_index``, ``federal_register``) — never
+another rollup's output — so pipelines stay independently schedulable with no
+cross-pipeline race.
+"""
+
+from abc import abstractmethod
+from pathlib import Path
+from typing import Annotated, ClassVar
+
+from cyclopts import App, Parameter
+from dotenv import load_dotenv
+from loguru import logger
+
+from spicy_regs.pipelines.base import Pipeline
+from spicy_regs.sources import r2
+
+load_dotenv()
+
+
+class RollupPipeline(Pipeline):
+    """A single materialized rollup, run standalone from the base tables on R2."""
+
+    #: Base-table Parquet files this rollup reads (R2 remote keys, e.g.
+    #: ``"documents.parquet"``). Primed from R2 before the build.
+    inputs: ClassVar[tuple[str, ...]] = ()
+
+    #: The single artifact this rollup writes and publishes (e.g.
+    #: ``"feed_summary.parquet"``). Its R2 remote key is the same filename.
+    output: ClassVar[str]
+
+    def __init__(self, *, output_dir: Path | None = None, skip_upload: bool = True) -> None:
+        self.output_dir = output_dir
+        self.skip_upload = skip_upload
+
+    def run(self) -> None:
+        output_dir = self.output_dir or (Path.cwd() / "output")
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # 1. Prime: pull the base tables this rollup reads from R2.
+        self._prime(output_dir)
+
+        # 2. Build: materialize the rollup artifact.
+        logger.info("Building rollup {}...", self.output)
+        out_path = self.build(output_dir)
+
+        # 3. Load: publish the single artifact (shrink-guarded), unless skipping.
+        if self.skip_upload:
+            logger.info("skip_upload=True — {} left in {}", self.output, output_dir)
+        else:
+            logger.info("Uploading {} to R2...", self.output)
+            r2.upload_file(out_path, remote_key=self.output)
+
+        logger.info("Done!")
+
+    def _prime(self, output_dir: Path) -> None:
+        """Download each required base table from R2 unless already local.
+
+        A missing base table is fatal: a rollup built from absent inputs would
+        publish a truncated artifact that the upload shrink-guard would then
+        (correctly) reject — better to fail loudly here with a clear message.
+        """
+        for remote_key in self.inputs:
+            local = output_dir / remote_key
+            if local.exists():
+                logger.info("Using local {} (skipping download)", remote_key)
+                continue
+            if not r2.download(remote_key, local):
+                raise RuntimeError(
+                    f"Rollup {self.output!r}: required base table {remote_key!r} "
+                    f"not found on R2 and not present locally in {output_dir}"
+                )
+
+    @abstractmethod
+    def build(self, output_dir: Path) -> Path:
+        """Materialize the rollup into ``output_dir`` and return its path."""
+        ...
+
+
+def make_rollup_app(pipeline_cls: type[RollupPipeline]) -> App:
+    """Build the ``run-rollup-*`` cyclopts CLI for one rollup pipeline.
+
+    All rollups share the same two flags, so each module just does::
+
+        app = make_rollup_app(FeedSummaryRollup)
+    """
+    app = App(
+        name=f"run-rollup-{pipeline_cls.name}",
+        help=(pipeline_cls.__doc__ or "").strip().splitlines()[0] if pipeline_cls.__doc__ else "",
+    )
+
+    @app.default
+    def main(
+        *,
+        output_dir: Annotated[Path | None, Parameter(help="Output directory")] = None,
+        skip_upload: Annotated[bool, Parameter(help="Skip R2 upload (recommended while vetting)")] = True,
+    ) -> None:
+        pipeline_cls(output_dir=output_dir, skip_upload=skip_upload).run()
+
+    return app

--- a/src/spicy_regs/pipelines/rollups/discovery_signals.py
+++ b/src/spicy_regs/pipelines/rollups/discovery_signals.py
@@ -1,0 +1,24 @@
+"""Rollup pipeline: discovery_signals.parquet (per-agency document-output spike)."""
+
+from pathlib import Path
+from typing import ClassVar
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.transforms import build_discovery_signals
+
+
+class DiscoverySignalsRollup(RollupPipeline):
+    """Feed 'spike' signal — agencies with a recent surge in document output."""
+
+    name: ClassVar[str] = "discovery-signals"
+    inputs: ClassVar[tuple[str, ...]] = ("documents.parquet",)
+    output: ClassVar[str] = "discovery_signals.parquet"
+
+    def build(self, output_dir: Path) -> Path:
+        return build_discovery_signals(output_dir)
+
+
+app = make_rollup_app(DiscoverySignalsRollup)
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/pipelines/rollups/docket_search.py
+++ b/src/spicy_regs/pipelines/rollups/docket_search.py
@@ -1,0 +1,24 @@
+"""Rollup pipeline: docket_search.json.gz (client-side MiniSearch index)."""
+
+from pathlib import Path
+from typing import ClassVar
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.transforms import INDEX_FILENAME, build_search_index
+
+
+class DocketSearchRollup(RollupPipeline):
+    """Gzipped docket search blob consumed by the browser MiniSearch index."""
+
+    name: ClassVar[str] = "docket-search"
+    inputs: ClassVar[tuple[str, ...]] = ("dockets.parquet",)
+    output: ClassVar[str] = INDEX_FILENAME
+
+    def build(self, output_dir: Path) -> Path:
+        return build_search_index(output_dir)
+
+
+app = make_rollup_app(DocketSearchRollup)
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/pipelines/rollups/feed_summary.py
+++ b/src/spicy_regs/pipelines/rollups/feed_summary.py
@@ -1,0 +1,24 @@
+"""Rollup pipeline: feed_summary.parquet (dockets + comment counts + comment-end dates)."""
+
+from pathlib import Path
+from typing import ClassVar
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.transforms import build_feed_summary
+
+
+class FeedSummaryRollup(RollupPipeline):
+    """Pre-joined docket feed summary — powers the feed/timeline without scanning comments."""
+
+    name: ClassVar[str] = "feed-summary"
+    inputs: ClassVar[tuple[str, ...]] = ("dockets.parquet", "comments_index.parquet", "documents.parquet")
+    output: ClassVar[str] = "feed_summary.parquet"
+
+    def build(self, output_dir: Path) -> Path:
+        return build_feed_summary(output_dir)
+
+
+app = make_rollup_app(FeedSummaryRollup)
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/pipelines/rollups/fr_docket_links.py
+++ b/src/spicy_regs/pipelines/rollups/fr_docket_links.py
@@ -1,0 +1,28 @@
+"""Rollup pipeline: fr_docket_links.parquet (Federal Register ↔ docket links)."""
+
+from pathlib import Path
+from typing import ClassVar
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.transforms import build_fr_docket_links
+
+
+class FrDocketLinksRollup(RollupPipeline):
+    """FR publications linked to each docket — replaces the docket page's LIKE scan.
+
+    ``federal_register.parquet`` is produced by a separate ingestion path; this
+    rollup reads it from R2 as a base input.
+    """
+
+    name: ClassVar[str] = "fr-docket-links"
+    inputs: ClassVar[tuple[str, ...]] = ("federal_register.parquet",)
+    output: ClassVar[str] = "fr_docket_links.parquet"
+
+    def build(self, output_dir: Path) -> Path:
+        return build_fr_docket_links(output_dir)
+
+
+app = make_rollup_app(FrDocketLinksRollup)
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/pipelines/rollups/rulemaking_lifecycles.py
+++ b/src/spicy_regs/pipelines/rollups/rulemaking_lifecycles.py
@@ -1,0 +1,24 @@
+"""Rollup pipeline: rulemaking_lifecycles.parquet (Proposed→Rule pairs + stuck)."""
+
+from pathlib import Path
+from typing import ClassVar
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.transforms import build_rulemaking_lifecycles
+
+
+class RulemakingLifecyclesRollup(RollupPipeline):
+    """Per-docket rulemaking durations + stuck proposals — agency profile / lab."""
+
+    name: ClassVar[str] = "lifecycles"
+    inputs: ClassVar[tuple[str, ...]] = ("documents.parquet",)
+    output: ClassVar[str] = "rulemaking_lifecycles.parquet"
+
+    def build(self, output_dir: Path) -> Path:
+        return build_rulemaking_lifecycles(output_dir)
+
+
+app = make_rollup_app(RulemakingLifecyclesRollup)
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -214,20 +214,16 @@ def upload_directory_to_r2(local_dir: Path, remote_prefix: str | None = None) ->
 
 
 def upload_dataset(output_dir: Path, data_types: list[str]) -> None:
-    """Publish the merged ``{data_type}.parquet`` files (+ rollups + manifest) in parallel."""
+    """Publish the merged ``{data_type}.parquet`` base tables (+ manifest) in parallel.
+
+    Rollups (feed_summary, agency_stats, ...) are no longer published here — each
+    is built and uploaded by its own decoupled ``run-rollup-*`` pipeline.
+    """
     files_to_upload = []
     for data_type in data_types:
         pf = output_dir / f"{data_type}.parquet"
         if pf.exists():
             files_to_upload.append(pf)
-
-    # Always include the materialized rollups if they exist (feed summary +
-    # the per-agency directory/profile rollups). These are tiny, denormalized,
-    # and identical across all viewers.
-    for rollup_name in ("feed_summary", "agency_stats", "agency_monthly_volume"):
-        rollup = output_dir / f"{rollup_name}.parquet"
-        if rollup.exists():
-            files_to_upload.append(rollup)
 
     manifest_file = output_dir / "manifest.parquet"
     if manifest_file.exists():

--- a/src/spicy_regs/transforms/__init__.py
+++ b/src/spicy_regs/transforms/__init__.py
@@ -1,6 +1,11 @@
 from spicy_regs.transforms.base import Transform
+from spicy_regs.transforms.build_agency_monthly_volume import build_agency_monthly_volume
 from spicy_regs.transforms.build_agency_rollups import build_agency_rollups
+from spicy_regs.transforms.build_agency_stats import build_agency_stats
+from spicy_regs.transforms.build_discovery_signals import build_discovery_signals
 from spicy_regs.transforms.build_feed_summary import build_feed_summary
+from spicy_regs.transforms.build_fr_docket_links import build_fr_docket_links
+from spicy_regs.transforms.build_rulemaking_lifecycles import build_rulemaking_lifecycles
 from spicy_regs.transforms.build_search_index import INDEX_FILENAME, build_search_index
 from spicy_regs.transforms.chain import Chain
 from spicy_regs.transforms.enrich_derived_text import EnrichCommentText
@@ -29,6 +34,11 @@ __all__ = [
     "partition_comments",
     "build_feed_summary",
     "build_agency_rollups",
+    "build_agency_stats",
+    "build_agency_monthly_volume",
+    "build_discovery_signals",
+    "build_rulemaking_lifecycles",
+    "build_fr_docket_links",
     "build_search_index",
     "INDEX_FILENAME",
     "extract_pdf_text",

--- a/src/spicy_regs/transforms/build_agency_monthly_volume.py
+++ b/src/spicy_regs/transforms/build_agency_monthly_volume.py
@@ -1,0 +1,75 @@
+"""Transform: build the per-agency monthly document-volume rollup.
+
+Split out of the former monolithic ``build_agency_rollups`` so it can be
+materialized by its own decoupled rollup pipeline. Produces
+``agency_monthly_volume.parquet`` — per-agency monthly document counts typed by
+``document_type``, serving both the directory activity sparkline and the profile
+activity panel.
+"""
+
+from pathlib import Path
+
+import polars as pl
+import pyarrow.parquet as pq
+from loguru import logger
+
+
+def build_agency_monthly_volume(output_dir: Path) -> Path:
+    """Build ``agency_monthly_volume.parquet`` — per-agency monthly document
+    count by ``document_type``.
+
+    Emits a stable-schema empty artifact when ``documents.parquet`` isn't present
+    yet, so the frontend can always read it.
+    """
+    import duckdb
+
+    documents_file = output_dir / "documents.parquet"
+    volume_file = output_dir / "agency_monthly_volume.parquet"
+
+    if documents_file.exists():
+        logger.info("Building agency monthly volume via DuckDB...")
+
+        spill_dir = output_dir / ".duckdb_tmp"
+        spill_dir.mkdir(exist_ok=True)
+
+        con = duckdb.connect()
+        con.execute("SET memory_limit='4GB'")
+        con.execute("SET preserve_insertion_order=false")
+        con.execute("SET threads=2")
+        con.execute(f"SET temp_directory='{spill_dir}'")
+
+        volume_query = f"""
+        COPY (
+            SELECT
+                agency_code,
+                EXTRACT(YEAR FROM TRY_CAST(posted_date AS DATE)) AS year,
+                EXTRACT(MONTH FROM TRY_CAST(posted_date AS DATE)) AS month,
+                document_type,
+                COUNT(*) AS document_count
+            FROM read_parquet('{documents_file}')
+            WHERE posted_date IS NOT NULL
+              AND TRY_CAST(posted_date AS DATE) IS NOT NULL
+            GROUP BY agency_code, year, month, document_type
+            ORDER BY agency_code, year, month
+        ) TO '{volume_file}' (FORMAT PARQUET, COMPRESSION ZSTD);
+        """
+        con.execute(volume_query)
+        con.close()
+    else:
+        # No documents yet — still emit the artifact with a stable schema so
+        # the frontend can always read it.
+        pl.DataFrame(
+            [],
+            schema={
+                "agency_code": pl.Utf8,
+                "year": pl.Int64,
+                "month": pl.Int64,
+                "document_type": pl.Utf8,
+                "document_count": pl.Int64,
+            },
+        ).write_parquet(volume_file, compression="zstd")
+
+    volume_rows = pq.ParquetFile(volume_file).metadata.num_rows
+    logger.info("Agency monthly volume: {:,} rows", volume_rows)
+
+    return volume_file

--- a/src/spicy_regs/transforms/build_agency_rollups.py
+++ b/src/spicy_regs/transforms/build_agency_rollups.py
@@ -1,160 +1,25 @@
-"""Transform: build the per-agency materialized rollups (stats + monthly volume)."""
+"""Transform: build the per-agency materialized rollups (stats + monthly volume).
+
+Thin orchestrator retained for backward compatibility. The logic now lives in
+two focused, independently-runnable transforms so each can be materialized by
+its own decoupled rollup pipeline:
+
+* :func:`build_agency_stats` → ``agency_stats.parquet``
+* :func:`build_agency_monthly_volume` → ``agency_monthly_volume.parquet``
+"""
 
 from pathlib import Path
 
-import polars as pl
-import pyarrow.parquet as pq
-from loguru import logger
+from spicy_regs.transforms.build_agency_monthly_volume import build_agency_monthly_volume
+from spicy_regs.transforms.build_agency_stats import build_agency_stats
 
 
 def build_agency_rollups(output_dir: Path) -> tuple[Path, Path]:
-    """Build the per-agency materialized rollups for the directory + profile pages.
+    """Build both per-agency rollups (stats + monthly volume).
 
-    Produces two small, denormalized "index-file" artifacts that replace
-    full scans of ``documents.parquet`` in the browser (see issue #54):
-
-    * ``agency_stats.parquet`` — one row per agency with dockets / documents /
-      comments counts (the directory + profile dimension table). Comment counts
-      come from the tiny ``comments_index.parquet`` rather than scanning the
-      24.7M-row comments dataset, falling back to the monolithic
-      ``comments.parquet`` if the index doesn't exist yet.
-    * ``agency_monthly_volume.parquet`` — per-agency monthly document count
-      typed by ``document_type``, so it serves both the directory activity
-      sparkline and the profile activity panel.
-
-    Both rollups are identical across all viewers and cheap to materialize.
+    Kept as a convenience wrapper; new code should call the two split transforms
+    directly. Returns ``(agency_stats.parquet, agency_monthly_volume.parquet)``.
     """
-    import duckdb
-
-    dockets_file = output_dir / "dockets.parquet"
-    documents_file = output_dir / "documents.parquet"
-    comments_index_file = output_dir / "comments_index.parquet"
-    comments_file = output_dir / "comments.parquet"
-
-    if not dockets_file.exists():
-        raise FileNotFoundError(f"dockets.parquet not found in {output_dir}")
-
-    logger.info("Building agency rollups via DuckDB...")
-
-    stats_file = output_dir / "agency_stats.parquet"
-    volume_file = output_dir / "agency_monthly_volume.parquet"
-
-    spill_dir = output_dir / ".duckdb_tmp"
-    spill_dir.mkdir(exist_ok=True)
-
-    con = duckdb.connect()
-    con.execute("SET memory_limit='4GB'")
-    con.execute("SET preserve_insertion_order=false")
-    con.execute("SET threads=2")
-    con.execute(f"SET temp_directory='{spill_dir}'")
-
-    # --- agency_stats: per-agency dockets / documents / comments counts ---
-    # Build the CTEs dynamically so the rollup works whether or not the
-    # documents / comments artifacts are present yet.
-    ctes = [
-        f"""dk AS (
-            SELECT agency_code, COUNT(*) AS docket_count
-            FROM read_parquet('{dockets_file}')
-            GROUP BY agency_code
-        )"""
-    ]
-    union_parts = ["SELECT agency_code FROM dk"]
-    joins = ["LEFT JOIN dk ON dk.agency_code = a.agency_code"]
-    doc_count_col = "0 AS document_count"
-    comment_count_col = "0 AS comment_count"
-
-    if documents_file.exists():
-        ctes.append(
-            f"""doc AS (
-            SELECT agency_code, COUNT(*) AS document_count
-            FROM read_parquet('{documents_file}')
-            GROUP BY agency_code
-        )"""
-        )
-        union_parts.append("SELECT agency_code FROM doc")
-        joins.append("LEFT JOIN doc ON doc.agency_code = a.agency_code")
-        doc_count_col = "COALESCE(doc.document_count, 0) AS document_count"
-
-    if comments_index_file.exists():
-        ctes.append(
-            f"""cmt AS (
-            SELECT agency_code, CAST(SUM(row_count) AS BIGINT) AS comment_count
-            FROM read_parquet('{comments_index_file}')
-            GROUP BY agency_code
-        )"""
-        )
-        union_parts.append("SELECT agency_code FROM cmt")
-        joins.append("LEFT JOIN cmt ON cmt.agency_code = a.agency_code")
-        comment_count_col = "COALESCE(cmt.comment_count, 0) AS comment_count"
-    elif comments_file.exists():
-        ctes.append(
-            f"""cmt AS (
-            SELECT agency_code, COUNT(*) AS comment_count
-            FROM read_parquet('{comments_file}')
-            GROUP BY agency_code
-        )"""
-        )
-        union_parts.append("SELECT agency_code FROM cmt")
-        joins.append("LEFT JOIN cmt ON cmt.agency_code = a.agency_code")
-        comment_count_col = "COALESCE(cmt.comment_count, 0) AS comment_count"
-
-    stats_query = f"""
-    COPY (
-        WITH {", ".join(ctes)},
-        agencies AS ({" UNION ".join(union_parts)})
-        SELECT
-            a.agency_code,
-            COALESCE(dk.docket_count, 0) AS docket_count,
-            {doc_count_col},
-            {comment_count_col}
-        FROM agencies a
-        {" ".join(joins)}
-        WHERE a.agency_code IS NOT NULL
-        ORDER BY comment_count DESC, document_count DESC, a.agency_code
-    ) TO '{stats_file}' (FORMAT PARQUET, COMPRESSION ZSTD);
-    """
-    con.execute(stats_query)
-
-    # --- agency_monthly_volume: per-agency monthly document count by type ---
-    if documents_file.exists():
-        volume_query = f"""
-        COPY (
-            SELECT
-                agency_code,
-                EXTRACT(YEAR FROM TRY_CAST(posted_date AS DATE)) AS year,
-                EXTRACT(MONTH FROM TRY_CAST(posted_date AS DATE)) AS month,
-                document_type,
-                COUNT(*) AS document_count
-            FROM read_parquet('{documents_file}')
-            WHERE posted_date IS NOT NULL
-              AND TRY_CAST(posted_date AS DATE) IS NOT NULL
-            GROUP BY agency_code, year, month, document_type
-            ORDER BY agency_code, year, month
-        ) TO '{volume_file}' (FORMAT PARQUET, COMPRESSION ZSTD);
-        """
-        con.execute(volume_query)
-    else:
-        # No documents yet — still emit the artifact with a stable schema so
-        # the frontend can always read it.
-        pl.DataFrame(
-            [],
-            schema={
-                "agency_code": pl.Utf8,
-                "year": pl.Int64,
-                "month": pl.Int64,
-                "document_type": pl.Utf8,
-                "document_count": pl.Int64,
-            },
-        ).write_parquet(volume_file, compression="zstd")
-
-    con.close()
-
-    stats_rows = pq.ParquetFile(stats_file).metadata.num_rows
-    volume_rows = pq.ParquetFile(volume_file).metadata.num_rows
-    logger.info(
-        "Agency rollups: agency_stats {:,} rows, agency_monthly_volume {:,} rows",
-        stats_rows,
-        volume_rows,
-    )
-
+    stats_file = build_agency_stats(output_dir)
+    volume_file = build_agency_monthly_volume(output_dir)
     return stats_file, volume_file

--- a/src/spicy_regs/transforms/build_agency_stats.py
+++ b/src/spicy_regs/transforms/build_agency_stats.py
@@ -1,0 +1,115 @@
+"""Transform: build the per-agency stats rollup (dockets/documents/comments counts).
+
+Split out of the former monolithic ``build_agency_rollups`` so it can be
+materialized by its own decoupled rollup pipeline. Produces
+``agency_stats.parquet`` — the directory + profile dimension table.
+"""
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from loguru import logger
+
+
+def build_agency_stats(output_dir: Path) -> Path:
+    """Build ``agency_stats.parquet`` — one row per agency with dockets /
+    documents / comments counts.
+
+    Comment counts come from the tiny ``comments_index.parquet`` rather than
+    scanning the 24.7M-row comments dataset, falling back to the monolithic
+    ``comments.parquet`` if the index doesn't exist yet. The CTEs are built
+    dynamically so the rollup works whether or not the documents / comments
+    artifacts are present yet.
+    """
+    import duckdb
+
+    dockets_file = output_dir / "dockets.parquet"
+    documents_file = output_dir / "documents.parquet"
+    comments_index_file = output_dir / "comments_index.parquet"
+    comments_file = output_dir / "comments.parquet"
+
+    if not dockets_file.exists():
+        raise FileNotFoundError(f"dockets.parquet not found in {output_dir}")
+
+    logger.info("Building agency stats via DuckDB...")
+
+    stats_file = output_dir / "agency_stats.parquet"
+
+    spill_dir = output_dir / ".duckdb_tmp"
+    spill_dir.mkdir(exist_ok=True)
+
+    con = duckdb.connect()
+    con.execute("SET memory_limit='4GB'")
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("SET threads=2")
+    con.execute(f"SET temp_directory='{spill_dir}'")
+
+    ctes = [
+        f"""dk AS (
+            SELECT agency_code, COUNT(*) AS docket_count
+            FROM read_parquet('{dockets_file}')
+            GROUP BY agency_code
+        )"""
+    ]
+    union_parts = ["SELECT agency_code FROM dk"]
+    joins = ["LEFT JOIN dk ON dk.agency_code = a.agency_code"]
+    doc_count_col = "0 AS document_count"
+    comment_count_col = "0 AS comment_count"
+
+    if documents_file.exists():
+        ctes.append(
+            f"""doc AS (
+            SELECT agency_code, COUNT(*) AS document_count
+            FROM read_parquet('{documents_file}')
+            GROUP BY agency_code
+        )"""
+        )
+        union_parts.append("SELECT agency_code FROM doc")
+        joins.append("LEFT JOIN doc ON doc.agency_code = a.agency_code")
+        doc_count_col = "COALESCE(doc.document_count, 0) AS document_count"
+
+    if comments_index_file.exists():
+        ctes.append(
+            f"""cmt AS (
+            SELECT agency_code, CAST(SUM(row_count) AS BIGINT) AS comment_count
+            FROM read_parquet('{comments_index_file}')
+            GROUP BY agency_code
+        )"""
+        )
+        union_parts.append("SELECT agency_code FROM cmt")
+        joins.append("LEFT JOIN cmt ON cmt.agency_code = a.agency_code")
+        comment_count_col = "COALESCE(cmt.comment_count, 0) AS comment_count"
+    elif comments_file.exists():
+        ctes.append(
+            f"""cmt AS (
+            SELECT agency_code, COUNT(*) AS comment_count
+            FROM read_parquet('{comments_file}')
+            GROUP BY agency_code
+        )"""
+        )
+        union_parts.append("SELECT agency_code FROM cmt")
+        joins.append("LEFT JOIN cmt ON cmt.agency_code = a.agency_code")
+        comment_count_col = "COALESCE(cmt.comment_count, 0) AS comment_count"
+
+    stats_query = f"""
+    COPY (
+        WITH {", ".join(ctes)},
+        agencies AS ({" UNION ".join(union_parts)})
+        SELECT
+            a.agency_code,
+            COALESCE(dk.docket_count, 0) AS docket_count,
+            {doc_count_col},
+            {comment_count_col}
+        FROM agencies a
+        {" ".join(joins)}
+        WHERE a.agency_code IS NOT NULL
+        ORDER BY comment_count DESC, document_count DESC, a.agency_code
+    ) TO '{stats_file}' (FORMAT PARQUET, COMPRESSION ZSTD);
+    """
+    con.execute(stats_query)
+    con.close()
+
+    stats_rows = pq.ParquetFile(stats_file).metadata.num_rows
+    logger.info("Agency stats: {:,} rows", stats_rows)
+
+    return stats_file

--- a/src/spicy_regs/transforms/build_discovery_signals.py
+++ b/src/spicy_regs/transforms/build_discovery_signals.py
@@ -1,0 +1,73 @@
+"""Transform: build the discovery *spike* signal rollup.
+
+Of the four feed discovery signals, only **spike** scans ``documents.parquet``
+in the browser (surge / closing / discussed already ride ``comments_index`` /
+``feed_summary``). This bakes the per-agency spike so the feed stops scanning
+the ~57 MB documents file on every load.
+
+Spike = agencies whose document output in the last 30 days is ≥ 2× their
+prior-year monthly mean (requiring ≥ 24 documents in the prior year to avoid
+tiny-denominator noise). Recomputed each run since it is CURRENT_DATE-relative;
+the full qualifying set is baked (no LIMIT) so the UI applies its own top-N.
+"""
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from loguru import logger
+
+
+def build_discovery_signals(output_dir: Path) -> Path:
+    """Build ``discovery_signals.parquet`` (the per-agency spike signal)."""
+    import duckdb
+
+    documents_file = output_dir / "documents.parquet"
+    if not documents_file.exists():
+        raise FileNotFoundError(f"documents.parquet not found in {output_dir}")
+
+    logger.info("Building discovery signals (spike) via DuckDB...")
+
+    out_file = output_dir / "discovery_signals.parquet"
+
+    spill_dir = output_dir / ".duckdb_tmp"
+    spill_dir.mkdir(exist_ok=True)
+
+    con = duckdb.connect()
+    con.execute("SET memory_limit='4GB'")
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("SET threads=2")
+    con.execute(f"SET temp_directory='{spill_dir}'")
+
+    query = f"""
+    COPY (
+        WITH per AS (
+            SELECT agency_code,
+              COUNT(*) FILTER (
+                WHERE TRY_CAST(posted_date AS TIMESTAMP) >= CURRENT_TIMESTAMP - INTERVAL '30' DAY
+              ) AS recent_30d,
+              COUNT(*) FILTER (
+                WHERE TRY_CAST(posted_date AS TIMESTAMP) >= CURRENT_TIMESTAMP - INTERVAL '13' MONTH
+                  AND TRY_CAST(posted_date AS TIMESTAMP) <  CURRENT_TIMESTAMP - INTERVAL '1' MONTH
+              ) AS prior_yr
+            FROM read_parquet('{documents_file}')
+            WHERE TRY_CAST(posted_date AS TIMESTAMP) >= CURRENT_TIMESTAMP - INTERVAL '13' MONTH
+              AND agency_code IS NOT NULL
+            GROUP BY 1
+        )
+        SELECT agency_code,
+               recent_30d,
+               (prior_yr / 12.0) AS baseline,
+               (recent_30d / NULLIF(prior_yr / 12.0, 0)) AS ratio
+        FROM per
+        WHERE prior_yr >= 24
+          AND (recent_30d / NULLIF(prior_yr / 12.0, 0)) >= 2.0
+        ORDER BY ratio DESC
+    ) TO '{out_file}' (FORMAT PARQUET, COMPRESSION ZSTD);
+    """
+    con.execute(query)
+    con.close()
+
+    rows = pq.ParquetFile(out_file).metadata.num_rows
+    logger.info("Discovery signals (spike): {:,} rows", rows)
+
+    return out_file

--- a/src/spicy_regs/transforms/build_fr_docket_links.py
+++ b/src/spicy_regs/transforms/build_fr_docket_links.py
@@ -1,0 +1,78 @@
+"""Transform: build the Federal Register ↔ docket link table.
+
+Replaces the ``docket_ids_json LIKE '%"<id>"%'`` full-scan over the 793K-row
+``federal_register.parquet`` that the docket page ran on every load. Explodes
+each FR document's ``docket_ids_json`` array into one row per (docket_id, FR
+doc), carrying the display columns the docket page needs, and sorts by
+``docket_id`` so ``WHERE docket_id = ?`` prunes row groups instead of scanning.
+
+``federal_register.parquet`` is produced by a **separate** federalregister.gov
+ingestion path (not this repo's ETL); this rollup reads it from R2 as a base
+input. Exploding preserves the exact matching semantics of the old ``LIKE``
+(verified equal on 200 sampled dockets), including the pre-existing quirk where
+a few array elements join two IDs — no regression introduced here.
+"""
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from loguru import logger
+
+
+def build_fr_docket_links(output_dir: Path) -> Path:
+    """Build ``fr_docket_links.parquet`` (exploded FR→docket links + display cols)."""
+    import duckdb
+
+    fr_file = output_dir / "federal_register.parquet"
+    if not fr_file.exists():
+        raise FileNotFoundError(f"federal_register.parquet not found in {output_dir}")
+
+    logger.info("Building FR docket links via DuckDB...")
+
+    out_file = output_dir / "fr_docket_links.parquet"
+
+    spill_dir = output_dir / ".duckdb_tmp"
+    spill_dir.mkdir(exist_ok=True)
+
+    con = duckdb.connect()
+    con.execute("SET memory_limit='4GB'")
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("SET threads=2")
+    con.execute(f"SET temp_directory='{spill_dir}'")
+
+    # Carries the columns the docket page's FR section renders (normalizeFRRow
+    # rebuilds `docket_ids` from docket_ids_json, so keep that column). Sorted by
+    # docket_id with a small row-group size so per-docket lookups prune.
+    query = f"""
+    COPY (
+        SELECT
+            link.docket_id AS docket_id,
+            fr.document_number,
+            fr.title,
+            fr.abstract,
+            fr.document_type,
+            fr.subtype,
+            fr.publication_date,
+            fr.effective_on,
+            fr.comments_close_on,
+            fr.signing_date,
+            fr.agency_slugs,
+            fr.docket_ids_json,
+            fr.html_url,
+            fr.pdf_url,
+            fr.executive_order_number
+        FROM read_parquet('{fr_file}') fr,
+             UNNEST(CAST(json_extract(fr.docket_ids_json, '$') AS VARCHAR[])) AS link(docket_id)
+        WHERE fr.docket_ids_json IS NOT NULL
+          AND link.docket_id IS NOT NULL
+          AND TRIM(link.docket_id) <> ''
+        ORDER BY docket_id, fr.publication_date DESC
+    ) TO '{out_file}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 50000);
+    """
+    con.execute(query)
+    con.close()
+
+    rows = pq.ParquetFile(out_file).metadata.num_rows
+    logger.info("FR docket links: {:,} rows", rows)
+
+    return out_file

--- a/src/spicy_regs/transforms/build_rulemaking_lifecycles.py
+++ b/src/spicy_regs/transforms/build_rulemaking_lifecycles.py
@@ -1,0 +1,95 @@
+"""Transform: build the rulemaking-lifecycles rollup (Proposed→Rule pairing).
+
+Replaces the multi-CTE self-join over ``documents.parquet`` that the browser ran
+on the agency profile / lab panels. Bakes both shapes the UI needs into one
+artifact, discriminated by a ``kind`` column, for **all** agencies (the UI
+filters by agency and slices its own samples/percentiles client-side):
+
+* ``kind = 'pair'``  — completed rulemakings: the earliest Proposed Rule paired
+  with the earliest matching Rule for the same docket, with the completion
+  ``days``. Powers the per-agency duration percentiles, the completed strip-plot
+  sample, and the government-wide benchmark.
+* ``kind = 'stuck'`` — Proposed Rules with no matching Rule in the docket
+  (``final_date``/``days`` NULL). The UI derives ``days_open`` from
+  ``proposed_date`` live and applies its own age-window + tier sampling.
+
+Bounded to ``proposed_date >= 2010`` (matching the browser floor); otherwise
+date-independent, so it does not need a daily rebuild for correctness.
+"""
+
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from loguru import logger
+
+
+def build_rulemaking_lifecycles(output_dir: Path) -> Path:
+    """Build ``rulemaking_lifecycles.parquet`` (completed pairs + stuck proposals)."""
+    import duckdb
+
+    documents_file = output_dir / "documents.parquet"
+    if not documents_file.exists():
+        raise FileNotFoundError(f"documents.parquet not found in {output_dir}")
+
+    logger.info("Building rulemaking lifecycles via DuckDB...")
+
+    out_file = output_dir / "rulemaking_lifecycles.parquet"
+
+    spill_dir = output_dir / ".duckdb_tmp"
+    spill_dir.mkdir(exist_ok=True)
+
+    con = duckdb.connect()
+    con.execute("SET memory_limit='4GB'")
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("SET threads=2")
+    con.execute(f"SET temp_directory='{spill_dir}'")
+
+    query = f"""
+    COPY (
+        WITH props AS (
+            SELECT docket_id, agency_code,
+                   ANY_VALUE(title) AS title,
+                   MIN(TRY_CAST(posted_date AS DATE)) AS proposed_date
+            FROM read_parquet('{documents_file}')
+            WHERE document_type = 'Proposed Rule'
+            GROUP BY 1, 2
+        ),
+        finals AS (
+            SELECT docket_id, MIN(TRY_CAST(posted_date AS DATE)) AS final_date
+            FROM read_parquet('{documents_file}')
+            WHERE document_type = 'Rule'
+            GROUP BY 1
+        ),
+        pairs AS (
+            SELECT 'pair' AS kind, p.docket_id, p.agency_code, p.title,
+                   p.proposed_date, f.final_date,
+                   date_diff('day', p.proposed_date, f.final_date) AS days
+            FROM props p
+            JOIN finals f USING (docket_id)
+            WHERE p.proposed_date IS NOT NULL
+              AND f.final_date IS NOT NULL
+              AND f.final_date >= p.proposed_date
+              AND p.proposed_date >= DATE '2010-01-01'
+        ),
+        stuck AS (
+            SELECT 'stuck' AS kind, p.docket_id, p.agency_code, p.title,
+                   p.proposed_date, CAST(NULL AS DATE) AS final_date,
+                   CAST(NULL AS BIGINT) AS days
+            FROM props p
+            LEFT JOIN finals f USING (docket_id)
+            WHERE f.docket_id IS NULL
+              AND p.proposed_date IS NOT NULL
+              AND p.proposed_date >= DATE '2010-01-01'
+        )
+        SELECT * FROM pairs
+        UNION ALL
+        SELECT * FROM stuck
+    ) TO '{out_file}' (FORMAT PARQUET, COMPRESSION ZSTD);
+    """
+    con.execute(query)
+    con.close()
+
+    rows = pq.ParquetFile(out_file).metadata.num_rows
+    logger.info("Rulemaking lifecycles: {:,} rows (pairs + stuck)", rows)
+
+    return out_file

--- a/tests/test_regulations_pipeline.py
+++ b/tests/test_regulations_pipeline.py
@@ -127,7 +127,6 @@ def test_run_extracts_stages_and_merges(tmp_output: Path, monkeypatch: pytest.Mo
         agency=AGENCY,
         output_dir=tmp_output,
         skip_comments=True,
-        skip_post_process=True,
         skip_upload=True,
     ).run()
 
@@ -146,7 +145,7 @@ def test_run_dedups_on_merge_keeping_latest_modify_date(
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
 
     RegulationsPipeline(
-        agency=AGENCY, output_dir=tmp_output, skip_comments=True, skip_post_process=True, skip_upload=True
+        agency=AGENCY, output_dir=tmp_output, skip_comments=True, skip_upload=True
     ).run()
 
     df = pl.read_parquet(tmp_output / "dockets.parquet")
@@ -158,7 +157,7 @@ def test_run_with_no_records_is_noop(tmp_output: Path, monkeypatch: pytest.Monke
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource({}))
 
     RegulationsPipeline(
-        agency=AGENCY, output_dir=tmp_output, skip_comments=True, skip_post_process=True, skip_upload=True
+        agency=AGENCY, output_dir=tmp_output, skip_comments=True, skip_upload=True
     ).run()
 
     assert not (tmp_output / "dockets.parquet").exists()
@@ -170,7 +169,7 @@ def test_run_with_no_records_is_noop(tmp_output: Path, monkeypatch: pytest.Monke
 def _run(tmp_output: Path, **overrides: Any) -> None:
     kwargs: dict[str, Any] = dict(
         agency=AGENCY, output_dir=tmp_output, skip_comments=True,
-        skip_post_process=True, skip_upload=True,
+        skip_upload=True,
     )
     kwargs.update(overrides)
     RegulationsPipeline(**kwargs).run()
@@ -238,7 +237,7 @@ def test_processes_multiple_agencies_in_parallel(
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
 
     RegulationsPipeline(
-        output_dir=tmp_output, skip_comments=True, skip_post_process=True,
+        output_dir=tmp_output, skip_comments=True,
         skip_upload=True, max_workers=2,
     ).run()
 
@@ -274,7 +273,7 @@ def test_run_uploads_changed_comment_partitions(
 
     RegulationsPipeline(
         agency=AGENCY, output_dir=tmp_output, only_comments=True,
-        enrich_text=False, skip_post_process=True, skip_upload=False,
+        enrich_text=False, skip_upload=False,
     ).run()
 
     assert "partitions" in calls, "changed comment partitions were never uploaded"
@@ -304,7 +303,7 @@ def test_run_skips_partition_upload_when_no_comments(
 
     RegulationsPipeline(
         agency=AGENCY, output_dir=tmp_output, skip_comments=True,
-        skip_post_process=True, skip_upload=False,
+        skip_upload=False,
     ).run()
 
     assert "dataset" in calls
@@ -361,7 +360,7 @@ def test_run_primes_comments_index_from_r2_before_merge(
 
     RegulationsPipeline(
         agency=AGENCY, output_dir=tmp_output, only_comments=True,
-        enrich_text=False, skip_post_process=True, skip_upload=False,
+        enrich_text=False, skip_upload=False,
     ).run()
 
     assert "comments_index.parquet" in requested, "existing comment index was never fetched from R2"

--- a/tests/test_regulations_pipeline.py
+++ b/tests/test_regulations_pipeline.py
@@ -172,7 +172,6 @@ def _run(tmp_output: Path, **overrides: Any) -> None:
         agency=AGENCY,
         output_dir=tmp_output,
         skip_comments=True,
-        skip_post_process=True,
         skip_upload=True,
     )
     kwargs.update(overrides)
@@ -238,7 +237,6 @@ def test_processes_multiple_agencies_in_parallel(tmp_output: Path, monkeypatch: 
     RegulationsPipeline(
         output_dir=tmp_output,
         skip_comments=True,
-        skip_post_process=True,
         skip_upload=True,
         max_workers=2,
     ).run()
@@ -278,7 +276,6 @@ def test_run_uploads_changed_comment_partitions(tmp_output: Path, monkeypatch: p
         output_dir=tmp_output,
         only_comments=True,
         enrich_text=False,
-        skip_post_process=True,
         skip_upload=False,
     ).run()
 
@@ -310,7 +307,6 @@ def test_run_skips_partition_upload_when_no_comments(tmp_output: Path, monkeypat
         agency=AGENCY,
         output_dir=tmp_output,
         skip_comments=True,
-        skip_post_process=True,
         skip_upload=False,
     ).run()
 
@@ -372,7 +368,6 @@ def test_run_primes_comments_index_from_r2_before_merge(tmp_output: Path, monkey
         output_dir=tmp_output,
         only_comments=True,
         enrich_text=False,
-        skip_post_process=True,
         skip_upload=False,
     ).run()
 


### PR DESCRIPTION
## Why

The main ETL built `feed_summary` + agency rollups + the search index **inline on its final batch**. This couples rollup logic to the extract/merge pipeline: you can't re-run or backfill one rollup without the whole ETL, a rollup failure isn't isolated, and the heavier rollups (comment clustering later) don't belong in the ETL's tail.

This splits every materialized rollup into its **own decoupled pipeline** with its **own GitHub Actions workflow on an independent cron**. (Companion UI PR: `ekim1394/spicy-regs-ui#3`, which repoints the browser's hot-scan queries onto these rollups. We deliberately kept the UI on Parquet+DuckDB — no database — see that PR.)

## What changed

- **`RollupPipeline` base** (`pipelines/rollups/base.py`): prime (download base tables from R2) → build (a `transforms/build_*.py`) → load (upload one artifact, reusing the R2 shrink guard). `make_rollup_app` gives each rollup a `run-rollup-*` CLI.
- **One pipeline + `run-rollup-*` entry per rollup:** `feed_summary`, `agency_stats`, `agency_monthly_volume`, `docket_search`, plus three **new**: `rulemaking_lifecycles` (Proposed→Rule pairs + stuck proposals), `discovery_signals` (the per-agency document-output *spike* — the only discovery signal that scanned documents), `fr_docket_links` (explodes `federal_register.docket_ids_json`, sorted by `docket_id`).
- **Split** `build_agency_rollups` → `build_agency_stats` + `build_agency_monthly_volume` (orchestrator kept for back-compat; existing tests unchanged).
- **Decoupled the main ETL:** removed the inline post-process and the `--skip-post-process` flag from `RegulationsPipeline`, and the rollup-append from `r2.upload_dataset`. The ETL now only publishes base tables + `comments_index`.
- **Workflows:** one `rollup-*.yml` per rollup on a staggered cron (22:30–23:30 UTC, after the ETL's 20:25 batch-14 window) + `workflow_dispatch`, all delegating to a reusable `_rollup.yml`.

**Contract:** each rollup reads only the ETL's published *base tables* (`dockets`, `documents`, `comments_index`, `federal_register`) — never a sibling rollup's output — so they stay independently schedulable with no cross-pipeline race. `comments_index` stays in the ETL (built incrementally during comment merge). `federal_register.parquet` is produced by a separate ingestion path; `fr_docket_links` reads it from R2.

## Verification

- Rollup SQL verified against **live R2** via the Spicy Regs MCP: `discovery_signals` spike, `rulemaking_lifecycles` (26,085 rows = 19,204 pairs + 6,881 stuck), `fr_docket_links` explode (200 dockets, 0 mismatches vs the old `LIKE`).
- Ran `discovery_signals`, `agency_monthly_volume`, `rulemaking_lifecycles` **end-to-end** (prime from R2 → build) — correct output; the "reuse local input" path works.
- `ruff check` clean; `pytest` transform + regulations-pipeline tests pass (updated the tests that passed the removed `skip_post_process`).

## Rollout note

The 3 new rollups' Parquet files must be produced once (dispatch their workflows, or `run-rollup-* --no-skip-upload`) so they exist on R2 before the companion UI PR deploys.