### PR TITLE
Fix catalog dedupe swap: replace unsupported RENAME with DROP+INSERT

### DIFF
--- a/scripts/dedupe_comments_catalog.py
+++ b/scripts/dedupe_comments_catalog.py
@@ -11,11 +11,14 @@ Default mode is a **read-only audit**: it reports every agency whose row count
 exceeds its distinct ``comment_id`` count, plus totals. Nothing is written.
 
 ``--apply`` rebuilds the table deduplicated (one row per ``comment_id``, latest
-``modify_date``): it writes a fresh sibling table **one agency at a time** and
-swaps it in by ``RENAME``. It never uses ``DELETE`` (the operation that left the
-duplicates) and never rewrites the whole table in one statement (which OOMs the
-runner on both the read and Iceberg-write sides) — only bounded per-agency
-writes, then a metadata-only rename. After a successful apply, re-run the mirror
+``modify_date``): it writes a fresh sibling table **one agency at a time**, then
+replaces the live table with it via ``DROP`` + per-agency ``INSERT`` (DuckDB's
+Iceberg REST integration does not support ``ALTER TABLE RENAME``). It never uses
+``DELETE`` (the operation that left the duplicates) and never rewrites the whole
+table in one statement (which OOMs the runner on both the read and Iceberg-write
+sides) — only bounded per-agency writes. The sibling is kept until the rebuilt
+table's row count is verified, so an interrupted swap loses nothing and re-running
+resumes it. After a successful apply, re-run the mirror
 (``publish_comments_mirror.py``) so the public files the UI reads are refreshed.
 
 Safe rollout: run with no flags first (audit), eyeball the report, then ``--apply``,
@@ -33,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import tempfile
+from os import getenv
 
 from loguru import logger
 
@@ -56,11 +60,17 @@ def main() -> int:
     comments_rt = RECORD_TYPES["comments"]
     con = iceberg._connect()
     try:
-        # Keep peak memory bounded on the CI runner: fewer threads, a firm memory
-        # cap, and on-disk spill for the per-agency dedup windows.
+        # Keep peak memory bounded: fewer threads, a firm memory cap, and on-disk
+        # spill for the per-agency dedup windows. The defaults suit the CI runner;
+        # override via DEDUP_MEMORY_LIMIT / DEDUP_THREADS on a bigger host (a large
+        # agency's window sort buffers whole rows, comment text included, so 5GB is
+        # tight for the worst agency).
+        mem_limit = getenv("DEDUP_MEMORY_LIMIT", "5GB")
+        threads = getenv("DEDUP_THREADS", "2")
+        logger.info("duckdb dedup limits: memory_limit={} threads={}", mem_limit, threads)
         con.execute("SET preserve_insertion_order=false")
