### PR TITLE
Let the comments mirror bypass the byte-size shrink guard

### DIFF
--- a/.github/workflows/publish-comments-mirror.yml
+++ b/.github/workflows/publish-comments-mirror.yml
@@ -62,6 +62,12 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
           R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          # Bypass r2's byte-size shrink guard: re-exporting from the catalog
+          # re-sorts + re-compresses the data, so a partition can be several times
+          # smaller on disk while holding *more* rows (verified: ACF 19.7 MB -> 6.0 MB
+          # with more rows + fresher dates). The script enforces a row-count floor
+          # instead, which is the right check for a full export.
+          R2_ALLOW_SHRINK: '1'
           R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
           R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}
           R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}

--- a/scripts/publish_comments_mirror.py
+++ b/scripts/publish_comments_mirror.py
@@ -31,11 +31,22 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+import pyarrow.parquet as pq
 from loguru import logger
 
 from spicy_regs.schemas.regulations import RECORD_TYPES
 from spicy_regs.sources import iceberg, r2
 from spicy_regs.transforms import partition_comments
+
+# The mirror runs with R2_ALLOW_SHRINK=1 (see the workflow): re-exporting from the
+# catalog legitimately changes on-disk size — the sorted, freshly-compressed
+# partitions can be several times *smaller* than the old published files while
+# holding *more* rows — so r2's byte-size shrink guard produces false positives.
+# This row-count floor replaces that protection with one appropriate for a full
+# export: a catastrophically empty/broken catalog read (which would otherwise wipe
+# the public files) is caught here before anything is uploaded. The live table is
+# tens of millions of rows; a floor well below that only trips on real breakage.
+MIN_EXPECTED_ROWS = 1_000_000
 
 
 def main() -> int:
@@ -55,6 +66,19 @@ def main() -> int:
 
     # 1. Monolith + index straight from the catalog.
     result = iceberg.export_public_comments(output_dir, comments_rt)
+
+    # Floor check (replaces the bypassed byte-size shrink guard): refuse to publish
+    # a catastrophically small export that would wipe the live public files.
+    n_rows = pq.ParquetFile(result["comments"]).metadata.num_rows
+    if n_rows < MIN_EXPECTED_ROWS:
+        logger.error(
+            "Exported monolith has only {:,} rows (< {:,} floor); the catalog read looks "
+            "broken — refusing to publish and overwrite the live files",
+            n_rows,
+            MIN_EXPECTED_ROWS,
+        )
+        return 1
+    logger.info("Exported monolith has {:,} rows", n_rows)
 
     # 2. Derive the per-agency tree the UI reads for scoped queries from that monolith.
     partition_dir = partition_comments(output_dir)


### PR DESCRIPTION
## Summary

Follow-up to #105. The first `Publish comments mirror` run exported the catalog and **uploaded the 2 GB monolith successfully**, then aborted when uploading the first agency partition:

```
Refusing to upload comments/agency/agency_code=ACF/part-0.parquet:
new file would shrink remote from 19.7 MB to 6.0 MB (ratio 0.303 < threshold 0.5)
```

That's a **false positive**. Comparing the same agency, new-from-catalog vs the old published file:

| | rows | comment text | attachments | latest comment |
|---|---|---|---|---|
| **new (catalog export)** | 327,466 | 439.2 MB | 1,103 | **2026-06-29** |
| old (published file) | 325,014 | 437.8 MB | 0 | 2026-02-27 |

The new file holds **more** data and is fresher — it's only smaller *on disk* because re-exporting from the catalog re-sorts and re-compresses the form-letter-heavy comment text far better (6.0 MB vs 19.7 MB for ~the same bytes of text). `_assert_upload_safe` uses on-disk size as a proxy for data volume, and that proxy is invalid for a full re-export where compression legitimately changes.

## Fix

- **Run the mirror with `R2_ALLOW_SHRINK=1`** (the documented override) so the byte-size guard doesn't block legitimate re-exports.
- **Replace the protection it provided with a row-count floor** in `publish_comments_mirror.py`: after exporting, if the monolith has fewer than 1,000,000 rows (the live table is ~36.7M), the script refuses to upload — so a broken/empty catalog read still can't wipe the live public files. This is the right shape of check for a full export.

## Test plan

- [x] `uv run pytest tests/test_iceberg.py` — 15 passed
- [x] `uv run ruff check scripts/publish_comments_mirror.py` — passed
- [x] Workflow YAML parses
- [x] Root-caused against live R2 data (table above): the shrink is compression, not data loss
- [ ] **Post-merge:** re-run the workflow; expect it to complete and publish all 178 agency partitions. Then confirm e.g. `comments/agency/agency_code=OMB/part-0.parquet` shows 2026 dates / ~764k rows.

## Note

The monolith (`comments.parquet`) already got refreshed by the first run before the abort, so the UI's full-scan surface is already current; this PR unblocks the per-agency tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q

---
_Generated by [Claude Code](https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q)_