### PR TITLE
Add scheduled comments-freshness check

### DIFF
--- a/.github/workflows/check-comments-freshness.yml
+++ b/.github/workflows/check-comments-freshness.yml
@@ -1,0 +1,64 @@
+name: Check comments freshness
+
+# Guards against the comments read surface drifting behind the comments_index.
+# The counts (comments_index / feed_summary / agency_stats) and the row-level
+# `comments` table are produced by different steps, so they can diverge — the
+# index advertising comments for a month the row data doesn't actually contain.
+# That exact gap (OMB-2026-0034: ~39k June-2026 comments in the index, zero rows
+# in `comments`) is what drove the Iceberg cutover; this check makes a recurrence
+# visible instead of silent.
+#
+# scripts/check_comments_freshness.py exits 1 when any agency's rows lag the
+# index, so a drift turns this job red (and notifies watchers). It reads whatever
+# the MCP server is configured to read: the R2 Data Catalog (Iceberg) when the
+# R2_CATALOG_* secrets are set, otherwise the public monolithic comments.parquet
+# — i.e. it validates the actual surface users query.
+#
+# Read-only: it never writes to R2 or the catalog. Runs after the day's ETL and
+# rollups have settled (last ETL batch ~20:25 UTC, feed_summary rollup 22:30).
+on:
+  schedule:
+    - cron: '30 23 * * *'
+  workflow_dispatch:
+    inputs:
+      agency:
+        description: 'Restrict the check to a single agency_code'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Check comments freshness
+        env:
+          # When present, the check validates the Iceberg catalog surface;
+          # otherwise it falls back to the public monolithic comments.parquet.
+          R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
+          R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}
+          R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
+          R2_CATALOG_NAMESPACE: ${{ secrets.R2_CATALOG_NAMESPACE }}
+        run: |
+          ARGS=""
+          if [ -n "${{ inputs.agency }}" ]; then
+            ARGS="$ARGS --agency ${{ inputs.agency }}"
+          fi
+          echo "Running: uv run python scripts/check_comments_freshness.py $ARGS"
+          uv run python scripts/check_comments_freshness.py $ARGS


### PR DESCRIPTION
## Summary

Runs `scripts/check_comments_freshness.py` on its own daily cron so the comments read surface drifting behind the `comments_index` becomes visible instead of silent.

The comment counts (`comments_index` / `feed_summary` / `agency_stats`) and the row-level `comments` table are produced by different steps, so they can diverge — the index advertising comments for a month the rows don't actually contain. That exact gap (OMB-2026-0034: ~39k June-2026 comments in the index, zero rows in `comments`) is what drove the Iceberg cutover. The check script already exists but only ran inside the manual seed workflow's `full_load` branch, so nothing catches re-drift once the seed is done.

Now that the scheduled ETL routes through the catalog (#102), this closes the monitoring gap.

Adds `.github/workflows/check-comments-freshness.yml`:
- Daily `schedule` at `30 23 * * *` — after the day's last ETL batch (~20:25 UTC) and the `feed_summary` rollup (22:30 UTC) have settled.
- `workflow_dispatch` with an optional `agency` input for a targeted check.
- Read-only: never writes to R2 or the catalog. The script exits `1` on drift, turning the job red so watchers get notified.
- Validates the same surface the MCP server reads — the Iceberg catalog when `R2_CATALOG_*` secrets are present, otherwise the public monolithic `comments.parquet`. `comments_index` comes from the public R2 URL, so no extra secret is required beyond the catalog ones.

## Test plan

- [x] Validated the workflow YAML parses (`python -c "import yaml; yaml.safe_load(...)"` → OK)
- [x] Confirmed the script's env needs against `mcp_server._connect()`: only `R2_CATALOG_*` gate the catalog surface; the index + monolith fall back reads use the public default R2 URL
- [ ] Post-merge: trigger the workflow via `workflow_dispatch` to confirm it connects to the catalog and reports OK (the user has set the `R2_CATALOG_*` secrets on the MCP; this run would be the first end-to-end verification)

## Checklist

- [x] My change is scoped to one concern
- [ ] I added or updated tests for new behavior (n/a — CI-workflow-only change wrapping an existing, tested script)
- [x] I updated docs (extensive workflow header comment)
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q

---
_Generated by [Claude Code](https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q)_