### PR TITLE
Durable catalog-write path for comment text_content backfill

### DIFF
--- a/src/spicy_regs/backfill_derived_text.py
+++ b/src/spicy_regs/backfill_derived_text.py
@@ -3,21 +3,33 @@
 The ETL fills ``text_content`` inline for *new* comments
 (:class:`~spicy_regs.transforms.enrich_derived_text.EnrichCommentText`), but
 every comment published before that wiring still has ``text_content`` NULL. This
-is the one-time / re-runnable backfill: it reads the already-published comment
-Parquet, fills ``text_content`` from the bucket's ``derived-data`` prefix (no PDF
-download, no JSON re-ingest), and writes it back.
-
-It is the derived-data sibling of :mod:`spicy_regs.enrich_pdf`: same
-in-place, incremental, partition-aware shape, but the text source is
-Mirrulations' pre-extracted ``.txt`` rather than a downloaded PDF. Rows are
+is the one-time / re-runnable backfill: it fills ``text_content`` from the
+bucket's ``derived-data`` prefix (no PDF download, no JSON re-ingest). Rows are
 skipped unless they have an attachment and no ``text_extraction_status`` yet, so
 repeated runs only do new work.
 
-A wrinkle the PDF path doesn't have: the Hive comment partitions drop the
-``agency_code`` column (it is encoded in the ``agency_code=<X>`` directory name),
-but the derived-data S3 path is keyed by agency. So the partition walker reads
-the agency from the directory and passes it in explicitly; the monolithic
-``comments.parquet`` still carries the column and is read per row.
+There are two write targets, because comments now live in two places:
+
+* **Catalog (``--use-iceberg``)** — the R2 Data Catalog (Iceberg) is the
+  system of record. Under the Iceberg pipeline the public mirror is regenerated
+  daily from the catalog (see :func:`spicy_regs.sources.iceberg.export_public_comments`),
+  so a mirror-only backfill is transient — the next ``publish-comments-mirror``
+  run overwrites it. This path upserts the filled rows straight into the catalog
+  (one agency at a time, the DELETE+INSERT idiom of ``iceberg._merge``), so the
+  fill survives. Run ``publish-comments-mirror`` afterwards to surface it.
+* **Published Parquet (default)** — the pre-Iceberg, in-place path: it reads the
+  already-published comment Parquet (monolith or the ``agency_code=<X>``
+  partition tree) and writes it back. Kept for the legacy layout / local use.
+  NB: under the live Iceberg pipeline this is *not durable* — prefer
+  ``--use-iceberg``.
+
+It is the derived-data sibling of :mod:`spicy_regs.enrich_pdf`: same incremental,
+attachment-only shape, but the text source is Mirrulations' pre-extracted
+``.txt`` rather than a downloaded PDF. A wrinkle the PDF path doesn't have: the
+Hive comment partitions drop the ``agency_code`` column (it is encoded in the
+``agency_code=<X>`` directory name), but the derived-data S3 path is keyed by
+agency — so the partition walker (and the catalog path) supply the agency
+explicitly; the monolithic ``comments.parquet`` still carries the column per row.
 """
 
 from __future__ import annotations
@@ -32,6 +44,7 @@ from typing import Any
 import polars as pl
 from loguru import logger
 
+from spicy_regs.schemas import RecordType
 from spicy_regs.sources import mirrulations
 from spicy_regs.sources.derived_text import DerivedCommentText
 from spicy_regs.transforms.pdf_text import PdfTextStatus
@@ -41,16 +54,25 @@ ResourceFactory = Callable[[], Any]
 _AGENCY_DIR_RE = re.compile(r"agency_code=([^/]+)")
 
 
-def enrich_comments_with_derived_text(
+_UPDATES_SCHEMA = {"comment_id": pl.Utf8, "_new_text": pl.Utf8, "_new_status": pl.Utf8}
+
+
+def _derived_text_updates(
     df: pl.DataFrame,
     *,
-    agency: str | None = None,
-    resource_factory: ResourceFactory = mirrulations.s3_resource,
-    limit: int | None = None,
-    max_workers: int = 8,
-    overwrite: bool = False,
+    agency: str | None,
+    resource_factory: ResourceFactory,
+    limit: int | None,
+    max_workers: int,
+    overwrite: bool,
 ) -> tuple[pl.DataFrame, dict[str, int]]:
-    """Fill ``text_content`` / ``text_extraction_status`` from derived-data S3.
+    """Fetch derived-data text for a frame's candidate comments.
+
+    Returns ``(updates, stats)`` where ``updates`` is a
+    ``(comment_id, _new_text, _new_status)`` frame of the rows that were filled
+    (empty when nothing was found). This is the shared core of both write paths:
+    the published-Parquet path (:func:`enrich_comments_with_derived_text`) joins
+    it back onto the whole frame; the catalog path upserts exactly these rows.
 
     Only attachment-bearing comments are candidates; unless ``overwrite`` is set,
     rows that already have a ``text_extraction_status`` are skipped so repeated
@@ -59,10 +81,6 @@ def enrich_comments_with_derived_text(
     frame. Work is grouped by docket and fanned out across ``max_workers`` so
     each docket's extraction prefix is listed once.
     """
