### PR TITLE
Close derived-data response body on error (the enrich-path connection leak)

### DIFF
--- a/src/spicy_regs/sources/derived_text.py
+++ b/src/spicy_regs/sources/derived_text.py
@@ -43,10 +43,7 @@ _EXTRACTED_RE = re.compile(r"(?P<comment_id>.+)_attachment_\d+_extracted\.txt$")
 
 def comments_extracted_prefix(agency: str, docket_id: str) -> str:
     """S3 prefix holding one docket's comment-attachment extractions (all tools)."""
-    return (
-        f"{DERIVED_PREFIX}/{agency}/{docket_id}/mirrulations/"
-        f"extracted_txt/comments_extracted_text/"
-    )
+    return f"{DERIVED_PREFIX}/{agency}/{docket_id}/mirrulations/extracted_txt/comments_extracted_text/"
 
 
 class DerivedCommentText:
@@ -86,9 +83,7 @@ class DerivedCommentText:
         self._docket_index[docket_id] = index
         return index
 
-    def text_for(
-        self, agency: str | None, docket_id: str | None, comment_id: str | None
-    ) -> str | None:
+    def text_for(self, agency: str | None, docket_id: str | None, comment_id: str | None) -> str | None:
         """Concatenated extracted text for one comment, or ``None`` if none exists."""
         if not (agency and docket_id and comment_id):
             return None
@@ -100,7 +95,13 @@ class DerivedCommentText:
         parts: list[str] = []
         for key in keys:
             try:
-                body = self._resource.Object(self._bucket_name, key).get()["Body"].read()
+                stream = self._resource.Object(self._bucket_name, key).get()["Body"]
+                # Close the body on every path — a failed read must not leak the
+                # connection into CLOSE_WAIT and eventually starve the pool.
+                try:
+                    body = stream.read()
+                finally:
+                    stream.close()
             except Exception as exc:  # noqa: BLE001 — one bad object shouldn't sink the rest
                 logger.warning("derived-data read failed for {}: {}", key, exc)
                 continue

--- a/tests/test_derived_text.py
+++ b/tests/test_derived_text.py
@@ -114,12 +114,15 @@ def test_text_for_closes_body_on_read_error() -> None:
         def close(self) -> None:
             closed["value"] = True
 
-    class _RaisingObj:
+    class _RaisingObj(_FakeObj):
+        def __init__(self) -> None:
+            super().__init__("key", b"")
+
         def get(self) -> dict:
             return {"Body": _RaisingBody()}
 
     class _RaisingResource(_FakeS3Resource):
-        def Object(self, name: str, key: str) -> _RaisingObj:  # noqa: N802
+        def Object(self, name: str, key: str) -> _FakeObj:  # noqa: N802
             return _RaisingObj()
 
     fetcher = DerivedCommentText(_RaisingResource(_store()), BUCKET)

--- a/tests/test_derived_text.py
+++ b/tests/test_derived_text.py
@@ -26,6 +26,9 @@ class _FakeBody:
     def read(self) -> bytes:
         return self._data
 
+    def close(self) -> None:
+        pass
+
 
 class _FakeObj:
     def __init__(self, key: str, content: bytes) -> None:
@@ -70,12 +73,20 @@ def _store() -> dict[str, bytes]:
     # ACF docket: comment 0004 has one attachment; comment 0015 has two
     # (pypdf tool). EPA docket: comment 0009 uses a different tool (pdfminer).
     return {
-        _extracted_key("ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0004_attachment_1_extracted.txt"): b"Wisconsin DCF comment body",
-        _extracted_key("ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0015_attachment_1_extracted.txt"): b"first attachment",
-        _extracted_key("ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0015_attachment_2_extracted.txt"): b"second attachment",
+        _extracted_key(
+            "ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0004_attachment_1_extracted.txt"
+        ): b"Wisconsin DCF comment body",
+        _extracted_key(
+            "ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0015_attachment_1_extracted.txt"
+        ): b"first attachment",
+        _extracted_key(
+            "ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0015_attachment_2_extracted.txt"
+        ): b"second attachment",
         # An empty extraction (e.g. a scanned/image PDF) — should not count as text.
         _extracted_key("ACF", "ACF-2025-0038", "pypdf", "ACF-2025-0038-0020_attachment_1_extracted.txt"): b"   \n  ",
-        _extracted_key("EPA", "EPA-HQ-OA-2024-0001", "pdfminer", "EPA-HQ-OA-2024-0001-0009_attachment_1_extracted.txt"): b"EPA comment text",
+        _extracted_key(
+            "EPA", "EPA-HQ-OA-2024-0001", "pdfminer", "EPA-HQ-OA-2024-0001-0009_attachment_1_extracted.txt"
+        ): b"EPA comment text",
     }
 
 
@@ -85,6 +96,38 @@ def _store() -> dict[str, bytes]:
 def test_text_for_single_attachment() -> None:
     fetcher = DerivedCommentText(_FakeS3Resource(_store()), BUCKET)
     assert fetcher.text_for("ACF", "ACF-2025-0038", "ACF-2025-0038-0004") == "Wisconsin DCF comment body"
+
+
+def test_text_for_closes_body_on_read_error() -> None:
+    """A failed derived-data read must still close the response body.
+
+    With enrichment on, text_for runs per comment; a leaked body (open on the
+    error path) leaves its S3 connection in CLOSE_WAIT until the pool starves
+    and downloads block forever — the hang seen on comment-heavy agencies.
+    """
+    closed = {"value": False}
+
+    class _RaisingBody:
+        def read(self) -> bytes:
+            raise OSError("connection reset by peer")
+
+        def close(self) -> None:
+            closed["value"] = True
+
+    class _RaisingObj:
+        def get(self) -> dict:
+            return {"Body": _RaisingBody()}
+
+    class _RaisingResource(_FakeS3Resource):
+        def Object(self, name: str, key: str) -> _RaisingObj:  # noqa: N802
+            return _RaisingObj()
+
+    fetcher = DerivedCommentText(_RaisingResource(_store()), BUCKET)
+    # This comment has one attachment in the index, so text_for reaches the read.
+    result = fetcher.text_for("ACF", "ACF-2025-0038", "ACF-2025-0038-0004")
+
+    assert result is None  # the bad read is handled gracefully
+    assert closed["value"] is True  # ...and the body was closed, so no leak
 
 
 def test_text_for_concatenates_multiple_attachments_in_order() -> None:


### PR DESCRIPTION
## Bug

The comment re-ingest kept hanging on comment-heavy agencies (EPA, etc.) — low CPU, CLOSE_WAIT pileup, no progress for hours — **even after PR #100** fixed the connection leak in `download_and_parse`.

## Root cause (confirmed via stack sample)

A macOS `sample` of a hung process showed the main thread parked on a lock waiting for stuck download futures — a download/network stall, not the catalog write. PR #100 fixed one download path, but `DerivedCommentText.text_for` (the **comment-text enrichment** path) had the identical unclosed-body pattern:

```python
body = self._resource.Object(...).get()["Body"].read()  # no close() on error
```

The re-ingest runs with enrichment **on** (`--only-comments` doesn't disable it), so every comment hits this path. A failed read left the streaming body — and its connection — in CLOSE_WAIT; enough leaks drained the pool and later downloads blocked forever acquiring a connection.

## Fix

Read the body in `try/finally` with `close()`, mirroring the `download_and_parse` fix. `grep` confirms these were the **only two** `.get()["Body"]` sites in the codebase — both are now leak-safe.

## Tests

- `test_text_for_closes_body_on_read_error` — body closed even when `read()` raises (RED before the fix).
- `_FakeBody` double updated with `close()`.
- Full suite green (236 passed).

Together with #100, this closes the connection-leak class that caused the large-agency hangs.