### PR TITLE
Publish the public comments mirror from the Iceberg catalog

### DIFF
--- a/.github/workflows/publish-comments-mirror.yml
+++ b/.github/workflows/publish-comments-mirror.yml
@@ -1,0 +1,75 @@
+name: Publish comments mirror
+
+# Regenerates the PUBLIC comments Parquet surface from the Iceberg catalog so the
+# browser UI (which can't read the credentialed catalog) serves current comments.
+#
+# Once the ETL routes comments through Iceberg, rows land in the catalog and only
+# comments_index.parquet is republished — the flat comments.parquet monolith and
+# the per-agency comments/agency/agency_code=*/part-0.parquet tree the UI reads
+# stop being refreshed. This job rebuilds all of them from the catalog and uploads
+# them, restoring the dual model (catalog = system of record, public Parquet = the
+# anonymous read mirror).
+#
+# Runs daily after the ETL batches finish (last batch ~20:25 UTC), plus manual
+# dispatch. Read-only against the catalog; the only writes are the public mirror
+# files, and upload_file refuses to overwrite a much smaller remote object, so a
+# truncated export can't wipe the live data.
+#
+# Requires:
+#   R2_CATALOG_URI, R2_CATALOG_WAREHOUSE, R2_CATALOG_TOKEN   (read the catalog)
+#   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT, R2_BUCKET_NAME  (write public Parquet)
+on:
+  schedule:
+    - cron: '30 21 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Build the mirror but do not publish to R2 (dry run)'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: publish-comments-mirror
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Full-table export of tens of millions of rows from the catalog, plus the
+    # streaming per-agency partition pass. Give it ample headroom.
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Publish comments mirror from the catalog
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
+          R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}
+          R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
+          R2_CATALOG_NAMESPACE: ${{ secrets.R2_CATALOG_NAMESPACE }}
+        run: |
+          ARGS=""
+          if [ "${{ inputs.skip_upload }}" = "true" ]; then
+            ARGS="$ARGS --skip-upload"
+          fi
+          echo "Running: uv run python scripts/publish_comments_mirror.py $ARGS"
+          uv run python scripts/publish_comments_mirror.py $ARGS

--- a/scripts/publish_comments_mirror.py
+++ b/scripts/publish_comments_mirror.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Publish the public comments read-mirror from the Iceberg catalog.
+
+The browser UI reads comments as public Parquet on R2 (it can't reach the
+credentialed R2 Data Catalog). Once the ETL routes comments through Iceberg it
+writes rows into the catalog and only republishes the small
+``comments_index.parquet`` — so the public surface the UI actually reads goes
+stale:
+
+* ``comments.parquet``                                  — the flat monolith (UI full scans)
+* ``comments/agency/agency_code={X}/part-0.parquet``    — the per-agency tree (UI agency/docket views)
+
+This regenerates that whole mirror from the catalog (the write-side system of
+record) and uploads it, restoring the dual model for comments so the UI serves
+current data without ever touching the catalog.
+
+Reads the catalog (``R2_CATALOG_*``) and writes public Parquet (``R2_*``). It is
+read-only against the catalog; the only writes are the public mirror files. Runs
+on a daily cron after the ETL batches settle, plus manual dispatch — see
+``.github/workflows/publish-comments-mirror.yml``. ``upload_file`` refuses to
+overwrite a much smaller remote object, so a truncated export can't wipe the live
+files.
+
+Usage:
+    uv run python scripts/publish_comments_mirror.py
+    uv run python scripts/publish_comments_mirror.py --skip-upload   # build locally only
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from loguru import logger
+
+from spicy_regs.schemas.regulations import RECORD_TYPES
+from spicy_regs.sources import iceberg, r2
+from spicy_regs.transforms import partition_comments
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, default=Path("output"))
+    parser.add_argument(
+        "--skip-upload", action="store_true", help="Build the mirror locally but don't publish to R2"
+    )
+    args = parser.parse_args()
+
+    if not iceberg.is_configured():
+        logger.error("R2 Data Catalog is not configured (R2_CATALOG_*); cannot export the mirror")
+        return 1
+
+    output_dir: Path = args.output_dir
+    comments_rt = RECORD_TYPES["comments"]
+
+    # 1. Monolith + index straight from the catalog.
+    result = iceberg.export_public_comments(output_dir, comments_rt)
+
+    # 2. Derive the per-agency tree the UI reads for scoped queries from that monolith.
+    partition_dir = partition_comments(output_dir)
+    agency_files = sorted(partition_dir.glob("agency_code=*/part-0.parquet"))
+    logger.info("Built {} agency partition(s)", len(agency_files))
+
+    if args.skip_upload:
+        logger.info("--skip-upload set; mirror left in {}", output_dir)
+        return 0
+
+    # 3. Publish: monolith, then the partitions + refreshed index.
+    r2.upload_file(result["comments"], remote_key="comments.parquet")
+    r2.upload_comment_partitions(output_dir, agency_files)
+    logger.info("Published comments mirror: monolith + {} partition(s) + index", len(agency_files))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -337,6 +337,42 @@ def merge_comments(staging_dir: Path, output_dir: Path, record_type: RecordType)
         con.close()
 
 
