### PR TITLE
Dedupe via per-agency write + rename swap (avoid write-side OOM)

### DIFF
--- a/.github/workflows/dedupe-comments-catalog.yml
+++ b/.github/workflows/dedupe-comments-catalog.yml
@@ -7,8 +7,9 @@ name: Dedupe comments catalog (manual)
 #
 # Manual dispatch only — the apply path WRITES to the production catalog, so it
 # never runs on a schedule. It defaults to a read-only audit; flip `apply` on to
-# rebuild the table deduplicated. The rebuild uses CREATE OR REPLACE (atomic swap,
-# never DELETE), so a failed run can't corrupt or double the data.
+# rebuild the table deduplicated. The rebuild writes a fresh table per-agency and
+# swaps it in by RENAME (never DELETE, never a whole-table single write), ordered
+# so an unsupported RENAME fails with the live table still in place.
 #
 # Recommended sequence: run once with apply=false (audit), review the report in
 # the logs, run again with apply=true, then run apply=false once more to confirm

--- a/scripts/dedupe_comments_catalog.py
+++ b/scripts/dedupe_comments_catalog.py
@@ -11,10 +11,11 @@ Default mode is a **read-only audit**: it reports every agency whose row count
 exceeds its distinct ``comment_id`` count, plus totals. Nothing is written.
 
 ``--apply`` rebuilds the table deduplicated (one row per ``comment_id``, latest
-``modify_date``) via ``CREATE OR REPLACE TABLE`` — an atomic swap that never
-relies on ``DELETE`` (the very operation that left the duplicates), so it can't
-double the problem: it either swaps in the clean snapshot or fails without
-touching the existing data. After a successful apply, re-run the mirror
+``modify_date``): it writes a fresh sibling table **one agency at a time** and
+swaps it in by ``RENAME``. It never uses ``DELETE`` (the operation that left the
+duplicates) and never rewrites the whole table in one statement (which OOMs the
+runner on both the read and Iceberg-write sides) — only bounded per-agency
+writes, then a metadata-only rename. After a successful apply, re-run the mirror
 (``publish_comments_mirror.py``) so the public files the UI reads are refreshed.
 
 Safe rollout: run with no flags first (audit), eyeball the report, then ``--apply``,

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -400,44 +400,48 @@ def audit_duplicates(con, record_type: RecordType) -> list[tuple[str, int, int]]
 def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
     """Collapse the catalog table to one row per ``dedup_key`` (latest modify_date).
 
-    Rebuilds the table with ``CREATE OR REPLACE TABLE`` from a materialized temp
-    rather than ``DELETE`` + reinsert. This is deliberate: the historical
-    duplication came from loads whose ``DELETE`` did not remove prior rows on the
-    R2 Data Catalog, so a DELETE-based cleanup could double the problem instead of
-    fixing it. ``CREATE OR REPLACE`` is atomic — it either swaps in the clean
-    snapshot or fails without destroying the existing data — and never depends on
-    delete semantics.
+    Builds a fresh sibling table by writing the deduped rows **one agency at a
+    time**, then swaps it in by ``RENAME``. Two constraints drive this shape:
 
-    The dedup temp is filled **one agency at a time** rather than with a single
-    global window: a ``ROW_NUMBER() OVER (PARTITION BY key)`` over tens of millions
-    of rows with large text is a blocking sort that OOMs the runner, whereas the
-    same window scoped to one agency stays small (this mirrors how
-    ``transforms.partition_comments`` keeps peak memory bounded). Duplicates only
-    ever occur within a single agency (a ``comment_id`` belongs to one agency), so
-    per-agency dedup is equivalent to a global one here. The final swap reads the
-    materialized temp, so it never reads the table it is rewriting.
+    * Never ``DELETE``. The historical duplication came from loads whose ``DELETE``
+      didn't remove prior rows on the R2 Data Catalog, so a delete-based cleanup
+      could double the problem.
+    * Never touch tens of millions of rows in one statement. A global
+      ``ROW_NUMBER() OVER (PARTITION BY key)`` OOMs the runner on the read side,
+      and a single ``CREATE OR REPLACE ... AS SELECT`` of the whole table OOMs it
+      on the Iceberg *write* side. Both the daily merge and the original seed only
+      ever write per-agency slices, which fit — so this does the same. Duplicates
+      only ever occur within one agency (a ``comment_id`` belongs to one agency),
+      so per-agency dedup equals a global one here.
+
+    The swap is ordered so that if the catalog doesn't support ``ALTER TABLE
+    RENAME`` the very first rename fails with the live table still in place (the
+    fresh table is only a harmless sibling at that point).
 
     Returns ``(rows_before, rows_after)``; ``rows_after`` equals the number of
     distinct keys when the rebuild succeeds.
     """
     key = record_type.dedup_key
+    name = record_type.name
     tbl = _qualified(record_type)
+    dedup_tbl = f'{_schema_ref()}."{name}_dedup"'
+    stale_tbl = f'{_schema_ref()}."{name}_stale"'
+    col_defs = ", ".join(f'"{c}" VARCHAR' for c in record_type.schema)
     col_list = ", ".join(f'"{c}"' for c in record_type.schema)
