### PR TITLE
Fix Iceberg catalog attach in the serverless MCP (provision avro)

### DIFF
--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -233,6 +233,23 @@ def _attach_catalog(con: duckdb.DuckDBPyConnection, config: dict[str, str]) -> b
     the configuration. Returns ``True`` only when the catalog is attached.
     """
     try:
+        # DuckDB 1.5's iceberg extension reads Avro manifests via a separate
+        # `avro` extension. iceberg tries to auto-install it lazily during LOAD,
+        # but that nested install doesn't inherit the session's home_directory in
+        # serverless sandboxes (Vercel) and dies with "Can't find the home
+        # directory at ''" — so the whole attach fails and comments silently fall
+        # back to the frozen monolith. Installing avro explicitly first runs on
+        # the same top-level path that already installs httpfs/iceberg fine, so it
+        # sees the configured home_directory and the nested auto-install is skipped.
+        #
+        # Best-effort: on older DuckDB (<1.5) avro isn't a separate extension and
+        # `INSTALL avro` errors — swallow it and let iceberg use its bundled Avro
+        # path, so this never regresses environments where the attach already works.
+        try:
+            con.execute("INSTALL avro")
+            con.execute("LOAD avro")
+        except duckdb.Error as avro_exc:
+            logger.info("avro not separately provisioned (%s); using iceberg's bundled path", avro_exc)
         con.execute("INSTALL iceberg")
         con.execute("LOAD iceberg")
         con.execute(

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -233,6 +233,23 @@ def _attach_catalog(con: duckdb.DuckDBPyConnection, config: dict[str, str]) -> b
     the configuration. Returns ``True`` only when the catalog is attached.
     """
     try:
+        # DuckDB 1.5's iceberg extension reads Avro manifests via a separate
+        # `avro` extension. iceberg tries to auto-install it lazily during LOAD,
+        # but that nested install doesn't inherit the session's home_directory in
+        # serverless sandboxes (Vercel) and dies with "Can't find the home
+        # directory at ''" — so the whole attach fails and comments silently fall
+        # back to the frozen monolith. Installing avro explicitly first runs on
+        # the same top-level path that already installs httpfs/iceberg fine, so it
+        # sees the configured home_directory and the nested auto-install is skipped.
+        #
+        # Best-effort: on older DuckDB (<1.5) avro isn't a separate extension and
+        # `INSTALL avro` errors — swallow it and let iceberg use its bundled Avro
+        # path, so this never regresses environments where the attach already works.
+        try:
+            con.execute("INSTALL avro")
+            con.execute("LOAD avro")
+        except duckdb.Error as avro_exc:
+            logger.info("avro not separately provisioned (%s); using iceberg's bundled path", avro_exc)
         con.execute("INSTALL iceberg")
         con.execute("LOAD iceberg")
         con.execute(

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -89,6 +89,16 @@ def _connect():
     token = getenv("R2_CATALOG_TOKEN", "")
 
     con = duckdb.connect()
+    # avro is installed explicitly before iceberg: DuckDB 1.5's iceberg extension
+    # pulls in `avro` to read Iceberg manifests and otherwise auto-installs it
+    # lazily during LOAD, a nested install that fails in sandboxes without a
+    # writable home directory. Provisioning it on the top-level path avoids that.
+    # Best-effort: older DuckDB (<1.5) has no separate avro extension, so ignore
+    # the error there and let iceberg use its bundled Avro path.
+    try:
+        con.execute("INSTALL avro; LOAD avro;")
+    except duckdb.Error as avro_exc:
+        logger.info("avro not separately provisioned ({}); using iceberg's bundled path", avro_exc)
     con.execute("INSTALL iceberg; LOAD iceberg;")
     con.execute("INSTALL httpfs; LOAD httpfs;")
     con.execute(f"CREATE OR REPLACE SECRET r2_catalog_secret (TYPE ICEBERG, TOKEN '{_sql_str(token)}');")


### PR DESCRIPTION
## Summary

The production MCP (`mcp.spicy-regs.dev`) has been silently serving the **frozen `comments.parquet` monolith** instead of the R2 Data Catalog — so despite the Iceberg cutover, users still get stale comments (e.g. OMB frozen at Oct 2025 / 342,915 rows, vs. the catalog's 764,404 through June).

Runtime logs pinpointed the cause. The `R2_CATALOG_*` env vars are set and duckdb is 1.5.4, but the attach fails on **every** request:

```
R2 catalog attach failed; comments fall back to monolith: Invalid Input Error:
Initialization function "iceberg_duckdb_cpp_init" ... threw:
"An error occurred while trying to automatically install the required extension 'avro':
 Can't find the home directory at ''"
```

DuckDB 1.5's `iceberg` extension reads Avro manifests via a **separate `avro` extension**, which it auto-installs lazily during `LOAD iceberg`. That *nested* auto-install doesn't inherit the session's `SET home_directory='/tmp'` in the Vercel serverless sandbox, so it dies, the whole attach throws, and the `except` falls back to the monolith. (It works in GitHub Actions because that has a real writable `$HOME` — which is why yesterday's freshness check read the catalog fine.)

## Fix

Provision `avro` explicitly **before** iceberg, on the same top-level path that already installs `httpfs`/`iceberg` successfully — so it sees the configured `home_directory` and iceberg's broken nested auto-install is skipped:

```python
try:
    con.execute("INSTALL avro"); con.execute("LOAD avro")
except duckdb.Error as avro_exc:
    logger.info("avro not separately provisioned (%s); using iceberg's bundled path", avro_exc)
con.execute("INSTALL iceberg"); con.execute("LOAD iceberg")
```

The `avro` install is **best-effort**: on older DuckDB (<1.5) `avro` isn't a separate extension, so the error is swallowed and iceberg uses its bundled Avro path — leaving the currently-working ETL / GitHub Actions path unchanged.

Applied in three places:
- `mcp-server/api/index.py` — the copy deployed to Vercel (the actual fix)
- `src/spicy_regs/mcp_server.py` — the canonical "keep in sync" copy (also used by `check_comments_freshness.py`)
- `src/spicy_regs/sources/iceberg.py` — the ETL connector, for defensiveness

## Test plan

- [x] `uv run ruff check` on all three files — passed
- [x] `uv run pytest -k "iceberg or mcp or catalog or comment"` — 73 passed
- [ ] Couldn't exercise the extension install locally: this sandbox's proxy blocks `extensions.duckdb.org` (HTTP 403), and local duckdb resolves to 1.4.4 where the serverless failure doesn't reproduce (real `$HOME`). Real verification is post-deploy.
- [ ] **Post-merge:** `deploy-mcp.yml` auto-redeploys to Vercel on `mcp-server/**` changes. Then confirm via Vercel runtime logs (attach warning gone) and re-query OMB through the MCP (`342,915` → `~764,404`).

## Notes

Also surfaced: `mcp-server/requirements.txt` pins `duckdb>=1.2.0` (floats to 1.5.4 in prod) while the package pins `>=1.4` (lockfile 1.4.4) — a version drift between tested and deployed. Not addressed here to keep this fix focused; worth a follow-up to pin the MCP's duckdb explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q

---
_Generated by [Claude Code](https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q)_