### PR TITLE
Hoist shared catalog comment-text upsert into iceberg.py

### DIFF
--- a/src/spicy_regs/backfill_derived_text.py
+++ b/src/spicy_regs/backfill_derived_text.py
@@ -336,46 +336,13 @@ def _backfill_agency_in_catalog(
     if updates.is_empty():
         return stats
 
-    cols = list(record_type.schema)
-    col_list = ", ".join(f'"{c}"' for c in cols)
-
-    # Build the replacement rows as a SELF-CONTAINED temp table, then swap them
-    # in — mirroring the proven upsert in iceberg._merge, whose INSERT reads from
-    # a plain temp table and never projects over the live catalog table.
-    #
-    # The earlier version projected the overrides straight off `{tbl} t JOIN
-    # updates` in the INSERT's SELECT; on the R2 Data Catalog that did NOT persist
-    # text_extraction_status (text_content landed, status came back NULL — see the
-    # NARA smoke run), so incremental re-runs kept re-selecting already-filled
-    # rows. Snapshotting the affected rows into an independent temp table and
-    # overriding the two columns in place removes the live-table reference from
-    # the write path and fixes it. (Plain DuckDB doesn't reproduce the catalog
-    # behavior, so this is validated by a scoped catalog run, not the unit test.)
-    con.register("_bf_updates_src", updates.to_arrow())
-    try:
-        con.execute("CREATE OR REPLACE TEMP TABLE _bf_updates AS SELECT * FROM _bf_updates_src;")
-    finally:
-        con.unregister("_bf_updates_src")
-    con.execute(
-        f"""
-        CREATE OR REPLACE TEMP TABLE _bf_replacement AS
-        SELECT {col_list} FROM {tbl}
-        WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _bf_updates);
-        """
-    )
-    con.execute(
-        """
-        UPDATE _bf_replacement AS r
-        SET text_content = u._new_text,
-            text_extraction_status = u._new_status
-        FROM _bf_updates u
-        WHERE r.comment_id = u.comment_id;
-        """
-    )
-    con.execute(f"DELETE FROM {tbl} WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _bf_replacement);")
-    con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM _bf_replacement;")
-    con.execute("DROP TABLE IF EXISTS _bf_updates;")
-    con.execute("DROP TABLE IF EXISTS _bf_replacement;")
+    # Durable per-agency upsert into the catalog. The shared helper builds the
+    # replacement rows in a self-contained temp table before the INSERT — a rule
+    # that matters on the R2 Data Catalog (see iceberg.upsert_comment_text / PR
+    # #117). The derived-text `updates` frame only ever carries non-null
+    # _new_text / _new_status (rows are appended only when text was found), so the
+    # helper's COALESCE is equivalent to a direct assignment here.
+    iceberg.upsert_comment_text(con, record_type, agency, updates)
 
     logger.info("catalog[{}]: upserted {} filled row(s) ({} missing)", agency, stats["ok"], stats["missing"])
     return stats

--- a/src/spicy_regs/enrich_pdf.py
+++ b/src/spicy_regs/enrich_pdf.py
@@ -430,41 +430,12 @@ def _enrich_comment_agency_in_catalog(
     if updates.is_empty():
         return stats
 
-    cols = list(record_type.schema)
-    col_list = ", ".join(f'"{c}"' for c in cols)
-
-    # Build the replacement rows as a SELF-CONTAINED temp table, then swap them in
-    # — mirroring the proven upsert in iceberg._merge (the INSERT reads a plain
-    # temp table, never a projection over the live catalog table). Projecting the
-    # overrides straight off `{tbl} t JOIN updates` did not persist
-    # text_extraction_status on the R2 Data Catalog (see the NARA smoke run), so
-    # we snapshot the affected rows and override the two columns in place.
+    # Durable per-agency upsert into the catalog via the shared helper, which
+    # snapshots the affected rows into a self-contained temp table before the
+    # INSERT — the invariant that keeps text_extraction_status writes from being
+    # dropped on the R2 Data Catalog (see iceberg.upsert_comment_text / PR #117).
     # COALESCE keeps a pre-existing text_content when a non-ok result has no text.
-    con.register("_pdf_updates_src", updates.to_arrow())
-    try:
-        con.execute("CREATE OR REPLACE TEMP TABLE _pdf_updates AS SELECT * FROM _pdf_updates_src;")
-    finally:
-        con.unregister("_pdf_updates_src")
-    con.execute(
-        f"""
-        CREATE OR REPLACE TEMP TABLE _pdf_replacement AS
-        SELECT {col_list} FROM {tbl}
-        WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _pdf_updates);
-        """
-    )
-    con.execute(
-        """
-        UPDATE _pdf_replacement AS r
-        SET text_content = COALESCE(u._new_text, r.text_content),
-            text_extraction_status = COALESCE(u._new_status, r.text_extraction_status)
-        FROM _pdf_updates u
-        WHERE r.comment_id = u.comment_id;
-        """
-    )
-    con.execute(f"DELETE FROM {tbl} WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _pdf_replacement);")
-    con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM _pdf_replacement;")
-    con.execute("DROP TABLE IF EXISTS _pdf_updates;")
-    con.execute("DROP TABLE IF EXISTS _pdf_replacement;")
+    iceberg.upsert_comment_text(con, record_type, agency, updates)
 
     logger.info(
         "catalog[{}]: PDF-enriched {} row(s) (ok={}, empty={}, encrypted={}, error={})",

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -305,6 +305,65 @@ def seed_comments_from_parquet(
     return con.execute(f"SELECT count(*) FROM {_qualified(record_type)}").fetchone()[0]
 
 
+def upsert_comment_text(con, record_type: RecordType, agency: str, updates) -> None:
+    """Upsert filled ``text_content`` / ``text_extraction_status`` for one agency.
+
+    Shared helper for the durable text-fill paths (derived-data backfill and PDF
+    enrichment). ``updates`` is a polars DataFrame with columns
+    ``comment_id, _new_text, _new_status``; every row whose ``comment_id`` matches
+    the agency's rows gets ``text_content`` / ``text_extraction_status`` refreshed
+    (``COALESCE`` keeps the existing value when the incoming column is NULL). The
+    upsert is scoped to a single ``agency_code`` so it never touches the whole
+    tens-of-millions-row table, and is expressed as DELETE+INSERT because DuckDB's
+    Iceberg engine has no ``MERGE INTO`` (see :func:`_merge`). No-ops on an empty
+    frame; the caller is expected to have handled that case already.
+
+    CRITICAL — self-contained temp table: the INSERT reads from an independent
+    ``_uct_replacement`` temp table (a full snapshot of the affected rows with the
+    two columns overridden in place), **never** from a projection over the live
+    catalog table. An earlier version projected the overrides straight off
+    ``{tbl} t JOIN updates`` in the INSERT's SELECT; on the R2 Data Catalog that
+    dropped column writes — ``text_content`` landed but ``text_extraction_status``
+    came back NULL, so incremental re-runs kept re-selecting already-filled rows.
+    Snapshotting into a self-contained temp table removes the live-table reference
+    from the write path and fixes it (see PR #117). Plain DuckDB does not reproduce
+    the catalog behavior, so this invariant is verified by a scoped catalog run,
+    not the unit test — keep the ``_uct_replacement`` indirection intact.
+    """
+    if updates.is_empty():
+        return
+
+    tbl = _qualified(record_type)
+    ag = _sql_str(agency)
+    col_list = ", ".join(f'"{c}"' for c in record_type.schema)
+
+    con.register("_uct_updates_src", updates.to_arrow())
+    try:
+        con.execute("CREATE OR REPLACE TEMP TABLE _uct_updates AS SELECT * FROM _uct_updates_src;")
+    finally:
+        con.unregister("_uct_updates_src")
+    con.execute(
+        f"""
+        CREATE OR REPLACE TEMP TABLE _uct_replacement AS
+        SELECT {col_list} FROM {tbl}
+        WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _uct_updates);
+        """
+    )
+    con.execute(
+        """
+        UPDATE _uct_replacement AS r
+        SET text_content = COALESCE(u._new_text, r.text_content),
+            text_extraction_status = COALESCE(u._new_status, r.text_extraction_status)
+        FROM _uct_updates u
+        WHERE r.comment_id = u.comment_id;
+        """
+    )
+    con.execute(f"DELETE FROM {tbl} WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _uct_replacement);")
+    con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM _uct_replacement;")
+    con.execute("DROP TABLE IF EXISTS _uct_updates;")
+    con.execute("DROP TABLE IF EXISTS _uct_replacement;")
+
+
 def merge_comments(staging_dir: Path, output_dir: Path, record_type: RecordType) -> Path | None:
     """Upsert staged comments into the catalog, then rebuild the comments index.
 

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -483,6 +483,72 @@ def test_audit_and_dedupe_table(tmp_path, local_catalog) -> None:
     assert kept == "2025-03-09T00:00:00Z"
 
 
+def test_upsert_comment_text_fills_in_place(tmp_path, local_catalog) -> None:
+    """upsert_comment_text sets text_content + text_extraction_status for the
+    matched rows, preserves other columns, never duplicates rows, and COALESCE
+    keeps the existing text when _new_text is NULL."""
+    con = local_catalog
+    iceberg._ensure_table(con, COMMENT)
+
+    base = tmp_path / "seed.parquet"
+    rows = [
+        _comment("c1", "EPA-1", "EPA", "2025-01-01T00:00:00Z"),
+        _comment("c2", "EPA-1", "EPA", "2025-01-02T00:00:00Z"),
+        # c3 already has text; a NULL _new_text must not clobber it (COALESCE).
+        _comment("c3", "EPA-1", "EPA", "2025-01-03T00:00:00Z"),
+        # A different agency's row must be untouched.
+        _comment("d1", "DOL-1", "DOL", "2025-02-01T00:00:00Z"),
+    ]
+    rows[2]["text_content"] = "existing text"
+    rows[2]["text_extraction_status"] = "ok"
+    pl.DataFrame(rows, schema=COMMENT.schema).write_parquet(base)
+    iceberg.seed_comments_from_parquet(con, str(base), COMMENT)
+
+    updates = pl.DataFrame(
+        {
+            "comment_id": ["c1", "c2", "c3"],
+            "_new_text": ["filled one", "filled two", None],
+            "_new_status": ["ok", "ok", None],
+        },
+        schema={"comment_id": pl.Utf8, "_new_text": pl.Utf8, "_new_status": pl.Utf8},
+    )
+    iceberg.upsert_comment_text(con, COMMENT, "EPA", updates)
+
+    tbl = iceberg._qualified(COMMENT)
+    # No row duplication (4 rows in, 4 rows out).
+    assert con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0] == 4
+
+    got = dict(con.execute(f"SELECT comment_id, text_content FROM {tbl} ORDER BY comment_id").fetchall())
+    assert got == {
+        "c1": "filled one",
+        "c2": "filled two",
+        "c3": "existing text",  # COALESCE kept the existing text (NULL _new_text)
+        "d1": None,  # other agency untouched
+    }
+
+    statuses = dict(con.execute(f"SELECT comment_id, text_extraction_status FROM {tbl} ORDER BY comment_id").fetchall())
+    assert statuses == {"c1": "ok", "c2": "ok", "c3": "ok", "d1": None}
+
+    # Other columns preserved (posted_date on a filled row).
+    posted = con.execute(f"SELECT posted_date FROM {tbl} WHERE comment_id = 'c1'").fetchone()[0]
+    assert posted == "2025-01-01T00:00:00Z"
+
+
+def test_upsert_comment_text_noop_on_empty(tmp_path, local_catalog) -> None:
+    """An empty updates frame leaves the table untouched (and creates no temp tables)."""
+    con = local_catalog
+    iceberg._ensure_table(con, COMMENT)
+    base = tmp_path / "seed.parquet"
+    pl.DataFrame([_comment("c1", "EPA-1", "EPA", "2025-01-01T00:00:00Z")], schema=COMMENT.schema).write_parquet(base)
+    iceberg.seed_comments_from_parquet(con, str(base), COMMENT)
+
+    empty = pl.DataFrame(schema={"comment_id": pl.Utf8, "_new_text": pl.Utf8, "_new_status": pl.Utf8})
+    iceberg.upsert_comment_text(con, COMMENT, "EPA", empty)
+
+    tbl = iceberg._qualified(COMMENT)
+    assert con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0] == 1
+
+
 def test_dedupe_table_resumes_interrupted_swap(tmp_path, local_catalog) -> None:
     """If a prior run built the deduped sibling but died before the swap finished
     (live table dropped), dedupe_table rebuilds the live table from the sibling


### PR DESCRIPTION
## What & why

Behavior-preserving dedup. The per-agency "upsert comment text columns into the Iceberg catalog" block introduced by #113/#115 and fixed by #117 was copy-pasted (near-identically) into two places:

- `backfill_derived_text._backfill_agency_in_catalog`
- `enrich_pdf._enrich_comment_agency_in_catalog`

Both ran the same DELETE+INSERT upsert after computing an `updates` frame of `(comment_id, _new_text, _new_status)`. This PR hoists that into a single helper:

```python
iceberg.upsert_comment_text(con, record_type, agency, updates)
```

and rewires both callers to it. Everything else in the callers (candidate SELECT, `_derived_text_updates` / `_pdf_text_updates`, stats, logging) is unchanged.

## Notes on equivalence

- The helper **always uses COALESCE**. The derived-text path previously did a direct assignment (`text_content = u._new_text, ...`), but its `updates` frame only ever contains rows with non-null `_new_text`/`_new_status` (rows are appended only when text was found, all with status `ok`), so COALESCE yields the identical result.
- The **self-contained-temp-table invariant from #117 is preserved**: the INSERT reads from a fully materialized `_uct_replacement` temp table, never a projection over the live `{tbl}`. Projecting off the live R2 Data Catalog table dropped `text_extraction_status` writes; the helper's docstring cross-references #117 and explains why the indirection must stay.
- Temp tables are uniquely named (`_uct_updates`, `_uct_replacement`) and dropped at the end; the helper no-ops on an empty frame.

## Tests

- Added `test_upsert_comment_text_fills_in_place` and `test_upsert_comment_text_noop_on_empty` to `tests/test_iceberg.py` (using the existing `local_catalog` fixture): asserts columns are set, other columns/agencies preserved, no row duplication, and COALESCE keeps existing text when `_new_text` is NULL.
- Existing catalog tests (`test_backfill_derived_text.py::test_catalog_backfill_upserts_filled_rows_in_place`, `test_enrich_pdf.py::test_catalog_pdf_enrich_upserts_extracted_text_in_place`) pass unchanged.

## Validation

- `uv run ruff check ...` — All checks passed
- `uv run ty check` — All checks passed
- `uv run pytest tests/test_iceberg.py tests/test_backfill_derived_text.py tests/test_enrich_pdf.py -q` — 38 passed