### PR TITLE
Add catalog dedup tooling + uniqueness monitoring for comments

### DIFF
--- a/.github/workflows/dedupe-comments-catalog.yml
+++ b/.github/workflows/dedupe-comments-catalog.yml
@@ -1,0 +1,66 @@
+name: Dedupe comments catalog (manual)
+
+# Audits and (optionally) removes duplicate rows from the Iceberg `comments`
+# catalog table. The one-time seed duplicated rows for agencies loaded more than
+# once (its per-agency DELETE didn't remove prior rows on the R2 Data Catalog);
+# the daily merge is unaffected. See scripts/dedupe_comments_catalog.py.
+#
+# Manual dispatch only — the apply path WRITES to the production catalog, so it
+# never runs on a schedule. It defaults to a read-only audit; flip `apply` on to
+# rebuild the table deduplicated. The rebuild uses CREATE OR REPLACE (atomic swap,
+# never DELETE), so a failed run can't corrupt or double the data.
+#
+# Recommended sequence: run once with apply=false (audit), review the report in
+# the logs, run again with apply=true, then run apply=false once more to confirm
+# it's clean. After a successful apply, run the "Publish comments mirror" workflow
+# so the public files the UI reads are refreshed from the cleaned catalog.
+#
+# Requires: R2_CATALOG_URI, R2_CATALOG_WAREHOUSE, R2_CATALOG_TOKEN (+ optional
+# R2_CATALOG_NAMESPACE) — read and write the catalog table.
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Rebuild the table deduplicated (off = read-only audit)'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: dedupe-comments-catalog
+  cancel-in-progress: false
+
+jobs:
+  dedupe:
+    runs-on: ubuntu-latest
+    # A full-table rebuild of tens of millions of rows; give it headroom.
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Audit / dedupe the catalog
+        env:
+          R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
+          R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}
+          R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
+          R2_CATALOG_NAMESPACE: ${{ secrets.R2_CATALOG_NAMESPACE }}
+        run: |
+          ARGS=""
+          if [ "${{ inputs.apply }}" = "true" ]; then
+            ARGS="$ARGS --apply"
+          fi
+          echo "Running: uv run python scripts/dedupe_comments_catalog.py $ARGS"
+          uv run python scripts/dedupe_comments_catalog.py $ARGS

--- a/scripts/check_comments_freshness.py
+++ b/scripts/check_comments_freshness.py
@@ -8,14 +8,19 @@ then count queries look current while ``SELECT ... FROM comments`` returns nothi
 for recent dockets. That exact gap (OMB-2026-0034 showed ~39k June-2026 comments
 in the index but zero rows in ``comments``) is what this check catches.
 
-It compares, per ``agency_code``, the latest ``(year, month)`` present in
-``comments_index`` against the latest ``posted_date`` month actually materialized
-in the ``comments`` read surface, and reports every agency whose rows lag the
-index (or are missing entirely).
+It runs two checks, each of which can independently flag:
 