+def export_public_comments(output_dir: Path, record_type: RecordType) -> dict[str, Path]:
+    """Rebuild the public comments read-mirror from the catalog.
+
+    The browser UI can't reach the credentialed catalog, so it reads comments as
+    public Parquet on R2. :func:`merge_comments` only republishes the tiny index,
+    so the public monolith + per-agency tree the UI reads otherwise go stale. This
+    regenerates that mirror from the catalog — the write-side system of record —
+    restoring the dual model for comments:
+
+    * ``comments.parquet``       — the flat monolith the UI full-scans
+    * ``comments_index.parquet`` — per-partition row counts
+
+    The caller derives the per-agency tree the UI reads for scoped queries
+    (``comments/agency/agency_code={X}/part-0.parquet``) from the monolith via
+    :func:`spicy_regs.transforms.partition_comments`. Returns the written paths
+    keyed ``"comments"`` and ``"index"``.
+    """
+    con = _connect()
+    try:
+        # Full-table export of tens of millions of rows. Cap memory and disable
+        # insertion-order preservation so the sort in _export_parquet spills to
+        # disk instead of OOM-ing the CI runner (temp_directory defaults to a
+        # writable dir here — this never runs on the read-only serverless host).
+        con.execute("SET preserve_insertion_order=false")
+        con.execute("SET memory_limit='6GB'")
+        _ensure_table(con, record_type)
+        total = con.execute(f"SELECT count(*) FROM {_qualified(record_type)}").fetchone()[0]
+        logger.info("iceberg: exporting {:,} catalog rows to the public comments mirror", total)
+        monolith = _export_parquet(con, record_type, output_dir)
+        index_file = _build_comments_index(con, record_type, output_dir)
+        logger.info("iceberg: wrote public monolith {} and index {}", monolith, index_file)
+        return {"comments": monolith, "index": index_file}
+    finally:
+        con.close()
+
+
 def merge_and_export(staging_dir: Path, output_dir: Path, record_type: RecordType) -> Path | None:
     """Upsert staged rows into the catalog table, then export the public Parquet.
 

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -397,3 +397,42 @@ def test_seed_comments_tolerates_missing_columns(tmp_path, local_catalog) -> Non
         f"SELECT text_content FROM {iceberg._qualified(COMMENT)} WHERE comment_id = 'old1'"
     ).fetchone()[0]
     assert text_content is None
+
+
+def test_export_public_comments_rebuilds_mirror(tmp_path, local_catalog, monkeypatch) -> None:
+    """export_public_comments writes the public monolith + index straight from the
+    catalog, and that monolith feeds partition_comments to produce the per-agency
+    tree the UI reads."""
+    from spicy_regs.transforms import partition_comments
+
+    con = local_catalog
+    iceberg._ensure_table(con, COMMENT)
+
+    staging = tmp_path / "staging"
+    _write_comment_staging(staging, "EPA", [
+        _comment("c1", "EPA-1", "EPA", "2025-01-15T00:00:00Z"),
+        _comment("c2", "EPA-2", "EPA", "2025-02-03T00:00:00Z"),
+    ])
+    _write_comment_staging(staging, "OMB", [
+        _comment("c3", "OMB-1", "OMB", "2026-06-29T00:00:00Z"),
+    ])
+    iceberg._merge(con, iceberg._staging_files(staging, COMMENT), COMMENT)
+
+    # export_public_comments opens its own catalog connection; point it at the
+    # local in-memory one (it closes the connection when done — safe to double-close).
+    monkeypatch.setattr(iceberg, "_connect", lambda: con)
+
+    out = tmp_path / "output"
+    result = iceberg.export_public_comments(out, COMMENT)
+
+    assert result["comments"] == out / "comments.parquet"
+    assert result["index"] == out / "comments_index.parquet"
+    monolith = pl.read_parquet(result["comments"])
+    assert monolith.height == 3
+    assert set(monolith["agency_code"].to_list()) == {"EPA", "OMB"}
+
+    # The monolith drives the coarse per-agency tree the UI reads for scoped queries.
+    partition_dir = partition_comments(out)
+    omb_part = partition_dir / "agency_code=OMB" / "part-0.parquet"
+    assert omb_part.exists()
+    assert pl.read_parquet(omb_part).height == 1


### PR DESCRIPTION
## Summary

Closes the last gap in the Iceberg cutover: the **browser UI still serves stale comments**.

The UI reads comments as **public Parquet** on R2 (DuckDB-WASM in the browser — it can't reach the credentialed R2 Data Catalog, and there's no anonymous catalog read). Once the ETL routes comments through Iceberg (#102), rows land in the catalog and only the tiny `comments_index.parquet` is republished — so the public surface the UI actually reads stops being refreshed. Verified against live R2:

| Surface the UI reads | Latest comment | vs. catalog |
|---|---|---|
| `comments.parquet` (monolith, full scans) | 2026-04-06 (OMB back to Oct 2025) | catalog current (June) |
| `comments/agency/agency_code=*/part-0.parquet` (agency/docket views) | 2025-10-15 | catalog current |

This restores the **dual model** for comments: the catalog stays the write-side system of record, and this regenerates the public read-mirror from it, so the UI serves current data without ever touching the catalog or holding a credential.

## Changes

- **`iceberg.export_public_comments()`** — exports `comments.parquet` and rebuilds `comments_index.parquet` from the catalog table. Caps memory and lets DuckDB spill to disk so the full-table export (tens of millions of rows) doesn't OOM the CI runner.
- **`scripts/publish_comments_mirror.py`** — exports the monolith, derives the per-agency tree the UI reads (`comments/agency/agency_code=*/part-0.parquet`) via the existing `transforms.partition_comments`, and uploads all three. `r2.upload_file`'s small-file guard means a truncated export can't wipe live data.
- **`.github/workflows/publish-comments-mirror.yml`** — daily cron at `30 21 * * *` (after the ETL batches settle) + manual dispatch with a `skip_upload` dry-run. Read-only against the catalog; only writes the public mirror files.
- **Test** — `export_public_comments` rebuilds the monolith + index from a local in-memory catalog and feeds `partition_comments` to produce the agency tree.

## Test plan

- [x] `uv run pytest tests/test_iceberg.py` — 15 passed (incl. new `test_export_public_comments_rebuilds_mirror`)
- [x] `uv run pytest -k "iceberg or comment or mirror or partition"` — 48 passed
- [x] `uv run ruff check` on all changed files — passed
- [x] Workflow YAML parses
- [ ] **Post-merge:** dispatch the workflow (optionally `skip_upload: true` first for a dry run), then confirm the UI's public files are current — e.g. `read_parquet('.../comments/agency/agency_code=OMB/part-0.parquet')` should show 2026 dates and ~764k OMB rows instead of the Oct-2025 / 342,915 it has now.

## Notes

- Design choice (per discussion): a **daily full mirror** rather than per-batch incremental. The monolith is a single file that can't be partially updated, so it needs a full export regardless; doing the agency tree in the same job keeps it simple and off the ETL hot path. Daily freshness is ample for the public UI.
- Reuses the existing `_export_parquet` (same shape/sort as the historical published monolith) and `partition_comments` (streaming, memory-safe) rather than introducing new export logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q

---
_Generated by [Claude Code](https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q)_