-    tmp = f"_dedup_{record_type.name}"
 
     before = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
 
-    # Empty temp with the table's shape; fill it per agency to bound peak memory.
-    con.execute(f"DROP TABLE IF EXISTS {tmp};")
-    con.execute(f"CREATE TEMP TABLE {tmp} AS SELECT {col_list} FROM {tbl} WHERE false;")
+    # Fresh sibling table (clear any stray from a prior aborted run).
+    con.execute(f"DROP TABLE IF EXISTS {dedup_tbl};")
+    con.execute(f"CREATE TABLE {dedup_tbl} ({col_defs});")
 
     agencies = [r[0] for r in con.execute(f"SELECT DISTINCT agency_code FROM {tbl}").fetchall()]
-    logger.info("iceberg: deduping {} agency bucket(s) of {}", len(agencies), record_type.name)
+    logger.info("iceberg: rebuilding {} deduplicated across {} agency bucket(s)", name, len(agencies))
     for agency in agencies:
         where = "agency_code IS NULL" if agency is None else f"agency_code = '{_sql_str(agency)}'"
         con.execute(
             f"""
-            INSERT INTO {tmp} ({col_list})
+            INSERT INTO {dedup_tbl} ({col_list})
             SELECT {col_list}
             FROM {tbl}
             WHERE {where}
@@ -448,10 +452,14 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
             """
         )
 
-    # Atomic swap from the materialized temp (streaming scan, no window/sort).
-    con.execute(f"CREATE OR REPLACE TABLE {tbl} AS SELECT {col_list} FROM {tmp};")
-    con.execute(f"DROP TABLE IF EXISTS {tmp};")
-    after = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
+    after = con.execute(f"SELECT count(*) FROM {dedup_tbl}").fetchone()[0]
+
+    # Swap by rename (metadata only — no bulk rewrite). Renaming the live table
+    # first means an unsupported RENAME fails here, before anything destructive.
+    con.execute(f"DROP TABLE IF EXISTS {stale_tbl};")
+    con.execute(f'ALTER TABLE {tbl} RENAME TO "{name}_stale";')
+    con.execute(f'ALTER TABLE {dedup_tbl} RENAME TO "{name}";')
+    con.execute(f"DROP TABLE IF EXISTS {stale_tbl};")
     return before, after
 
 


### PR DESCRIPTION
## Summary

Follow-up to #108. The per-agency **read-side** dedup worked, but the apply still OOM'd — this time on the **write side**, at the final single statement that wrote all ~34M deduped rows into the catalog:

```
iceberg: deduping 178 agency bucket(s) of comments      ← all per-agency passes ran
_duckdb.OutOfMemoryException: failed to pin block ... (4.6 GiB/4.6 GiB used)
  at dedupe_table ... CREATE OR REPLACE TABLE {tbl} AS SELECT ... FROM {tmp}
```

The Iceberg writer buffers too much when writing the whole table at once. Notably, **nothing else in the system does that** — the daily merge and the original seed only ever write **per-agency slices**, which is why they fit in the runner's ~7 GB. (The catalog was not modified — `CREATE OR REPLACE` aborts atomically.)

## Fix

Rebuild the same way the rest of the system writes: a fresh sibling table filled **one agency at a time** (bounded per-agency `INSERT`s), then swapped in with `ALTER TABLE ... RENAME` — metadata only, no bulk rewrite. Still never uses `DELETE`.

The swap renames the **live table first**, so if the catalog doesn't support `RENAME` it fails there with the live `comments` still in place and only a harmless `comments_dedup` sibling left behind (which the next run cleans up).

```
CREATE TABLE comments_dedup (...)
-- per agency: INSERT INTO comments_dedup SELECT dedup(agency) FROM comments WHERE agency=X
ALTER TABLE comments RENAME TO comments_stale   -- fails safe here if RENAME unsupported
ALTER TABLE comments_dedup RENAME TO comments
DROP TABLE comments_stale
```

## Test plan

- [x] `uv run pytest tests/test_iceberg.py` — 16 passed (`test_audit_and_dedupe_table` exercises the full per-agency-build + rename swap against a local catalog: 7 rows → 3, keeps latest `modify_date`)
- [x] `uv run ruff check` — passed; workflow YAML parses
- [ ] **Post-merge:** re-run **Dedupe comments catalog** `apply=true` → expect success + "Verified clean". Then **Publish comments mirror**, then confirm OMB partition `count == distinct`.

## Note

This is now the real test of `RENAME`/`DROP` support on the R2 Data Catalog. If those aren't supported, the run fails at the first rename with the live table intact, and I'll report — no `DELETE` fallback without checking in. The alternative discussed (running the dedup off a memory-capped runner) remains available if CI limits keep biting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q

---
_Generated by [Claude Code](https://claude.ai/code/session_01B75dT3a3E2rhQgrTVAir5q)_