-    for col in ("text_content", "text_extraction_status"):
-        if col not in df.columns:
-            df = df.with_columns(pl.lit(None, dtype=pl.Utf8).alias(col))
-
     select_cols = ["comment_id", "docket_id", "attachments_json", "text_extraction_status"]
     if agency is None:
         select_cols.append("agency_code")
@@ -88,9 +106,10 @@ def enrich_comments_with_derived_text(
         selected += 1
 
     stats = {"selected": selected, "ok": 0, "missing": 0}
+    empty = pl.DataFrame(schema=_UPDATES_SCHEMA)
     if not work_by_docket:
         logger.info("No comments to backfill from derived-data")
-        return df, stats
+        return empty, stats
 
     logger.info(
         "Backfilling {} comments across {} dockets from derived-data ({} workers)...",
@@ -122,12 +141,46 @@ def enrich_comments_with_derived_text(
 
     if not ids:
         logger.info("Backfill: 0 ok, {} missing (no derived-data text found)", stats["missing"])
-        return df, stats
+        return empty, stats
 
     updates = pl.DataFrame(
         {"comment_id": ids, "_new_text": texts, "_new_status": [PdfTextStatus.OK.value] * len(ids)},
-        schema={"comment_id": pl.Utf8, "_new_text": pl.Utf8, "_new_status": pl.Utf8},
+        schema=_UPDATES_SCHEMA,
     )
+    logger.info("Backfill: {} ok, {} missing", stats["ok"], stats["missing"])
+    return updates, stats
+
+
+def enrich_comments_with_derived_text(
+    df: pl.DataFrame,
+    *,
+    agency: str | None = None,
+    resource_factory: ResourceFactory = mirrulations.s3_resource,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> tuple[pl.DataFrame, dict[str, int]]:
+    """Fill ``text_content`` / ``text_extraction_status`` on a comments frame.
+
+    The published-Parquet path: fetch derived text for the frame's candidates
+    (:func:`_derived_text_updates`) and join it back onto the whole frame,
+    returning the enriched frame and stats.
+    """
+    for col in ("text_content", "text_extraction_status"):
+        if col not in df.columns:
+            df = df.with_columns(pl.lit(None, dtype=pl.Utf8).alias(col))
+
+    updates, stats = _derived_text_updates(
+        df,
+        agency=agency,
+        resource_factory=resource_factory,
+        limit=limit,
+        max_workers=max_workers,
+        overwrite=overwrite,
+    )
+    if updates.is_empty():
+        return df, stats
+
     enriched = (
         df.join(updates, on="comment_id", how="left")
         .with_columns(
@@ -136,8 +189,6 @@ def enrich_comments_with_derived_text(
         )
         .drop("_new_text", "_new_status")
     )
-
-    logger.info("Backfill: {} ok, {} missing", stats["ok"], stats["missing"])
     return enriched, stats
 
 
@@ -234,6 +285,149 @@ def backfill_comment_partitions(
     return totals, changed
 
 
+def _backfill_agency_in_catalog(
+    con,
+    record_type: RecordType,
+    agency: str,
+    *,
+    resource_factory: ResourceFactory = mirrulations.s3_resource,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> dict[str, int]:
+    """Fill + upsert one agency's attachment comments in the attached catalog.
+
+    Selects the agency's candidate rows (attachment-bearing, no
+    ``text_extraction_status`` unless ``overwrite``) from the catalog table,
+    fetches derived text, and upserts the filled rows back with the same
+    per-agency DELETE+INSERT idiom as :func:`spicy_regs.sources.iceberg._merge`
+    (Iceberg has no ``MERGE INTO`` in DuckDB). Scoping every statement to one
+    agency keeps it off the whole tens-of-millions-row table. ``con`` is the
+    catalog connection (injected so this is testable against a local DuckDB
+    attached under the ``reg_catalog`` alias). Returns fill stats.
+    """
+    from spicy_regs.sources import iceberg
+
+    tbl = iceberg._qualified(record_type)
+    ag = iceberg._sql_str(agency)
+    status_filter = "" if overwrite else "AND (text_extraction_status IS NULL OR text_extraction_status = '')"
+    limit_sql = f" LIMIT {int(limit)}" if limit is not None else ""
+    candidates = con.execute(
+        f"""
+        SELECT comment_id, docket_id, agency_code, attachments_json, text_extraction_status
+        FROM {tbl}
+        WHERE agency_code = '{ag}'
+          AND attachments_json IS NOT NULL AND TRIM(attachments_json) NOT IN ('', '[]')
+          {status_filter}
+        {limit_sql}
+        """
+    ).pl()
+    if candidates.is_empty():
+        return {"selected": 0, "ok": 0, "missing": 0}
+
+    updates, stats = _derived_text_updates(
+        candidates,
+        agency=agency,
+        resource_factory=resource_factory,
+        limit=limit,
+        max_workers=max_workers,
+        overwrite=overwrite,
+    )
+    if updates.is_empty():
+        return stats
+
+    cols = list(record_type.schema)
+    other_sel = ", ".join(f't."{c}"' for c in cols if c not in ("text_content", "text_extraction_status"))
+    col_list = ", ".join(f'"{c}"' for c in cols)
+
+    # Rebuild the full winning rows (catalog row + overridden text columns), then
+    # replace exactly those keys within this agency. Registering the small updates
+    # frame as Arrow avoids inlining thousands of literals.
+    con.register("_bf_updates_src", updates.to_arrow())
+    try:
+        con.execute("CREATE OR REPLACE TEMP TABLE _bf_updates AS SELECT * FROM _bf_updates_src;")
+    finally:
+        con.unregister("_bf_updates_src")
+    con.execute(
+        f"""
+        CREATE OR REPLACE TEMP TABLE _bf_winners AS
+        SELECT {other_sel},
+               u._new_text AS text_content,
+               u._new_status AS text_extraction_status
+        FROM {tbl} t JOIN _bf_updates u ON t.comment_id = u.comment_id
+        WHERE t.agency_code = '{ag}';
+        """
+    )
+    con.execute(f"DELETE FROM {tbl} WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _bf_winners);")
+    con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM _bf_winners;")
+    con.execute("DROP TABLE IF EXISTS _bf_updates;")
+    con.execute("DROP TABLE IF EXISTS _bf_winners;")
+
+    logger.info("catalog[{}]: upserted {} filled row(s) ({} missing)", agency, stats["ok"], stats["missing"])
+    return stats
+
+
+def backfill_comments_catalog(
+    record_type: RecordType,
+    *,
+    agencies: list[str] | None = None,
+    resource_factory: ResourceFactory = mirrulations.s3_resource,
+    limit: int | None = None,
+    max_workers: int = 8,
+    overwrite: bool = False,
+) -> dict[str, int]:
+    """Backfill ``text_content`` directly in the R2 Data Catalog (durable path).
+
+    Iterates agencies (all in the table, or the given subset) and upserts each
+    one's filled rows via :func:`_backfill_agency_in_catalog`, honoring a global
+    ``limit`` budget. Writing the catalog — the system of record — means the fill
+    survives the daily ``publish-comments-mirror`` regeneration (a mirror-only
+    backfill does not). Run ``publish-comments-mirror`` afterwards to surface it
+    in the public read files. Returns aggregate stats.
+    """
+    from spicy_regs.sources import iceberg
+
+    con = iceberg._connect()
+    try:
+        iceberg._ensure_table(con, record_type)
+        tbl = iceberg._qualified(record_type)
+        if agencies:
+            agency_list = [a.strip().upper() for a in agencies if a.strip()]
+        else:
+            agency_list = [
+                r[0]
+                for r in con.execute(
+                    f"SELECT DISTINCT agency_code FROM {tbl} WHERE agency_code IS NOT NULL ORDER BY 1"
+                ).fetchall()
+            ]
+
+        totals = {"selected": 0, "ok": 0, "missing": 0}
+        remaining = limit
+        for agency in agency_list:
+            if remaining is not None and remaining <= 0:
+                logger.info("Reached --limit budget; {} agency bucket(s) left unprocessed", len(agency_list))
+                break
+            stats = _backfill_agency_in_catalog(
+                con,
+                record_type,
+                agency,
+                resource_factory=resource_factory,
+                limit=remaining,
+                max_workers=max_workers,
+                overwrite=overwrite,
+            )
+            for key, value in stats.items():
+                totals[key] += value
+            if remaining is not None:
+                remaining -= stats["selected"]
+
+        logger.info("Catalog backfill totals: {} across {} agency bucket(s)", totals, len(agency_list))
+        logger.info("Next: run publish-comments-mirror so the filled text reaches the public read mirror.")
+        return totals
+    finally:
+        con.close()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Backfill comment text_content from Mirrulations derived-data extracted text."
@@ -243,9 +437,38 @@ def main() -> None:
     parser.add_argument("--max-workers", type=int, default=8)
     parser.add_argument("--overwrite", action="store_true", help="Re-fill rows that already have a status")
     parser.add_argument(
-        "--upload", action="store_true", help="Upload changed comment partitions + index to R2 (needs credentials)"
+        "--use-iceberg",
+        action="store_true",
+        help="Backfill directly in the R2 Data Catalog (durable; survives the mirror republish). "
+        "Needs R2_CATALOG_* credentials. Run publish-comments-mirror afterwards.",
+    )
+    parser.add_argument(
+        "--agency",
+        default=None,
+        help="Comma-separated agency codes to limit the --use-iceberg backfill (default: all)",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Published-Parquet path only: upload changed partitions + index to R2 (needs credentials)",
     )
     args = parser.parse_args()
+
+    # Durable path: write the catalog (the system of record the mirror is
+    # regenerated from). The published-Parquet paths below are not durable under
+    # the live Iceberg pipeline — the next publish-comments-mirror overwrites them.
+    if args.use_iceberg:
+        from spicy_regs.schemas.regulations import RECORD_TYPES
+
+        agencies = [a for a in args.agency.split(",")] if args.agency else None
+        backfill_comments_catalog(
+            RECORD_TYPES["comments"],
+            agencies=agencies,
+            limit=args.limit,
+            max_workers=args.max_workers,
+            overwrite=args.overwrite,
+        )
+        return
 
     # Prefer the Hive-partitioned layout, fall back to the monolithic file.
     partition_dir = args.output_dir / "comments" / "agency"

--- a/tests/test_backfill_derived_text.py
+++ b/tests/test_backfill_derived_text.py
@@ -168,7 +168,8 @@ def test_catalog_backfill_upserts_filled_rows_in_place() -> None:
         ).fetchall()
         assert len(row) == 1
         assert row[0] == ("orig body", "ok")
-        assert con.execute(f"SELECT count(*) FROM {iceberg._qualified(COMMENT)}").fetchone()[0] == 3
+        count = con.execute(f"SELECT count(*) FROM {iceberg._qualified(COMMENT)}").fetchone()
+        assert count is not None and count[0] == 3
 
         # Idempotent: a second run finds nothing new (the filled row now has a status).
         again = _backfill_agency_in_catalog(con, COMMENT, "ACF", resource_factory=_factory())

--- a/tests/test_backfill_derived_text.py
+++ b/tests/test_backfill_derived_text.py
@@ -9,12 +9,16 @@ from __future__ import annotations
 
 import json
 
+import duckdb
 import polars as pl
 
 from spicy_regs.backfill_derived_text import (
+    _backfill_agency_in_catalog,
     backfill_comment_partitions,
     enrich_comments_with_derived_text,
 )
+from spicy_regs.schemas import COMMENT
+from spicy_regs.sources import iceberg
 from tests.conftest import COMMENT_SCHEMA
 
 # Reuse the fake S3 surface from the derived-text unit tests.
@@ -110,3 +114,64 @@ def test_backfill_partitions_reads_agency_from_path(tmp_path) -> None:
     written = pl.read_parquet(part_dir / "part-0.parquet")
     assert "agency_code" not in written.columns  # schema preserved
     assert written.row(0, named=True)["text_content"] == "Wisconsin DCF comment body"
+
+
+def _seed_catalog(con, rows: list[dict]) -> None:
+    """Insert comment rows into the local catalog table (all COMMENT columns)."""
+    iceberg._ensure_table(con, COMMENT)
+    frame = pl.DataFrame(
+        [{**{c: None for c in COMMENT.schema}, **r} for r in rows], schema=COMMENT.schema
+    )
+    col_list = ", ".join(f'"{c}"' for c in COMMENT.schema)
+    con.register("_seed_src", frame.to_arrow())
+    con.execute(f"INSERT INTO {iceberg._qualified(COMMENT)} ({col_list}) SELECT {col_list} FROM _seed_src;")
+    con.unregister("_seed_src")
+
+
+def test_catalog_backfill_upserts_filled_rows_in_place() -> None:
+    # Local DuckDB standing in for the attached R2 catalog (same alias the
+    # connector uses), so the DELETE+INSERT upsert is exercised without network.
+    con = duckdb.connect()
+    con.execute(f"ATTACH ':memory:' AS {iceberg._CATALOG_ALIAS};")
+    try:
+        _seed_catalog(
+            con,
+            [
+                # found in the fake derived-data store → gets filled
+                {"comment_id": "ACF-2025-0038-0004", "docket_id": "ACF-2025-0038", "agency_code": "ACF",
+                 "attachments_json": _attach(), "modify_date": "2025-01-01", "comment": "orig body"},
+                # attachment but no derived text → counts as missing, stays NULL
+                {"comment_id": "ACF-2025-0038-9999", "docket_id": "ACF-2025-0038", "agency_code": "ACF",
+                 "attachments_json": _attach(), "modify_date": "2025-01-01"},
+                # no attachment → not a candidate at all
+                {"comment_id": "ACF-2025-0038-0007", "docket_id": "ACF-2025-0038", "agency_code": "ACF",
+                 "attachments_json": None, "modify_date": "2025-01-01"},
+            ],
+        )
+
+        stats = _backfill_agency_in_catalog(con, COMMENT, "ACF", resource_factory=_factory())
+        assert stats == {"selected": 2, "ok": 1, "missing": 1}
+
+        out = dict(
+            con.execute(
+                f"SELECT comment_id, text_content FROM {iceberg._qualified(COMMENT)} ORDER BY comment_id"
+            ).fetchall()
+        )
+        assert out["ACF-2025-0038-0004"] == "Wisconsin DCF comment body"
+        assert out["ACF-2025-0038-9999"] is None  # missing left NULL for the PDF fallback
+        assert out["ACF-2025-0038-0007"] is None  # non-candidate untouched
+
+        # Upsert preserves other columns and doesn't duplicate the row.
+        row = con.execute(
+            f"SELECT comment, text_extraction_status FROM {iceberg._qualified(COMMENT)} "
+            f"WHERE comment_id = 'ACF-2025-0038-0004'"
+        ).fetchall()
+        assert len(row) == 1
+        assert row[0] == ("orig body", "ok")
+        assert con.execute(f"SELECT count(*) FROM {iceberg._qualified(COMMENT)}").fetchone()[0] == 3
+
+        # Idempotent: a second run finds nothing new (the filled row now has a status).
+        again = _backfill_agency_in_catalog(con, COMMENT, "ACF", resource_factory=_factory())
+        assert again == {"selected": 1, "ok": 0, "missing": 1}
+    finally:
+        con.close()


### PR DESCRIPTION
## Why

`backfill-comment-text` fills comment `text_content` from Mirrulations' pre-extracted derived text. It wrote the **published Parquet mirror** in place — which was correct pre-Iceberg, when the mirror *was* the system of record.

Under the current `--use-iceberg` pipeline it no longer is: the mirror is regenerated **daily from the R2 Data Catalog** (`publish-comments-mirror` → `iceberg.export_public_comments`, a full `COPY (SELECT * FROM catalog) …`). So a mirror-only backfill is **overwritten within ~24h**, reverting `text_content` to NULL. It's the same "tool written for the pre-Iceberg layout" drift as the abandoned deep partition tree.

## What this adds

A `--use-iceberg` path (plus optional `--agency`) that writes the **catalog** — the system of record — so the fill survives the mirror republish:

- Selects each agency's attachment-bearing comments with no `text_extraction_status` (or all, with `--overwrite`).
- Fetches derived text via the existing logic, refactored into a shared `_derived_text_updates` helper (the published-Parquet path uses it too — behavior unchanged).
- Upserts the filled rows with the **same per-agency DELETE+INSERT idiom as `iceberg._merge`** (DuckDB's Iceberg engine has no `MERGE INTO`). One agency per statement keeps it off the whole tens-of-millions-row table, matching `merge`/`dedupe`/`seed`.

Then run `publish-comments-mirror` to surface it in the public files. The published-Parquet path is untouched (kept for the legacy layout / local use) but now documented as non-durable under Iceberg.

Usage:
```
uv run backfill-comment-text --use-iceberg [--agency EPA,DOL] [--limit N]
# then: publish-comments-mirror
```

## Scope

Attachments are rare (~**0.4%** of comments), so a full run touches only **tens of thousands** of rows, ~**83%** of which have derived text available (measured via a dry-run on NARA/EOIR). Cheap and incremental (re-runs skip filled rows).

## Verification

- Refactor preserves the existing published-Parquet behavior — the 6 prior backfill tests pass unchanged.
- New test drives the catalog upsert end-to-end against a local DuckDB attached under the `reg_catalog` alias (the same fixture style as `test_iceberg`): fills found rows, leaves missing NULL for the PDF fallback, preserves other columns, no row duplication, idempotent on re-run.
- `test_backfill_derived_text.py` + `test_iceberg.py` + `test_derived_text.py`: **38 passed**. `ruff check`: clean.

Note: the full unit suite has 4 pre-existing failures + a hang in `test_load.py` (shrink guard) and `test_regulations_pipeline.py` — unrelated to this change (they reproduce on clean `main` with this diff stashed; nothing outside `backfill_derived_text` imports it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)