### PR TITLE
Fix catalog upsert dropping text_extraction_status on R2 Data Catalog

### DIFF
--- a/src/spicy_regs/backfill_derived_text.py
+++ b/src/spicy_regs/backfill_derived_text.py
@@ -337,12 +337,20 @@ def _backfill_agency_in_catalog(
         return stats
 
     cols = list(record_type.schema)
-    other_sel = ", ".join(f't."{c}"' for c in cols if c not in ("text_content", "text_extraction_status"))
     col_list = ", ".join(f'"{c}"' for c in cols)
 
-    # Rebuild the full winning rows (catalog row + overridden text columns), then
-    # replace exactly those keys within this agency. Registering the small updates
-    # frame as Arrow avoids inlining thousands of literals.
+    # Build the replacement rows as a SELF-CONTAINED temp table, then swap them
+    # in — mirroring the proven upsert in iceberg._merge, whose INSERT reads from
+    # a plain temp table and never projects over the live catalog table.
+    #
+    # The earlier version projected the overrides straight off `{tbl} t JOIN
+    # updates` in the INSERT's SELECT; on the R2 Data Catalog that did NOT persist
+    # text_extraction_status (text_content landed, status came back NULL — see the
+    # NARA smoke run), so incremental re-runs kept re-selecting already-filled
+    # rows. Snapshotting the affected rows into an independent temp table and
+    # overriding the two columns in place removes the live-table reference from
+    # the write path and fixes it. (Plain DuckDB doesn't reproduce the catalog
+    # behavior, so this is validated by a scoped catalog run, not the unit test.)
     con.register("_bf_updates_src", updates.to_arrow())
     try:
         con.execute("CREATE OR REPLACE TEMP TABLE _bf_updates AS SELECT * FROM _bf_updates_src;")
@@ -350,18 +358,24 @@ def _backfill_agency_in_catalog(
         con.unregister("_bf_updates_src")
     con.execute(
         f"""
-        CREATE OR REPLACE TEMP TABLE _bf_winners AS
-        SELECT {other_sel},
-               u._new_text AS text_content,
-               u._new_status AS text_extraction_status
-        FROM {tbl} t JOIN _bf_updates u ON t.comment_id = u.comment_id
-        WHERE t.agency_code = '{ag}';
+        CREATE OR REPLACE TEMP TABLE _bf_replacement AS
+        SELECT {col_list} FROM {tbl}
+        WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _bf_updates);
         """
     )
-    con.execute(f"DELETE FROM {tbl} WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _bf_winners);")
-    con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM _bf_winners;")
+    con.execute(
+        """
+        UPDATE _bf_replacement AS r
+        SET text_content = u._new_text,
+            text_extraction_status = u._new_status
+        FROM _bf_updates u
+        WHERE r.comment_id = u.comment_id;
+        """
+    )
+    con.execute(f"DELETE FROM {tbl} WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _bf_replacement);")
+    con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM _bf_replacement;")
     con.execute("DROP TABLE IF EXISTS _bf_updates;")
-    con.execute("DROP TABLE IF EXISTS _bf_winners;")
+    con.execute("DROP TABLE IF EXISTS _bf_replacement;")
 
     logger.info("catalog[{}]: upserted {} filled row(s) ({} missing)", agency, stats["ok"], stats["missing"])
     return stats

--- a/src/spicy_regs/enrich_pdf.py
+++ b/src/spicy_regs/enrich_pdf.py
@@ -431,11 +431,15 @@ def _enrich_comment_agency_in_catalog(
         return stats
 
     cols = list(record_type.schema)
-    other_sel = ", ".join(f't."{c}"' for c in cols if c not in ("text_content", "text_extraction_status"))
     col_list = ", ".join(f'"{c}"' for c in cols)
 
-    # COALESCE so a non-ok result (text=None) records its status without nulling
-    # any pre-existing text_content. Then replace exactly these keys, per agency.
+    # Build the replacement rows as a SELF-CONTAINED temp table, then swap them in
+    # — mirroring the proven upsert in iceberg._merge (the INSERT reads a plain
+    # temp table, never a projection over the live catalog table). Projecting the
+    # overrides straight off `{tbl} t JOIN updates` did not persist
+    # text_extraction_status on the R2 Data Catalog (see the NARA smoke run), so
+    # we snapshot the affected rows and override the two columns in place.
+    # COALESCE keeps a pre-existing text_content when a non-ok result has no text.
     con.register("_pdf_updates_src", updates.to_arrow())
     try:
         con.execute("CREATE OR REPLACE TEMP TABLE _pdf_updates AS SELECT * FROM _pdf_updates_src;")
@@ -443,18 +447,24 @@ def _enrich_comment_agency_in_catalog(
         con.unregister("_pdf_updates_src")
     con.execute(
         f"""
-        CREATE OR REPLACE TEMP TABLE _pdf_winners AS
-        SELECT {other_sel},
-               COALESCE(u._new_text, t.text_content) AS text_content,
-               COALESCE(u._new_status, t.text_extraction_status) AS text_extraction_status
-        FROM {tbl} t JOIN _pdf_updates u ON t.comment_id = u.comment_id
-        WHERE t.agency_code = '{ag}';
+        CREATE OR REPLACE TEMP TABLE _pdf_replacement AS
+        SELECT {col_list} FROM {tbl}
+        WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _pdf_updates);
         """
     )
-    con.execute(f"DELETE FROM {tbl} WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _pdf_winners);")
-    con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM _pdf_winners;")
+    con.execute(
+        """
+        UPDATE _pdf_replacement AS r
+        SET text_content = COALESCE(u._new_text, r.text_content),
+            text_extraction_status = COALESCE(u._new_status, r.text_extraction_status)
+        FROM _pdf_updates u
+        WHERE r.comment_id = u.comment_id;
+        """
+    )
+    con.execute(f"DELETE FROM {tbl} WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _pdf_replacement);")
+    con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM _pdf_replacement;")
     con.execute("DROP TABLE IF EXISTS _pdf_updates;")
-    con.execute("DROP TABLE IF EXISTS _pdf_winners;")
+    con.execute("DROP TABLE IF EXISTS _pdf_replacement;")
 
     logger.info(
         "catalog[{}]: PDF-enriched {} row(s) (ok={}, empty={}, encrypted={}, error={})",


### PR DESCRIPTION
## What the NARA smoke run (workflow #116) caught

Running the backfill workflow catalog-only on NARA surfaced a data bug:

- **25 attachment rows: valid `text_content`, but status `error`**
- **5 rows: no text, status `NULL`** (untouched)

The logs show the derived step reported `25 ok`, yet the PDF step then `selected 25, error 25`. Since the 5 genuinely-missing rows were left alone while the PDF step re-processed the **25 the derived step had just filled**, the derived step's `text_extraction_status='ok'` **did not persist** on the catalog — so the incremental filter (`status IS NULL OR ''`) kept treating them as candidates. The PDF step then re-downloaded them (failed in CI → `error`), with `COALESCE` preserving the correct text.

## Root cause

Both catalog upserts (#113 derived, #115 PDF) built the `INSERT`'s source by projecting the overridden columns straight off `{tbl} t JOIN updates` — the `INSERT ... SELECT` **referenced the live catalog table being mutated**. The proven `iceberg._merge` (which writes this same table in the daily ETL) never does that: it inserts from a **self-contained temp table** sourced independently of the live table. Plain in-memory DuckDB (the unit tests) doesn't reproduce the divergence; only the Iceberg REST catalog does — which is exactly why the smoke test, not the tests, caught it.

## Fix

In both `backfill_derived_text` and `enrich_pdf`: snapshot the affected rows into an independent temp table, override `text_content` / `text_extraction_status` in place with a plain `UPDATE`, then `DELETE` + `INSERT` from that temp table. No live-table reference remains in the write path, matching `iceberg._merge`. (PDF keeps the `COALESCE` so a non-ok result records its status without nulling any existing text.)

## Validation plan (the important part)

Local `ruff` + `ty` + **19 tests** pass, but they can't prove the catalog fix (plain DuckDB doesn't exhibit the bug). The real check is a scoped catalog run **on this branch before merge**:

```
gh workflow run backfill-comment-attachment-text.yml \
  --ref claude/fix-catalog-upsert-status-persist \
  -f agency=NARA -f overwrite=true -f publish_mirror=false
```

Then confirm the 25 NARA rows come back `status='ok'` (this also corrects the rows the smoke run left as `error`). Do **not** run `full_load` until this is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)