### PR TITLE
Route the scheduled ETL through the Iceberg catalog

### DIFF
--- a/.github/workflows/etl-new-pipeline.yml
+++ b/.github/workflows/etl-new-pipeline.yml
@@ -6,8 +6,10 @@ name: ETL (new pipeline)
 # removed.
 #
 # On `schedule`: 15 batches (21 agencies each = 315) spread across the day; the
-# batch number is derived from the UTC hour and upload to R2 is ON. Rollups
-# (feed_summary, agency_stats, ...) are built by separate `rollup-*.yml`
+# batch number is derived from the UTC hour, upload to R2 is ON, and the run is
+# routed through the R2 Data Catalog (Iceberg) — the comments read surface the
+# MCP servers query — so the catalog stays current instead of drifting stale.
+# Rollups (feed_summary, agency_stats, ...) are built by separate `rollup-*.yml`
 # workflows, each on its own cron reading the base tables this ETL publishes.
 #
 # On `workflow_dispatch`: inputs drive a one-off run. `skip_upload` still
@@ -64,7 +66,7 @@ on:
         default: true
         type: boolean
       use_iceberg:
-        description: 'Route dockets + comments through R2 Data Catalog (Iceberg)'
+        description: 'Route dockets + comments through R2 Data Catalog (Iceberg). Dispatch runs only; scheduled runs always use Iceberg.'
         required: false
         default: false
         type: boolean
@@ -85,10 +87,16 @@ jobs:
             echo "batch_number=$BATCH" >> $GITHUB_OUTPUT
             # Scheduled runs publish to R2.
             echo "skip_upload=false" >> $GITHUB_OUTPUT
+            # The comments read surface is the Iceberg catalog now, so scheduled
+            # runs MUST route through it — otherwise comments land only in the
+            # partitioned tree and the catalog (what the MCP servers read) drifts
+            # stale again. Dispatch runs still honor their own use_iceberg input.
+            echo "use_iceberg=true" >> $GITHUB_OUTPUT
             echo "Running scheduled batch $BATCH (hour $HOUR UTC)"
           else
             echo "batch_number=${{ inputs.batch_number }}" >> $GITHUB_OUTPUT
             echo "skip_upload=${{ inputs.skip_upload }}" >> $GITHUB_OUTPUT
+            echo "use_iceberg=${{ inputs.use_iceberg }}" >> $GITHUB_OUTPUT
             echo "Running manual dispatch (skip_upload=${{ inputs.skip_upload }})"
           fi
 
@@ -138,7 +146,7 @@ jobs:
           else
             ARGS="$ARGS --no-skip-upload"
           fi
-          if [ "${{ inputs.use_iceberg }}" = "true" ]; then
+          if [ "${{ steps.params.outputs.use_iceberg }}" = "true" ]; then
             ARGS="$ARGS --use-iceberg"
           fi
           echo "Running: uv run run-pipeline $ARGS"


### PR DESCRIPTION
## Summary

Enables Iceberg on the **daily scheduled ETL**, completing the R2 Data Catalog cutover.

The comments read surface is now the R2 Data Catalog (Iceberg): the MCP servers query it directly (#89/#90) and the full seed has been loaded. But the scheduled runs in `etl-new-pipeline.yml` still wrote comments only via the partitioned tree — `--use-iceberg` was a `workflow_dispatch` input defaulting to `false`, and the `schedule` branch never set it. So new comments landed outside the catalog and it would drift stale again, the exact bug the cutover was meant to fix.

Changes to `.github/workflows/etl-new-pipeline.yml`:
- The `params` step now emits a `use_iceberg` output: `true` for `schedule` events, and the dispatch input's value for `workflow_dispatch`.
- The run step reads `steps.params.outputs.use_iceberg` instead of `inputs.use_iceberg`, so scheduled batches pass `--use-iceberg` while manual dispatch runs still honor their own toggle.
- Updated the header comment and the `use_iceberg` input description to reflect that scheduled runs always use Iceberg.

No application code changed — the `--use-iceberg` pipeline path (`RegulationsPipeline`, `sources/iceberg.py`) already exists and is exercised; this only wires the scheduled workflow onto it.

## Test plan

- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [x] Validated the workflow YAML parses (`python -c "import yaml; yaml.safe_load(...)"` → OK)
- [x] Traced the arg flow: `schedule` → `use_iceberg=true` output → `--use-iceberg` appended to `run-pipeline`; `workflow_dispatch` → honors the input as before
- [ ] Post-merge: watch the next scheduled batch and run `scripts/check_comments_freshness.py` to confirm the catalog stays current

## Checklist

- [x] My change is scoped to one concern
- [ ] I added or updated tests for new behavior (n/a — CI-workflow-only change)
- [x] I updated docs (workflow header + input description)
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q

---
_Generated by [Claude Code](https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q)_