-        con.execute("SET memory_limit='5GB'")
-        con.execute("SET threads=2")
+        con.execute(f"SET memory_limit='{mem_limit}'")
+        con.execute(f"SET threads={threads}")
         con.execute(f"SET temp_directory='{tempfile.gettempdir()}/duckdb_dedup_spill'")
 
         dupes = iceberg.audit_duplicates(con, comments_rt)

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -400,8 +400,8 @@ def audit_duplicates(con, record_type: RecordType) -> list[tuple[str, int, int]]
 def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
     """Collapse the catalog table to one row per ``dedup_key`` (latest modify_date).
 
-    Builds a fresh sibling table by writing the deduped rows **one agency at a
-    time**, then swaps it in by ``RENAME``. Two constraints drive this shape:
+    Builds a fresh deduped sibling table one agency at a time, then replaces the
+    live table with it. Three constraints drive the shape:
 
     * Never ``DELETE``. The historical duplication came from loads whose ``DELETE``
       didn't remove prior rows on the R2 Data Catalog, so a delete-based cleanup
@@ -413,10 +413,14 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
       ever write per-agency slices, which fit — so this does the same. Duplicates
       only ever occur within one agency (a ``comment_id`` belongs to one agency),
       so per-agency dedup equals a global one here.
-
-    The swap is ordered so that if the catalog doesn't support ``ALTER TABLE
-    RENAME`` the very first rename fails with the live table still in place (the
-    fresh table is only a harmless sibling at that point).
+    * Never ``ALTER TABLE RENAME``. DuckDB's Iceberg REST integration does not
+      implement it (``NotImplementedException: Alter Schema Entry``), so the swap
+      replaces the live table by ``DROP`` + ``CREATE`` + per-agency ``INSERT``
+      from the sibling — all operations this catalog supports. The sibling is the
+      durable copy: it is dropped only after the rebuilt table's row count is
+      verified, so an interruption mid-swap loses nothing. A re-run detects the
+      live table missing (but the sibling present) and resumes from the sibling
+      instead of rebuilding it from a table that no longer exists.
 
     Returns ``(rows_before, rows_after)``; ``rows_after`` equals the number of
     distinct keys when the rebuild succeeds.
@@ -425,13 +429,49 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
     name = record_type.name
     tbl = _qualified(record_type)
     dedup_tbl = f'{_schema_ref()}."{name}_dedup"'
-    stale_tbl = f'{_schema_ref()}."{name}_stale"'
     col_defs = ", ".join(f'"{c}" VARCHAR' for c in record_type.schema)
     col_list = ", ".join(f'"{c}"' for c in record_type.schema)
 
+    def _exists(ident: str) -> bool:
+        try:
+            con.execute(f"SELECT 1 FROM {ident} LIMIT 1")
+            return True
+        except Exception:
+            return False
+
+    def _replace_live_from_sibling() -> int:
+        # Swap without RENAME: rebuild the live table from the deduped sibling
+        # using DROP/CREATE/INSERT (per-agency, so no whole-table statement). The
+        # sibling still holds every row throughout, so this is safe to re-run if
+        # interrupted; it is dropped only once the rebuilt row count matches.
+        expected = con.execute(f"SELECT count(*) FROM {dedup_tbl}").fetchone()[0]
+        sibling_agencies = [r[0] for r in con.execute(f"SELECT DISTINCT agency_code FROM {dedup_tbl}").fetchall()]
+        con.execute(f"DROP TABLE IF EXISTS {tbl};")
+        con.execute(f"CREATE TABLE {tbl} ({col_defs});")
+        for agency in sibling_agencies:
+            where = "agency_code IS NULL" if agency is None else f"agency_code = '{_sql_str(agency)}'"
+            con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM {dedup_tbl} WHERE {where};")
+        rebuilt = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
+        if rebuilt != expected:
+            raise RuntimeError(
+                f"dedupe rebuild mismatch: {tbl} has {rebuilt:,} rows, expected {expected:,}; "
+                f"{dedup_tbl} left in place as the safe copy — re-run to retry the swap"
+            )
+        con.execute(f"DROP TABLE IF EXISTS {dedup_tbl};")
+        return rebuilt
+
+    # Resume an interrupted swap: the live table is gone but the deduped sibling
+    # is intact. Rebuild from the sibling rather than rebuilding the sibling from
+    # a missing table (which would destroy the only good copy).
+    if not _exists(tbl) and _exists(dedup_tbl):
+        logger.warning("iceberg: {} missing but {} present — resuming interrupted dedupe swap", tbl, dedup_tbl)
+        after = _replace_live_from_sibling()
+        return after, after
+
     before = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
 
-    # Fresh sibling table (clear any stray from a prior aborted run).
+    # Build the deduped sibling fresh (discarding any partial one from an aborted
+    # run), one agency at a time.
     con.execute(f"DROP TABLE IF EXISTS {dedup_tbl};")
     con.execute(f"CREATE TABLE {dedup_tbl} ({col_defs});")
 
@@ -454,12 +494,9 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
 
     after = con.execute(f"SELECT count(*) FROM {dedup_tbl}").fetchone()[0]
 
-    # Swap by rename (metadata only — no bulk rewrite). Renaming the live table
-    # first means an unsupported RENAME fails here, before anything destructive.
-    con.execute(f"DROP TABLE IF EXISTS {stale_tbl};")
-    con.execute(f'ALTER TABLE {tbl} RENAME TO "{name}_stale";')
-    con.execute(f'ALTER TABLE {dedup_tbl} RENAME TO "{name}";')
-    con.execute(f"DROP TABLE IF EXISTS {stale_tbl};")
+    # Replace the live table with the deduped sibling (no RENAME — see docstring).
+    logger.info("iceberg: swapping deduped {} into place ({:,} -> {:,} rows)", name, before, after)
+    _replace_live_from_sibling()
     return before, after
 
 

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -481,3 +481,42 @@ def test_audit_and_dedupe_table(tmp_path, local_catalog) -> None:
         f"SELECT modify_date FROM {iceberg._qualified(COMMENT)} WHERE comment_id = 'c1'"
     ).fetchone()[0]
     assert kept == "2025-03-09T00:00:00Z"
+
+
+def test_dedupe_table_resumes_interrupted_swap(tmp_path, local_catalog) -> None:
+    """If a prior run built the deduped sibling but died before the swap finished
+    (live table dropped), dedupe_table rebuilds the live table from the sibling
+    instead of rebuilding the sibling from a table that no longer exists."""
+    con = local_catalog
+    iceberg._ensure_table(con, COMMENT)
+
+    base = tmp_path / "seed.parquet"
+    pl.DataFrame(
+        [
+            _comment("c1", "EPA-1", "EPA", "2025-01-01T00:00:00Z", modify_date="2025-01-01T00:00:00Z"),
+            _comment("c2", "EPA-1", "EPA", "2025-01-02T00:00:00Z", modify_date="2025-01-02T00:00:00Z"),
+            _comment("c3", "OMB-1", "OMB", "2025-02-01T00:00:00Z", modify_date="2025-02-01T00:00:00Z"),
+        ],
+        schema=COMMENT.schema,
+    ).write_parquet(base)
+    iceberg.seed_comments_from_parquet(con, str(base), COMMENT)
+
+    # Simulate the interrupted-swap state: a complete deduped sibling exists but
+    # the live table has already been dropped (as happens after DROP + before the
+    # per-agency INSERTs finish).
+    tbl = iceberg._qualified(COMMENT)
+    dedup_tbl = f'{iceberg._schema_ref()}."comments_dedup"'
+    col_defs = ", ".join(f'"{c}" VARCHAR' for c in COMMENT.schema)
+    col_list = ", ".join(f'"{c}"' for c in COMMENT.schema)
+    con.execute(f"CREATE TABLE {dedup_tbl} ({col_defs});")
+    con.execute(f"INSERT INTO {dedup_tbl} ({col_list}) SELECT {col_list} FROM {tbl};")
+    con.execute(f"DROP TABLE {tbl};")
+
+    before, after = iceberg.dedupe_table(con, COMMENT)
+    assert (before, after) == (3, 3)
+
+    # Live table restored, clean, and the sibling consumed.
+    assert iceberg.audit_duplicates(con, COMMENT) == []
+    assert con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0] == 3
+    with pytest.raises(duckdb.Error):
+        con.execute(f"SELECT 1 FROM {dedup_tbl} LIMIT 1")


### PR DESCRIPTION
## Problem

`scripts/dedupe_comments_catalog.py --apply` builds a fully deduplicated sibling table and then swaps it into place via `ALTER TABLE ... RENAME`. DuckDB's Iceberg REST-catalog integration **does not implement rename** — so against the R2 Data Catalog the swap fails with:

```
_duckdb.NotImplementedException: Not implemented Error: Alter Schema Entry
```

The build (the expensive part) succeeds; only the final swap dies. Because the swap renames the *live* table first, it fails before touching anything, leaving `comments` intact beside a complete `comments_dedup`.

## Fix

`dedupe_table()` now swaps using only operations this catalog supports (and that this module already uses against R2 elsewhere): **`DROP` + `CREATE` + per-agency `INSERT`** from the deduped sibling. No `RENAME` (unsupported) and no `DELETE` (its R2 unreliability is what created the duplicates in the first place).

- **Safe & resumable**: the sibling holds every row throughout and is dropped only after the rebuilt table's row count is verified. If a run dies mid-swap (live table dropped, sibling intact), a re-run detects that and rebuilds from the sibling instead of rebuilding the sibling from a table that no longer exists.
- **Configurable memory**: `DEDUP_MEMORY_LIMIT` / `DEDUP_THREADS` env knobs (default `5GB`/`2` for CI). The per-agency window sort buffers whole rows including comment text, so 5GB is tight for the largest agency; a bigger host can raise it.
- **Docstrings** in both files updated to describe the DROP/INSERT swap.

## Testing

- `test_dedupe_table_resumes_interrupted_swap` added for the resume path; existing `test_audit_and_dedupe_table` covers the happy path. **17 tests pass**, ruff clean.
- Validated by equivalence to a one-off finish script that completed the swap against the **live catalog**: `comments` went 36,724,336 → 25,212,690 rows (**11,511,646 duplicate rows removed**, all 178 agencies covered, `rows == distinct comment_id`), then the public mirror was republished.

> Note: the committed `dedupe_table()` path itself has not been re-run end-to-end against the live catalog (the dedup is already complete and doesn't need re-running); it is validated by unit tests and by equivalence to the finish script that did run against R2.