### PR TITLE
Make catalog dedup memory-safe (per-agency)

### DIFF
--- a/scripts/dedupe_comments_catalog.py
+++ b/scripts/dedupe_comments_catalog.py
@@ -31,6 +31,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import tempfile
 
 from loguru import logger
 
@@ -54,8 +55,12 @@ def main() -> int:
     comments_rt = RECORD_TYPES["comments"]
     con = iceberg._connect()
     try:
+        # Keep peak memory bounded on the CI runner: fewer threads, a firm memory
+        # cap, and on-disk spill for the per-agency dedup windows.
         con.execute("SET preserve_insertion_order=false")
-        con.execute("SET memory_limit='6GB'")
+        con.execute("SET memory_limit='5GB'")
+        con.execute("SET threads=2")
+        con.execute(f"SET temp_directory='{tempfile.gettempdir()}/duckdb_dedup_spill'")
 
         dupes = iceberg.audit_duplicates(con, comments_rt)
         if not dupes:

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -406,8 +406,16 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
     R2 Data Catalog, so a DELETE-based cleanup could double the problem instead of
     fixing it. ``CREATE OR REPLACE`` is atomic — it either swaps in the clean
     snapshot or fails without destroying the existing data — and never depends on
-    delete semantics. The temp is materialized first so the replace doesn't read
-    the table it is rewriting.
+    delete semantics.
+
+    The dedup temp is filled **one agency at a time** rather than with a single
+    global window: a ``ROW_NUMBER() OVER (PARTITION BY key)`` over tens of millions
+    of rows with large text is a blocking sort that OOMs the runner, whereas the
+    same window scoped to one agency stays small (this mirrors how
+    ``transforms.partition_comments`` keeps peak memory bounded). Duplicates only
+    ever occur within a single agency (a ``comment_id`` belongs to one agency), so
+    per-agency dedup is equivalent to a global one here. The final swap reads the
+    materialized temp, so it never reads the table it is rewriting.
 
     Returns ``(rows_before, rows_after)``; ``rows_after`` equals the number of
     distinct keys when the rebuild succeeds.
@@ -418,17 +426,29 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
     tmp = f"_dedup_{record_type.name}"
 
     before = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
-    con.execute(
-        f"""
-        CREATE OR REPLACE TEMP TABLE {tmp} AS
-        SELECT {col_list}
-        FROM {tbl}
-        QUALIFY ROW_NUMBER() OVER (
-            PARTITION BY "{key}"
-            ORDER BY modify_date DESC NULLS LAST
-        ) = 1;
-        """
-    )
+
+    # Empty temp with the table's shape; fill it per agency to bound peak memory.
+    con.execute(f"DROP TABLE IF EXISTS {tmp};")
+    con.execute(f"CREATE TEMP TABLE {tmp} AS SELECT {col_list} FROM {tbl} WHERE false;")
+
+    agencies = [r[0] for r in con.execute(f"SELECT DISTINCT agency_code FROM {tbl}").fetchall()]
+    logger.info("iceberg: deduping {} agency bucket(s) of {}", len(agencies), record_type.name)
+    for agency in agencies:
+        where = "agency_code IS NULL" if agency is None else f"agency_code = '{_sql_str(agency)}'"
+        con.execute(
+            f"""
+            INSERT INTO {tmp} ({col_list})
+            SELECT {col_list}
+            FROM {tbl}
+            WHERE {where}
+            QUALIFY ROW_NUMBER() OVER (
+                PARTITION BY "{key}"
+                ORDER BY modify_date DESC NULLS LAST
+            ) = 1;
+            """
+        )
+
+    # Atomic swap from the materialized temp (streaming scan, no window/sort).
     con.execute(f"CREATE OR REPLACE TABLE {tbl} AS SELECT {col_list} FROM {tmp};")
     con.execute(f"DROP TABLE IF EXISTS {tmp};")
     after = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]


### PR DESCRIPTION
## Summary

Follow-up to #107. The first `--apply` run of the dedup **OOM'd** (5.5 GiB) and did **not** modify the catalog:

```
Rebuilding comments deduplicated (CREATE OR REPLACE ...)
_duckdb.OutOfMemoryException: could not allocate ... (5.5 GiB/5.5 GiB used)
  at dedupe_table ... CREATE OR REPLACE TEMP TABLE _dedup AS SELECT ... QUALIFY ROW_NUMBER() ...
```

A single global `ROW_NUMBER() OVER (PARTITION BY comment_id)` over 36M+ rows with large comment text is a blocking sort that doesn't fit the runner. Crucially the OOM happened while building the temp — **before** the `CREATE OR REPLACE` swap — so the catalog is untouched (still duplicated-but-intact). This was a memory bug, not the Iceberg-DDL concern (we never reached the swap).

## Fix

Fill the dedup temp **one agency at a time**: the same window scoped to a single agency stays small (mirroring `transforms.partition_comments`, which already handles these 36M rows fine). Duplicates only ever occur within one agency (a `comment_id` belongs to one agency), so per-agency dedup is equivalent to a global one here. The final `CREATE OR REPLACE TABLE` reads the materialized temp — a streaming scan with no window/sort — so it stays memory-light and still never relies on `DELETE`.

Also caps the dedup session: `threads=2`, `memory_limit=5GB`, on-disk temp spill.

## Test plan

- [x] `uv run pytest tests/test_iceberg.py` — 16 passed (existing `test_audit_and_dedupe_table` still green with the per-agency rewrite: before=7 → after=3, keeps latest `modify_date`)
- [x] `uv run ruff check` — passed
- [ ] **Post-merge:** re-run **Dedupe comments catalog** with `apply=true` → expect success + "Verified clean" this time. Then **Publish comments mirror**, then confirm OMB partition `count == distinct`.

## Note

This is the first run that will actually exercise `CREATE OR REPLACE TABLE` on the R2 Data Catalog (the OOM pre-empted it last time). If that DDL turns out to be unsupported, the apply will fail there without mutating the table (the atomic swap either takes or errors), and I'll report before trying anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q

---
_Generated by [Claude Code](https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q)_