### PR TITLE
Add --chunk-size: ingest a huge agency's comments in bounded, per-chunk-committed pieces

### DIFF
--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -45,6 +45,7 @@ from spicy_regs.transforms import (
     merge_comments_partitioned,
     merge_staging_files,
     update_comments_index,
+    write_staging,
 )
 
 load_dotenv()
@@ -70,6 +71,7 @@ class RegulationsPipeline(Pipeline):
         max_workers: int = 4,
         use_iceberg: bool = False,
         enrich_text: bool = True,
+        chunk_size: int = 0,
         verbose: bool = False,
     ) -> None:
         self.agency = agency
@@ -84,6 +86,7 @@ class RegulationsPipeline(Pipeline):
         self.max_workers = max_workers
         self.use_iceberg = use_iceberg
         self.enrich_text = enrich_text
+        self.chunk_size = chunk_size
         self.verbose = verbose
 
     def run(self) -> None:
@@ -93,6 +96,18 @@ class RegulationsPipeline(Pipeline):
 
         record_types = self._record_types()
         agencies = self._agencies()
+
+        # Chunked comments path: for an agency too large to buffer whole (millions
+        # of comments would OOM), ingest its comments in bounded key-chunks,
+        # committing each into the catalog. Only meaningful for the iceberg
+        # comments-only case (the catalog is a row-level upsert surface).
+        if self.chunk_size and self.only_comments and self.use_iceberg:
+            manifest = Manifest.empty() if self.full_refresh else Manifest.load(output_dir)
+            for agency in agencies:
+                self._ingest_comments_chunked(agency, output_dir, staging_dir, manifest)
+            rmtree(staging_dir, ignore_errors=True)
+            logger.info("Done!")
+            return
 
         # 1. Prime: load processed-key manifest + existing output for incremental work.
         if self.full_refresh:
@@ -160,6 +175,42 @@ class RegulationsPipeline(Pipeline):
                     r2.upload_file(index_file, remote_key="comments_index.parquet")
 
         logger.info("Done!")
+
+    def _ingest_comments_chunked(self, agency: str, output_dir: Path, staging_dir: Path, manifest: Manifest) -> None:
+        """Ingest one agency's comments in bounded key-chunks, committing each.
+
+        Downloads at most ``chunk_size`` comment files at a time, stages them,
+        MERGEs them into the catalog, then frees memory before the next chunk —
+        so a multi-million-comment agency (which would otherwise buffer every
+        record and OOM) ingests in even, durable pieces. Deleting the staging
+        chunk between iterations keeps peak memory ~one chunk.
+        """
+        comment_rt = RECORD_TYPES["comments"]
+        resource = mirrulations.s3_resource()
+        keys = mirrulations.list_agency_files_by_type(
+            resource,
+            mirrulations.BUCKET,
+            mirrulations.PREFIX,
+            agency,
+            [comment_rt],
+            processed_keys=manifest,
+            since_year=self.since_year,
+            verbose=self.verbose,
+        )["comments"]
+        transform = self._transform_for(comment_rt)
+        total = len(keys)
+        logger.info("[{}] comments: {} files, ingesting in chunks of {}", agency, total, self.chunk_size)
+
+        for start in range(0, total, self.chunk_size):
+            chunk = keys[start : start + self.chunk_size]
+            label = f"[{agency}] comments {start + len(chunk)}/{total}"
+            payloads = mirrulations.download_keys(resource, mirrulations.BUCKET, chunk, label=label)
+            records = list(transform.apply(payloads))
+            write_staging(agency, comment_rt.name, records, staging_dir, comment_rt.schema)
+            iceberg.merge_comments(staging_dir, output_dir, comment_rt)
+            rmtree(staging_dir / comment_rt.name, ignore_errors=True)
+            manifest.record(chunk)
+            logger.info("[{}] comments: committed {}/{}", agency, start + len(chunk), total)
 
     # -- regulations-specific wiring ---------------------------------------
 
@@ -308,6 +359,13 @@ def main(
         bool,
         Parameter(help="Fill comment text_content inline from Mirrulations derived-data extracted text"),
     ] = True,
+    chunk_size: Annotated[
+        int,
+        Parameter(
+            help="Ingest comments in bounded key-chunks of this size (0 = whole agency at once). "
+            "Use for agencies too large to buffer in memory; requires --only-comments --use-iceberg."
+        ),
+    ] = 0,
     verbose: Annotated[bool, Parameter(name=["--verbose", "-v"], help="Verbose logging")] = False,
 ) -> None:
     """Run the regulations.gov ETL pipeline."""
