### PR TITLE
Raise MCP query timeout from 30s to ~5 minutes

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -139,9 +139,12 @@ Then point a client at `http://localhost:8000/mcp`.
 
 ## Limitations
 
-- Vercel serverless functions cap at 60s. The first query in a cold container
-  pays a few seconds to install the DuckDB `httpfs` extension and fetch parquet
-  metadata; subsequent queries within the same container are fast.
+- Vercel functions here cap at 300s (`maxDuration` in `vercel.json`, the Pro
+  plan ceiling). A DuckDB statement-timeout watchdog trips at `290s` (override
+  with `SPICY_REGS_STATEMENT_TIMEOUT`) so runaway queries return a clean
+  `TimeoutError` just before the platform kill. The first query in a cold
+  container pays a few seconds to install the DuckDB `httpfs` extension and
+  fetch parquet metadata; subsequent queries within the same container are fast.
 - The `find_duplicate_regulations.py` helper isn't exposed over MCP — its
   pairwise scan can exceed the function timeout. For that workload, use the
   local script via `uv run --script` (see the skill's SKILL.md).

--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -47,7 +47,10 @@ TABLES = (
     "agency_stats",
     "agency_monthly_volume",
 )
-STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "30s")
+# Kept just under the Vercel ``maxDuration`` (300s) so a runaway query trips
+# this watchdog and returns a clean ``TimeoutError`` before the platform hard
+# kills the function. Override with ``SPICY_REGS_STATEMENT_TIMEOUT``.
+STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "290s")
 
 logger = logging.getLogger(__name__)
 

--- a/mcp-server/vercel.json
+++ b/mcp-server/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
     "api/index.py": {
-      "maxDuration": 60
+      "maxDuration": 300
     }
   },
   "rewrites": [

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -47,7 +47,9 @@ TABLES = (
     "agency_stats",
     "agency_monthly_volume",
 )
-STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "30s")
+# Matches the Vercel copy's default (kept just under that deploy's 300s
+# ``maxDuration``). Override with ``SPICY_REGS_STATEMENT_TIMEOUT``.
+STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "290s")
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Increases the query timeout for the Spicy Regs MCP server from 30s to ~5 minutes.

The `30s` limit was the DuckDB statement-timeout watchdog default, but the actual ceiling was Vercel's `maxDuration` of **60s** — so raising the watchdog alone would have had no effect. This PR raises both:

- `mcp-server/vercel.json`: `maxDuration` `60` → `300` (the Vercel Pro plan ceiling, = 5 min).
- `mcp-server/api/index.py` (Vercel copy) and `src/spicy_regs/mcp_server.py` (canonical): default `SPICY_REGS_STATEMENT_TIMEOUT` `"30s"` → `"290s"`. Kept just under `maxDuration` so a runaway query trips the watchdog and returns a clean `TimeoutError` before the platform hard-kills the function.
- `mcp-server/README.md`: updated the limitation note (was "cap at 60s").

Still fully overridable at runtime via the `SPICY_REGS_STATEMENT_TIMEOUT` env var. Requires the deployment to be on Vercel Pro or higher (confirmed).

## Test plan

- [x] `uv run pytest tests/test_mcp_server.py` — 23 passed (includes the Vercel-copy-in-sync check)
- [x] `uv run ruff check` on the changed files — all checks passed
- [x] Manually verified `vercel.json` is valid JSON with `maxDuration = 300` and that `"290s"` parses to 290.0 seconds via the existing `_parse_timeout_seconds` logic

## Checklist

- [x] My change is scoped to one concern
- [ ] I added or updated tests for new behavior (existing tests cover the parse logic and copy-sync; the change is a config default)
- [x] I updated docs (README limitation note)
- [ ] CI is green (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsNfyEBQqFFb88MNss7Lzb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsNfyEBQqFFb88MNss7Lzb)_