### PR TITLE
Shrink per-agency comment mirror row groups (500k → 20k) for per-docket reads

### DIFF
--- a/src/spicy_regs/transforms/partition_comments.py
+++ b/src/spicy_regs/transforms/partition_comments.py
@@ -113,11 +113,24 @@ def partition_comments(output_dir: Path) -> Path:
             con.execute("SET preserve_insertion_order=false")
             con.execute("SET threads=2")
             con.execute(f"SET temp_directory='{spill_dir}'")
+            # ROW_GROUP_SIZE is small on purpose. These per-agency files are the
+            # browser UI's read surface for *scoped* queries — it reads one
+            # docket's comments at a time (WHERE docket_id = ?) over HTTP range
+            # requests. Since rows are sorted by docket_id, a docket lands in a
+            # contiguous span of row groups, and the row group is the granularity
+            # at which DuckDB(-WASM) fetches column chunks. A large row group
+            # (e.g. 500k) forced a per-docket read to pull the whole group's
+            # comment/text_content chunks — seconds over the network even for a
+            # handful of matching rows. 20k rows/group prunes far tighter (a
+            # small docket reads ~one group) at negligible file-size cost
+            # (measured <1% larger, since zstd + the column data dominate). Full
+            # scans (the monolith comments.parquet) are unaffected — that file is
+            # exported separately.
             con.execute(f"""
             COPY (
                 SELECT {select_cols} FROM read_parquet('{part_path}', hive_partitioning=false)
                 ORDER BY docket_id, posted_date
-            ) TO '{tmp_path}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 500000);
+            ) TO '{tmp_path}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 20000);
             """)
         finally:
             con.close()


### PR DESCRIPTION
## Why

Follow-up to the UI data-layer alignment ([spicy-regs-ui#6](https://github.com/ekim1394/spicy-regs-ui/pull/6)). Goal: let the browser UI show comment submitter fields (`first_name`/`last_name`/`organization`/`category`) and `text_content` on its **paginated** comment feed, efficiently.

### What I found (the original plan changed)

The plan was "add the columns to the deep per-docket-month partition layout." Investigating the pipeline showed that layout is **no longer written**: production ETL runs `--use-iceberg` (`etl-new-pipeline.yml`), so comments are upserted into the R2 Data Catalog and the public read surface is republished by `publish_comments_mirror.py` as:

- `comments.parquet` — flat monolith (full scans)
- `comments/agency/agency_code={A}/part-0.parquet` — **per-agency mirror** (scoped/per-docket reads)

The deep `comments/agency_code=/docket_id=/year=/month=/` files on R2 are stale relics from the pre-Iceberg pipeline. The per-agency mirror is the canonical, fresh surface and **already carries the full 16-column schema** — so no schema change is needed. The blocker is purely read *cost*.

## The change

The per-agency mirror is sorted by `docket_id`, so a docket's rows are contiguous — but the **row group** is the granularity at which DuckDB(-WASM) fetches column chunks over HTTP. At `ROW_GROUP_SIZE 500000`, a per-docket read pulled the whole group's `comment`/`text_content` chunks even to return a few rows.

This drops `ROW_GROUP_SIZE` to `20000` in `partition_comments.py` (per-agency files only; the monolith is exported separately and unaffected).

### Measured (EOIR, ~202K comments, local)

| Row-group size | File size | Groups | Per-docket page read |
|---|---|---|---|
| 500,000 (before) | 19.8 MB | 1 | 0.061s |
| 20,000 (after) | 19.9 MB | 5 | 0.014s |

File size is **<1% larger**; pruning is much tighter. The network win is larger than the local numbers show, since the UI fetches only the matched group's column chunks instead of a 500K-row group's (a 1-row FWS docket measured ~2.5s against the current 500K-row groups).

## Scope / follow-up

- No schema change, no new files, no change to full-scan consumers or the Iceberg path.
- The matching **UI change** (point the paginated comment feed at the per-agency mirror instead of the abandoned deep layout — which also fixes latent staleness) is a separate PR in `spicy-regs-ui`.

## Verification

- `partition_comments` unit tests: 12 passed
- `ruff check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)