### PR TITLE
Fix connection leak that hung the extract on large agencies

### DIFF
--- a/src/spicy_regs/sources/mirrulations.py
+++ b/src/spicy_regs/sources/mirrulations.py
@@ -49,7 +49,16 @@ def s3_resource(max_pool_connections: int = DEFAULT_DOWNLOAD_WORKERS) -> Any:
     return boto3.resource(
         "s3",
         region_name="us-east-1",
-        config=BotoConfig(signature_version=UNSIGNED, max_pool_connections=max_pool_connections),
+        config=BotoConfig(
+            signature_version=UNSIGNED,
+            max_pool_connections=max_pool_connections,
+            # Bound every S3 op so a stalled connection fails fast and retries
+            # instead of wedging a worker indefinitely; standard mode retries
+            # transient errors (throttling, resets) rather than dropping records.
+            connect_timeout=30,
+            read_timeout=30,
+            retries={"max_attempts": 5, "mode": "standard"},
+        ),
     )
 
 
@@ -173,12 +182,22 @@ def download_and_parse(
     key: str,
     extract_fn: Callable[[dict], dict],
 ) -> dict | None:
-    """Download a single JSON file from S3 and parse it with the given extractor."""
+    """Download a single JSON file from S3 and parse it with the given extractor.
+
+    The response body is closed on every path — including a failed read — so a
+    transient error can't leak the connection into CLOSE_WAIT and starve the
+    pool. Leaked connections were the cause of the low-CPU/CLOSE_WAIT hang seen
+    on large agencies: once the pool drained, later downloads blocked forever
+    waiting for a free connection.
+    """
     try:
         obj = s3_resource.Object(bucket_name, key)
-        content = obj.get()["Body"].read()
-        data = loads(content)
-        return extract_fn(data)
+        body = obj.get()["Body"]
+        try:
+            content = body.read()
+        finally:
+            body.close()
+        return extract_fn(loads(content))
     except Exception:
         return None
 

--- a/tests/test_mirrulations_reader.py
+++ b/tests/test_mirrulations_reader.py
@@ -32,6 +32,9 @@ class _FakeBody:
     def read(self) -> bytes:
         return self._data
 
+    def close(self) -> None:
+        pass
+
 
 class _FakeObj:
     def __init__(self, key: str, content: bytes) -> None:
@@ -216,6 +219,53 @@ def test_reader_factory_scans_each_agency_once() -> None:
     assert len(keys_by_type["dockets"]) == 1
     assert len(keys_by_type["documents"]) == 1
     assert len(keys_by_type["comments"]) == 1
+
+
+def test_download_and_parse_closes_body_on_read_error() -> None:
+    """A failed download must still close the response body.
+
+    If ``read()`` raises (timeout, connection reset) and the body is left open,
+    the underlying S3 connection leaks into CLOSE_WAIT instead of returning to
+    the pool. Enough leaks exhaust the pool and later downloads block forever
+    acquiring a connection — the low-CPU / CLOSE_WAIT-pileup hang seen on large
+    agencies. Closing the body on every path keeps the pool healthy.
+    """
+    from spicy_regs.sources.mirrulations import download_and_parse
+
+    closed = {"value": False}
+
+    class _Body:
+        def read(self) -> bytes:
+            raise OSError("connection reset by peer")
+
+        def close(self) -> None:
+            closed["value"] = True
+
+    class _Obj:
+        def get(self) -> dict:
+            return {"Body": _Body()}
+
+    class _Res:
+        def Object(self, bucket: str, key: str) -> _Obj:  # noqa: N802
+            return _Obj()
+
+    result = download_and_parse(_Res(), BUCKET, "some/key.json", lambda d: d)
+
+    assert result is None  # the error is swallowed (record skipped this run)
+    assert closed["value"] is True  # ...but the body was closed, so no leak
+
+
+def test_s3_resource_configures_retries() -> None:
+    """The resource must set an explicit retry policy so a transient S3 error
+    is retried rather than silently dropping the record (botocore's default
+    leaves ``retries`` unset)."""
+    from spicy_regs.sources.mirrulations import s3_resource
+
+    cfg = s3_resource().meta.client.meta.config
+    assert cfg.retries is not None
+    # botocore normalizes max_attempts -> total_max_attempts under standard mode.
+    attempts = cfg.retries.get("total_max_attempts") or cfg.retries.get("max_attempts", 0)
+    assert attempts >= 2
 
 
 def test_s3_resource_connection_pool_fits_download_workers() -> None:

--- a/tests/test_regulations_pipeline.py
+++ b/tests/test_regulations_pipeline.py
@@ -39,6 +39,9 @@ class _FakeBody:
     def read(self) -> bytes:
         return self._data
 