-The check runs against whatever the MCP server is configured to read: the R2 Data
+1. Freshness — per ``agency_code``, the latest ``(year, month)`` in
+   ``comments_index`` vs the latest ``posted_date`` month actually materialized in
+   the ``comments`` read surface; flags agencies whose rows lag the index.
+2. Uniqueness — per ``agency_code``, ``count(*)`` vs ``count(distinct comment_id)``
+   in the ``comments`` surface; flags agencies carrying duplicate rows (which
+   inflate counts and repeat comments — the one-time seed did this for agencies it
+   loaded more than once, and the freshness check alone can't see it).
+
+Both run against whatever the MCP server is configured to read: the R2 Data
 Catalog (Iceberg) when ``R2_CATALOG_*`` is set, otherwise the public monolithic
-``comments.parquet``. So it validates the *actual* surface users query.
+``comments.parquet``. So they validate the *actual* surface users query.
 
 Usage:
     uv run python scripts/check_comments_freshness.py
@@ -72,10 +77,67 @@ ORDER BY i.idx_rows DESC
 """
 
 
+# Per-agency duplication: the row-level surface should hold exactly one row per
+# comment_id. When count(*) exceeds count(distinct comment_id) the table carries
+# duplicate rows (the one-time seed did this for agencies loaded more than once),
+# which inflates counts and repeats comments. This catches that class of bug that
+# the month-lag freshness check above can't see.
+_DUP_SQL = """
+SELECT agency_code,
+       count(*) AS rows,
+       count(DISTINCT comment_id) AS distinct_ids
+FROM comments
+WHERE agency_code IS NOT NULL
+{rows_where}
+GROUP BY agency_code
+HAVING count(*) > count(DISTINCT comment_id)
+ORDER BY count(*) - count(DISTINCT comment_id) DESC
+"""
+
+
 def _fmt_ym(ym: int | None) -> str:
     if ym is None:
         return "—"
     return f"{ym // 100:04d}-{ym % 100:02d}"
+
+
+def _check_freshness(con, idx_where: str, rows_where: str, limit: int) -> bool:
+    """Report agencies whose comment rows lag the index. Returns True if any flagged."""
+    flagged = con.execute(_FRESHNESS_SQL.format(idx_where=idx_where, rows_where=rows_where)).fetchall()
+    if not flagged:
+        print("OK (freshness): every agency's comment rows are at least as current as the index.")
+        return False
+
+    print(f"STALE: {len(flagged)} agency partition(s) lag the comments index\n")
+    print(f"{'agency':<10} {'index_to':<9} {'rows_to':<9} {'index_rows':>12} {'actual_rows':>12}")
+    print("-" * 56)
+    for agency, idx_ym, rows_ym, idx_rows, actual_rows in flagged[:limit]:
+        print(
+            f"{agency:<10} {_fmt_ym(idx_ym):<9} {_fmt_ym(rows_ym):<9} "
+            f"{idx_rows:>12,} {actual_rows:>12,}"
+        )
+    if len(flagged) > limit:
+        print(f"... and {len(flagged) - limit} more (raise --limit to see them)")
+    return True
+
+
+def _check_duplicates(con, rows_where: str, limit: int) -> bool:
+    """Report agencies with duplicate comment_id rows. Returns True if any flagged."""
+    flagged = con.execute(_DUP_SQL.format(rows_where=rows_where)).fetchall()
+    if not flagged:
+        print("OK (uniqueness): every agency's comment rows are unique by comment_id.")
+        return False
+
+    total_dupes = sum(rows - distinct for _, rows, distinct in flagged)
+    print(f"\nDUPLICATED: {len(flagged)} agency(ies) carry duplicate comment rows ({total_dupes:,} duplicate rows)\n")
+    print(f"{'agency':<10} {'rows':>14} {'distinct_ids':>14} {'factor':>8}")
+    print("-" * 48)
+    for agency, rows, distinct in flagged[:limit]:
+        factor = rows / distinct if distinct else 0
+        print(f"{agency:<10} {rows:>14,} {distinct:>14,} {factor:>7.2f}x")
+    if len(flagged) > limit:
+        print(f"... and {len(flagged) - limit} more (raise --limit to see them)")
+    return True
 
 
 def main() -> int:
@@ -94,29 +156,14 @@ def main() -> int:
         idx_where = ""
         rows_where = ""
 
-    sql = _FRESHNESS_SQL.format(idx_where=idx_where, rows_where=rows_where)
-
     con = mcp_server._connect()
     try:
-        flagged = con.execute(sql).fetchall()
+        stale = _check_freshness(con, idx_where, rows_where, args.limit)
+        duplicated = _check_duplicates(con, rows_where, args.limit)
     finally:
         con.close()
 
-    if not flagged:
-        print("OK: every agency's comment rows are at least as current as the index.")
-        return 0
-
-    print(f"STALE: {len(flagged)} agency partition(s) lag the comments index\n")
-    print(f"{'agency':<10} {'index_to':<9} {'rows_to':<9} {'index_rows':>12} {'actual_rows':>12}")
-    print("-" * 56)
-    for agency, idx_ym, rows_ym, idx_rows, actual_rows in flagged[: args.limit]:
-        print(
-            f"{agency:<10} {_fmt_ym(idx_ym):<9} {_fmt_ym(rows_ym):<9} "
-            f"{idx_rows:>12,} {actual_rows:>12,}"
-        )
-    if len(flagged) > args.limit:
-        print(f"... and {len(flagged) - args.limit} more (raise --limit to see them)")
-    return 1
+    return 1 if (stale or duplicated) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/dedupe_comments_catalog.py
+++ b/scripts/dedupe_comments_catalog.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Audit and remove duplicate rows from the Iceberg ``comments`` catalog table.
+
+The one-time seed that loaded the pre-existing R2 partition tree into the catalog
+duplicated rows for agencies that were loaded more than once — its per-agency
+``DELETE`` did not remove prior rows on the R2 Data Catalog, so re-loads
+accumulated exact copies (e.g. OMB ~2.5x, NARA ~3.8x; FWS/EPA/DOT clean). Comments
+added later by the daily merge are unaffected — this is historical, not ongoing.
+
+Default mode is a **read-only audit**: it reports every agency whose row count
+exceeds its distinct ``comment_id`` count, plus totals. Nothing is written.
+
+``--apply`` rebuilds the table deduplicated (one row per ``comment_id``, latest
+``modify_date``) via ``CREATE OR REPLACE TABLE`` — an atomic swap that never
+relies on ``DELETE`` (the very operation that left the duplicates), so it can't
+double the problem: it either swaps in the clean snapshot or fails without
+touching the existing data. After a successful apply, re-run the mirror
+(``publish_comments_mirror.py``) so the public files the UI reads are refreshed.
+
+Safe rollout: run with no flags first (audit), eyeball the report, then ``--apply``,
+then run once more with no flags to confirm the table is clean.
+
+Reads/writes the catalog via ``R2_CATALOG_*``. See
+``.github/workflows/dedupe-comments-catalog.yml``.
+
+Usage:
+    uv run python scripts/dedupe_comments_catalog.py            # audit only (default)
+    uv run python scripts/dedupe_comments_catalog.py --apply    # rebuild deduplicated
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from loguru import logger
+
+from spicy_regs.schemas.regulations import RECORD_TYPES
+from spicy_regs.sources import iceberg
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Rebuild the table deduplicated. Without this flag the script only audits.",
+    )
+    args = parser.parse_args()
+
+    if not iceberg.is_configured():
+        logger.error("R2 Data Catalog is not configured (R2_CATALOG_*); cannot proceed")
+        return 1
+
+    comments_rt = RECORD_TYPES["comments"]
+    con = iceberg._connect()
+    try:
+        con.execute("SET preserve_insertion_order=false")
+        con.execute("SET memory_limit='6GB'")
+
+        dupes = iceberg.audit_duplicates(con, comments_rt)
+        if not dupes:
+            logger.info("No duplication: every agency's comment rows are unique by comment_id.")
+            return 0
+
+        total_dupe_rows = sum(rows - distinct for _, rows, distinct in dupes)
+        logger.warning("{} agency(ies) carry duplicate comment rows ({:,} duplicate rows total):", len(dupes), total_dupe_rows)
+        logger.warning("{:<10} {:>14} {:>14} {:>8}", "agency", "rows", "distinct_ids", "factor")
+        for agency, rows, distinct in dupes:
+            factor = rows / distinct if distinct else 0
+            logger.warning("{:<10} {:>14,} {:>14,} {:>7.2f}x", agency, rows, distinct, factor)
+
+        if not args.apply:
+            logger.info("Audit only (pass --apply to rebuild the table deduplicated).")
+            return 0
+
+        logger.info("Rebuilding {} deduplicated (CREATE OR REPLACE, keeping latest modify_date per comment_id)...", comments_rt.name)
+        before, after = iceberg.dedupe_table(con, comments_rt)
+        logger.info("Rebuilt: {:,} rows -> {:,} rows ({:,} duplicates removed)", before, after, before - after)
+
+        remaining = iceberg.audit_duplicates(con, comments_rt)
+        if remaining:
+            logger.error(
+                "Dedup did NOT fully take — {} agency(ies) still show duplicates. "
+                "The catalog may not honor CREATE OR REPLACE as expected; investigate before re-running.",
+                len(remaining),
+            )
+            return 1
+        logger.info("Verified clean: rows now equal distinct comment_id counts for every agency.")
+        logger.info("Next: run publish_comments_mirror.py to refresh the public files the UI reads.")
+        return 0
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -373,6 +373,68 @@ def export_public_comments(output_dir: Path, record_type: RecordType) -> dict[st
         con.close()
 
 
+def audit_duplicates(con, record_type: RecordType) -> list[tuple[str, int, int]]:
+    """Per-agency (agency_code, rows, distinct_keys) where rows exceed distinct keys.
+
+    A read-only duplication report over the catalog table: any agency whose row
+    count is above its distinct ``dedup_key`` count carries duplicate rows. Sorted
+    by the number of duplicate rows, worst first. Empty when the table is clean.
+    """
+    key = record_type.dedup_key
+    tbl = _qualified(record_type)
+    rows = con.execute(
+        f"""
+        SELECT agency_code,
+               count(*) AS rows,
+               count(DISTINCT "{key}") AS distinct_keys
+        FROM {tbl}
+        WHERE agency_code IS NOT NULL
+        GROUP BY agency_code
+        HAVING count(*) > count(DISTINCT "{key}")
+        ORDER BY count(*) - count(DISTINCT "{key}") DESC
+        """
+    ).fetchall()
+    return [(r[0], r[1], r[2]) for r in rows]
+
+
+def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
+    """Collapse the catalog table to one row per ``dedup_key`` (latest modify_date).
+
+    Rebuilds the table with ``CREATE OR REPLACE TABLE`` from a materialized temp
+    rather than ``DELETE`` + reinsert. This is deliberate: the historical
+    duplication came from loads whose ``DELETE`` did not remove prior rows on the
+    R2 Data Catalog, so a DELETE-based cleanup could double the problem instead of
+    fixing it. ``CREATE OR REPLACE`` is atomic — it either swaps in the clean
+    snapshot or fails without destroying the existing data — and never depends on
+    delete semantics. The temp is materialized first so the replace doesn't read
+    the table it is rewriting.
+
+    Returns ``(rows_before, rows_after)``; ``rows_after`` equals the number of
+    distinct keys when the rebuild succeeds.
+    """
+    key = record_type.dedup_key
+    tbl = _qualified(record_type)
+    col_list = ", ".join(f'"{c}"' for c in record_type.schema)
+    tmp = f"_dedup_{record_type.name}"
+
+    before = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
+    con.execute(
+        f"""
+        CREATE OR REPLACE TEMP TABLE {tmp} AS
+        SELECT {col_list}
+        FROM {tbl}
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY "{key}"
+            ORDER BY modify_date DESC NULLS LAST
+        ) = 1;
+        """
+    )
+    con.execute(f"CREATE OR REPLACE TABLE {tbl} AS SELECT {col_list} FROM {tmp};")
+    con.execute(f"DROP TABLE IF EXISTS {tmp};")
+    after = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
+    return before, after
+
+
 def merge_and_export(staging_dir: Path, output_dir: Path, record_type: RecordType) -> Path | None:
     """Upsert staged rows into the catalog table, then export the public Parquet.
 

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -436,3 +436,48 @@ def test_export_public_comments_rebuilds_mirror(tmp_path, local_catalog, monkeyp
     omb_part = partition_dir / "agency_code=OMB" / "part-0.parquet"
     assert omb_part.exists()
     assert pl.read_parquet(omb_part).height == 1
+
+
+def test_audit_and_dedupe_table(tmp_path, local_catalog) -> None:
+    """audit_duplicates flags agencies with duplicate keys; dedupe_table collapses
+    the table to one row per comment_id, keeping the latest modify_date."""
+    con = local_catalog
+    iceberg._ensure_table(con, COMMENT)
+
+    base = tmp_path / "seed.parquet"
+    pl.DataFrame(
+        [
+            _comment("c1", "EPA-1", "EPA", "2025-01-01T00:00:00Z", modify_date="2025-01-01T00:00:00Z"),
+            _comment("c2", "EPA-1", "EPA", "2025-01-02T00:00:00Z", modify_date="2025-01-02T00:00:00Z"),
+            _comment("c3", "OMB-1", "OMB", "2025-02-01T00:00:00Z", modify_date="2025-02-01T00:00:00Z"),
+        ],
+        schema=COMMENT.schema,
+    ).write_parquet(base)
+
+    # seed_comments_from_parquet is a plain INSERT (no dedup) — loading twice
+    # duplicates every row, mimicking the historical seed-into-catalog bug.
+    iceberg.seed_comments_from_parquet(con, str(base), COMMENT)
+    iceberg.seed_comments_from_parquet(con, str(base), COMMENT)
+
+    # A newer version of c1 so dedupe must keep the latest modify_date, not just any copy.
+    newer = tmp_path / "newer.parquet"
+    pl.DataFrame(
+        [_comment("c1", "EPA-1", "EPA", "2025-03-09T00:00:00Z", modify_date="2025-03-09T00:00:00Z")],
+        schema=COMMENT.schema,
+    ).write_parquet(newer)
+    iceberg.seed_comments_from_parquet(con, str(newer), COMMENT)
+
+    # State: c1 x3 (two old + one newer), c2 x2, c3 x2 = 7 rows, 3 distinct ids.
+    audit = {a: (rows, distinct) for a, rows, distinct in iceberg.audit_duplicates(con, COMMENT)}
+    assert audit == {"EPA": (5, 2), "OMB": (2, 1)}
+
+    before, after = iceberg.dedupe_table(con, COMMENT)
+    assert before == 7
+    assert after == 3
+
+    # Clean afterward, and c1 kept its latest modify_date.
+    assert iceberg.audit_duplicates(con, COMMENT) == []
+    kept = con.execute(
+        f"SELECT modify_date FROM {iceberg._qualified(COMMENT)} WHERE comment_id = 'c1'"
+    ).fetchone()[0]
+    assert kept == "2025-03-09T00:00:00Z"


### PR DESCRIPTION
## Summary

Fixes the duplicate-comments issue found while verifying the mirror. The Iceberg `comments` catalog carries duplicate rows for agencies the one-time **seed** loaded more than once:

| agency | dup factor |
|---|---|
| FWS, DOT, EPA, CMS | ~1.0× (clean) |
| SSA | 2.0× |
| OMB | 2.49× |
| NARA | 3.79× |

Evidence it's historical seed damage, not the live pipeline:
- Copies are **byte-identical** (same `modify_date`) — e.g. 114k OMB comment_ids each appear exactly 3×.
- **Recent merge-era comments are clean** (OMB ≥ Jun 25: 7,557 rows / 7,557 distinct = 1.0×), so the daily upsert is healthy.

Root cause: the seed's per-agency `DELETE` did not remove prior rows on the R2 Data Catalog, so re-loads accumulated exact copies. This inflates the counts the UI shows and would repeat comments in listings.

## Changes

- **`iceberg.audit_duplicates()`** — per-agency `rows` vs `distinct dedup_key`, worst first; empty when clean.
- **`iceberg.dedupe_table()`** — rebuilds the table one-row-per-key (latest `modify_date`) via `CREATE OR REPLACE TABLE` from a materialized temp. Deliberately **never uses `DELETE`** (the operation that left the duplicates): `CREATE OR REPLACE` is an atomic swap, so it can't double the data — it either swaps in the clean snapshot or fails without touching the existing table.
- **`scripts/dedupe_comments_catalog.py`** — read-only **audit by default**; `--apply` rebuilds and then re-audits, failing if any duplicates remain.
- **`.github/workflows/dedupe-comments-catalog.yml`** — manual dispatch, `apply` defaults to false (audit).
- **`check_comments_freshness.py`** — adds a **uniqueness check** (`count(*)` vs `count(distinct comment_id)` per agency) beside the existing month-lag check, so this class of bug is caught automatically from now on. Either check can flag; exit 1 if either does.
- **Test** — `audit_duplicates` flags dupes and `dedupe_table` collapses them keeping the latest `modify_date`.

## Test plan

- [x] `uv run pytest tests/test_iceberg.py` — 16 passed (incl. new `test_audit_and_dedupe_table`)
- [x] `uv run ruff check` on all changed files — passed
- [x] Workflow YAML parses
- [ ] **Post-merge, staged rollout:**
  1. Run **Dedupe comments catalog** with `apply=false` — review the per-agency audit in the logs.
  2. Run again with `apply=true` — rebuilds deduplicated, self-verifies clean.
  3. Run **Publish comments mirror** — refreshes the public files the UI reads from the cleaned catalog.
  4. The next **Check comments freshness** run should report `OK (uniqueness)`.

## Caveat

`dedupe_table` relies on the DuckDB iceberg extension supporting `CREATE OR REPLACE TABLE` on the R2 Data Catalog, which I couldn't exercise from here (no catalog token in this environment; the unit test covers the SQL against a local catalog). It's the safe choice regardless — if the extension doesn't support it, the apply errors out without mutating the table. The audit path is fully safe to run anytime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q

---
_Generated by [Claude Code](https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q)_