@@ -324,6 +382,7 @@ def main(
         max_workers=max_workers,
         use_iceberg=use_iceberg,
         enrich_text=enrich_text,
+        chunk_size=chunk_size,
         verbose=verbose,
     ).run()
 

--- a/src/spicy_regs/sources/mirrulations.py
+++ b/src/spicy_regs/sources/mirrulations.py
@@ -21,6 +21,7 @@ from typing import Any
 import boto3
 from botocore import UNSIGNED
 from botocore.config import Config as BotoConfig
+from loguru import logger
 from tqdm import tqdm
 
 from spicy_regs.schemas import RecordType
@@ -36,6 +37,11 @@ PREFIX = "raw-data"
 # anonymous resource is shared across the pool: unsigned read-only GetObject has
 # no credential-refresh race, and botocore's connection pool is thread-safe.
 DEFAULT_DOWNLOAD_WORKERS = 16
+
+# Emit a download-progress line every this many files, so a large agency's
+# multi-hour download reports how far along it is (small agencies finish before
+# the first mark and just log their staged total).
+_PROGRESS_EVERY = 25_000
 
 
 def s3_resource(max_pool_connections: int = DEFAULT_DOWNLOAD_WORKERS) -> Any:
@@ -212,6 +218,43 @@ def _identity(payload: dict) -> dict:
     return payload
 
 
+def download_keys(
+    s3_resource: Any,
+    bucket_name: str,
+    keys: list[str],
+    workers: int = DEFAULT_DOWNLOAD_WORKERS,
+    *,
+    label: str = "",
+) -> Iterator[dict]:
+    """Concurrently download + parse the given keys, yielding raw payloads.
+
+    The shared download engine for both :class:`MirrulationsReader` (whole
+    agency) and the chunked ingest path (one bounded key-chunk at a time, so a
+    huge agency never buffers all its records at once). Order is not preserved —
+    dedup happens later by key. With ``label`` set, emits a progress line every
+    ``_PROGRESS_EVERY`` files.
+    """
+    total = len(keys)
+    n = max(1, min(workers, total)) if total else 1
+    if n <= 1:
+        for key in keys:
+            payload = download_and_parse(s3_resource, bucket_name, key, _identity)
+            if payload is not None:
+                yield payload
+        return
+
+    done = 0
+    with ThreadPoolExecutor(max_workers=n) as executor:
+        futures = [executor.submit(download_and_parse, s3_resource, bucket_name, key, _identity) for key in keys]
+        for future in as_completed(futures):
+            done += 1
+            if label and done % _PROGRESS_EVERY == 0:
+                logger.info("{}: downloaded {}/{}", label, done, total)
+            payload = future.result()
+            if payload is not None:
+                yield payload
+
+
 class MirrulationsReader(Reader):
     """Reads one agency's records of a single record type from Mirrulations S3.
 
@@ -267,25 +310,10 @@ class MirrulationsReader(Reader):
                 self.verbose,
                 self.since_year,
             )
-        # Fan the per-file GETs out across a thread pool — they are independent,
-        # I/O-bound round trips. Order is irrelevant (dedup happens later by key).
-        workers = max(1, min(self.download_workers, len(self.last_keys)))
-        if workers <= 1:
-            for key in self.last_keys:
-                payload = download_and_parse(self.s3_resource, self.bucket, key, _identity)
-                if payload is not None:
-                    yield payload
-            return
-
-        with ThreadPoolExecutor(max_workers=workers) as executor:
-            futures = [
-                executor.submit(download_and_parse, self.s3_resource, self.bucket, key, _identity)
-                for key in self.last_keys
-            ]
-            for future in as_completed(futures):
-                payload = future.result()
-                if payload is not None:
-                    yield payload
+        # Fan the per-file GETs across a thread pool via the shared engine —
+        # independent, I/O-bound round trips; order is irrelevant (dedup by key).
+        label = f"[{self.agency}] {self.record_type.name}"
+        yield from download_keys(self.s3_resource, self.bucket, self.last_keys, self.download_workers, label=label)
 
 
 class _AgencyListingCache:

--- a/tests/test_mirrulations_reader.py
+++ b/tests/test_mirrulations_reader.py
@@ -221,6 +221,22 @@ def test_reader_factory_scans_each_agency_once() -> None:
     assert len(keys_by_type["comments"]) == 1
 
 
+def test_download_keys_yields_payloads() -> None:
+    """download_keys concurrently downloads a given key list and yields payloads.
+
+    This is the shared download engine used by both iter_records and the chunked
+    ingest path (which downloads one bounded key-chunk at a time).
+    """
+    from spicy_regs.sources.mirrulations import download_keys
+
+    store = _make_store()
+    keys = [_docket_key("EPA-2024-0001"), _docket_key("EPA-2025-0002")]
+    payloads = list(download_keys(_FakeS3Resource(store), BUCKET, keys, workers=4))
+
+    ids = sorted(p["data"]["id"] for p in payloads)
+    assert ids == ["EPA-2024-0001", "EPA-2025-0002"]
+
+
 def test_download_and_parse_closes_body_on_read_error() -> None:
     """A failed download must still close the response body.
 