+    def close(self) -> None:
+        pass
+
 
 class _FakeObj:
     def __init__(self, key: str, content: bytes) -> None:
@@ -135,9 +138,7 @@ def test_run_extracts_stages_and_merges(tmp_output: Path, monkeypatch: pytest.Mo
     assert sorted(df["docket_id"].to_list()) == ["EPA-2024-0001", "EPA-2025-0002"]
 
 
-def test_run_dedups_on_merge_keeping_latest_modify_date(
-    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_dedups_on_merge_keeping_latest_modify_date(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Same docket id seen twice with different modify dates -> one row, latest wins.
     store = {
         _docket_key("EPA-2024-0001", "old"): dumps(_docket_payload("EPA-2024-0001", "2024-01-01")).encode(),
@@ -169,16 +170,17 @@ def test_run_with_no_records_is_noop(tmp_output: Path, monkeypatch: pytest.Monke
 
 def _run(tmp_output: Path, **overrides: Any) -> None:
     kwargs: dict[str, Any] = dict(
-        agency=AGENCY, output_dir=tmp_output, skip_comments=True,
-        skip_post_process=True, skip_upload=True,
+        agency=AGENCY,
+        output_dir=tmp_output,
+        skip_comments=True,
+        skip_post_process=True,
+        skip_upload=True,
     )
     kwargs.update(overrides)
     RegulationsPipeline(**kwargs).run()
 
 
-def test_second_run_skips_keys_already_in_manifest(
-    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_second_run_skips_keys_already_in_manifest(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     store = {
         _docket_key("EPA-2024-0001"): dumps(_docket_payload("EPA-2024-0001", "2024-01-01")).encode(),
@@ -200,9 +202,7 @@ def test_second_run_skips_keys_already_in_manifest(
     assert merge_calls == []
 
 
-def test_full_refresh_reprocesses_despite_manifest(
-    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_full_refresh_reprocesses_despite_manifest(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     store = {_docket_key("EPA-2024-0001"): dumps(_docket_payload("EPA-2024-0001", "2024-01-01")).encode()}
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
@@ -212,7 +212,8 @@ def test_full_refresh_reprocesses_despite_manifest(
     merge_calls: list = []
     real_merge = regulations.merge_staging_files
     monkeypatch.setattr(
-        regulations, "merge_staging_files",
+        regulations,
+        "merge_staging_files",
         lambda *a, **k: (merge_calls.append(1), real_merge(*a, **k))[1],
     )
     _run(tmp_output, full_refresh=True)
@@ -222,9 +223,7 @@ def test_full_refresh_reprocesses_despite_manifest(
 # --- parallelism -----------------------------------------------------------
 
 
-def test_processes_multiple_agencies_in_parallel(
-    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_processes_multiple_agencies_in_parallel(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     monkeypatch.setenv("AGENCIES", "EPA,FDA")
     store = {
@@ -238,8 +237,11 @@ def test_processes_multiple_agencies_in_parallel(
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
 
     RegulationsPipeline(
-        output_dir=tmp_output, skip_comments=True, skip_post_process=True,
-        skip_upload=True, max_workers=2,
+        output_dir=tmp_output,
+        skip_comments=True,
+        skip_post_process=True,
+        skip_upload=True,
+        max_workers=2,
     ).run()
 
     df = pl.read_parquet(tmp_output / "dockets.parquet")
@@ -249,9 +251,7 @@ def test_processes_multiple_agencies_in_parallel(
 # --- upload ----------------------------------------------------------------
 
 
-def test_run_uploads_changed_comment_partitions(
-    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_uploads_changed_comment_partitions(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A run that stages comments must publish the changed partitions + index,
     not just the monolithic dataset."""
     monkeypatch.delenv("R2_PUBLIC_URL", raising=False)  # keep merge's R2 fetch offline
@@ -264,17 +264,23 @@ def test_run_uploads_changed_comment_partitions(
 
     calls: dict[str, list] = {}
     monkeypatch.setattr(
-        regulations.r2, "upload_dataset",
+        regulations.r2,
+        "upload_dataset",
         lambda out, types: calls.setdefault("dataset", []).append((out, types)),
     )
     monkeypatch.setattr(
-        regulations.r2, "upload_comment_partitions",
+        regulations.r2,
+        "upload_comment_partitions",
         lambda out, changed: calls.setdefault("partitions", []).append((out, list(changed))),
     )
 
     RegulationsPipeline(
-        agency=AGENCY, output_dir=tmp_output, only_comments=True,
-        enrich_text=False, skip_post_process=True, skip_upload=False,
+        agency=AGENCY,
+        output_dir=tmp_output,
+        only_comments=True,
+        enrich_text=False,
+        skip_post_process=True,
+        skip_upload=False,
     ).run()
 
     assert "partitions" in calls, "changed comment partitions were never uploaded"
@@ -285,9 +291,7 @@ def test_run_uploads_changed_comment_partitions(
     assert "dataset" in calls
 
 
-def test_run_skips_partition_upload_when_no_comments(
-    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_skips_partition_upload_when_no_comments(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A dockets-only run must not call the comment-partition upload."""
     monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     store = {
@@ -298,22 +302,24 @@ def test_run_skips_partition_upload_when_no_comments(
     calls: dict[str, list] = {}
     monkeypatch.setattr(regulations.r2, "upload_dataset", lambda out, types: calls.setdefault("dataset", []).append(1))
     monkeypatch.setattr(
-        regulations.r2, "upload_comment_partitions",
+        regulations.r2,
+        "upload_comment_partitions",
         lambda out, changed: calls.setdefault("partitions", []).append(1),
     )
 
     RegulationsPipeline(
-        agency=AGENCY, output_dir=tmp_output, skip_comments=True,
-        skip_post_process=True, skip_upload=False,
+        agency=AGENCY,
+        output_dir=tmp_output,
+        skip_comments=True,
+        skip_post_process=True,
+        skip_upload=False,
     ).run()
 
     assert "dataset" in calls
     assert "partitions" not in calls
 
 
-def test_run_primes_comments_index_from_r2_before_merge(
-    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_run_primes_comments_index_from_r2_before_merge(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """An incremental comments run must download the existing global index.
 
     ``update_comments_index`` keeps the rows for partitions this batch didn't
@@ -343,8 +349,11 @@ def test_run_primes_comments_index_from_r2_before_merge(
             "row_count": [42],
         },
         schema={
-            "agency_code": pl.Utf8, "docket_id": pl.Utf8,
-            "year": pl.Int64, "month": pl.Int64, "row_count": pl.Int64,
+            "agency_code": pl.Utf8,
+            "docket_id": pl.Utf8,
+            "year": pl.Int64,
+            "month": pl.Int64,
+            "row_count": pl.Int64,
         },
     )
 
@@ -360,8 +369,12 @@ def test_run_primes_comments_index_from_r2_before_merge(
     monkeypatch.setattr(regulations.r2, "download", fake_download)
 
     RegulationsPipeline(
-        agency=AGENCY, output_dir=tmp_output, only_comments=True,
-        enrich_text=False, skip_post_process=True, skip_upload=False,
+        agency=AGENCY,
+        output_dir=tmp_output,
+        only_comments=True,
+        enrich_text=False,
+        skip_post_process=True,
+        skip_upload=False,
     ).run()
 
     assert "comments_index.parquet" in requested, "existing comment index was never fetched from R2"


### PR DESCRIPTION
## Bug

Large-agency batches hung for hours with a distinctive signature — **0 ESTABLISHED connections, a pile of CLOSE_WAIT, ~3-7% CPU, no progress** — until killed (one batch was SIGKILLed after ~16h). It recurred even after the earlier connection-pool sizing fix. Hit repeatedly during the comments re-ingest (batches containing EPA and other high-volume agencies).

## Root cause

`download_and_parse` read `obj.get()["Body"]` but **never closed the body on the error path**. When a read raised (read timeout, connection reset — more likely on big agencies with many GETs), the `except` swallowed it and returned `None`, but the unclosed streaming body left its connection dangling in CLOSE_WAIT instead of returning it to the pool. Enough leaks drained the pool, and subsequent downloads then **blocked forever acquiring a connection** (pool acquisition has no timeout) — hence the low-CPU/CLOSE_WAIT hang, unaffected by the 60s read timeout (the threads weren't reading, they were waiting for a connection).

Confirmed the *listing* is a separate, CPU-bound cost (100% CPU, progresses) — not this hang, which is download-side and low-CPU.

## Fix

- Close the response body on **every** path — read the content in `try/finally` — so a failed read can't leak the connection.
- Configure `s3_resource` with explicit **30s connect/read timeouts** and **standard retry mode (5 attempts)**, so a transient stall fails fast and retries rather than silently dropping the record.

## Tests

- `test_download_and_parse_closes_body_on_read_error` — body is closed even when `read()` raises (RED before the fix).
- `test_s3_resource_configures_retries` — an explicit retry policy is set.
- Updated the `_FakeBody` test doubles to implement `close()` (they modeled only `read()`, which is why the leak wasn't caught).
- Full suite green (235 passed).

## Caveat

Validated via unit tests + the observed runtime signature; a full end-to-end re-validation on EPA is impractical (its listing alone runs many minutes). The listing-floor slowness on giant agencies is a separate, known issue not addressed here.