--- a/tests/test_regulations_pipeline.py
+++ b/tests/test_regulations_pipeline.py
@@ -145,21 +145,47 @@ def test_run_dedups_on_merge_keeping_latest_modify_date(tmp_output: Path, monkey
     }
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
 
-    RegulationsPipeline(
-        agency=AGENCY, output_dir=tmp_output, skip_comments=True, skip_upload=True
-    ).run()
+    RegulationsPipeline(agency=AGENCY, output_dir=tmp_output, skip_comments=True, skip_upload=True).run()
 
     df = pl.read_parquet(tmp_output / "dockets.parquet")
     assert df.height == 1
     assert df["modify_date"].to_list() == ["2024-09-09"]
 
 
+def test_chunked_comments_commit_per_chunk(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """With chunk_size set, comments ingest in bounded key-chunks and the catalog
+    MERGE runs once per chunk (so a huge agency commits in pieces, never buffering
+    everything in memory)."""
+    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
+    # 5 comment files, chunk_size 2 -> chunks [2,2,1] -> 3 merges.
+    store = {
+        _comment_key(f"c{i}", "EPA-2026-0001"): dumps(
+            _comment_payload(f"c{i}", "EPA-2026-0001", "2026-01-01T00:00:00Z")
+        ).encode()
+        for i in range(5)
+    }
+    monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
+
+    merge_calls: list = []
+    monkeypatch.setattr(regulations.iceberg, "merge_comments", lambda sd, od, rt: merge_calls.append(1))
+
+    RegulationsPipeline(
+        agency=AGENCY,
+        output_dir=tmp_output,
+        only_comments=True,
+        use_iceberg=True,
+        enrich_text=False,
+        chunk_size=2,
+        skip_upload=True,
+    ).run()
+
+    assert len(merge_calls) == 3  # ceil(5 / 2)
+
+
 def test_run_with_no_records_is_noop(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource({}))
 
-    RegulationsPipeline(
-        agency=AGENCY, output_dir=tmp_output, skip_comments=True, skip_upload=True
-    ).run()
+    RegulationsPipeline(agency=AGENCY, output_dir=tmp_output, skip_comments=True, skip_upload=True).run()
 
     assert not (tmp_output / "dockets.parquet").exists()
 


### PR DESCRIPTION
## Problem

An agency with millions of 2026 comments OOMs the pipeline. `run()` lists all keys, **downloads and buffers every record in memory**, then writes/merges once. On a 24 GB box, HHS (~1.1M) barely fit (~20 GB) and **FWS (~2.5M) was OOM-killed** (exit 137). Ordering can't fix this — any agency past ~1M comments fails regardless of position.

## Fix

`--chunk-size N` (with `--only-comments --use-iceberg`) ingests an agency's comments in **bounded key-chunks**: download N files → stage → MERGE into the catalog → free → next N. Peak memory stays ~one chunk (~2 GB at N=100k), and a 2.5M agency commits in ~25 durable pieces — a crash keeps everything already committed.

Why count-based, not by month: the month lives inside each comment's `posted_date`, not the S3 key, so the download can't be sliced by month without first downloading everything; and months are uneven (one busy window could still OOM). A fixed count bounds memory regardless of clustering.

## Changes

- Extract `download_keys()` as the shared concurrent-download engine (with progress logging); both `MirrulationsReader.iter_records` and the chunked path use it.
- `RegulationsPipeline._ingest_comments_chunked` + a `chunk_size` field, dispatched from `run()` when set (iceberg comments-only case). Deletes each staging chunk between iterations to cap memory.
- `--chunk-size` CLI flag (default 0 = current whole-agency behavior).

## Tests

- `test_download_keys_yields_payloads` — the shared engine.
- `test_chunked_comments_commit_per_chunk` — 5 keys @ chunk 2 → 3 MERGEs (per-chunk commit).
- Full suite green (237); ruff + ty clean.
