### PR TITLE
Send browser User-Agent when fetching PDF attachments

### DIFF
--- a/src/spicy_regs/sources/pdf.py
+++ b/src/spicy_regs/sources/pdf.py
@@ -16,6 +16,16 @@ from loguru import logger
 DEFAULT_MAX_BYTES = 100 * 1024 * 1024
 DEFAULT_TIMEOUT = 30.0
 
+# downloads.regulations.gov returns 403 Forbidden to the default
+# ``python-httpx/*`` User-Agent (and to a blank one); a browser-like UA gets
+# 200. Send one so batch enrichment can actually fetch the attachments.
+DEFAULT_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+    )
+}
+
 
 def fetch_pdf_bytes(
     url: str,
@@ -34,7 +44,7 @@ def fetch_pdf_bytes(
     owns_client = client is None
     client = client or httpx.Client(timeout=timeout, follow_redirects=True)
     try:
-        resp = client.get(url)
+        resp = client.get(url, headers=DEFAULT_HEADERS)
         resp.raise_for_status()
         content = resp.content
         if len(content) > max_bytes:

--- a/tests/test_fetch_pdf.py
+++ b/tests/test_fetch_pdf.py
@@ -39,3 +39,19 @@ def test_fetch_returns_none_on_transport_error() -> None:
 
     with _client(handler) as client:
         assert fetch_pdf_bytes("https://example.com/a.pdf", client=client) is None
+
+
+def test_fetch_sends_browser_user_agent() -> None:
+    # downloads.regulations.gov 403s the default python-httpx UA, so a
+    # browser-like User-Agent must be sent on the request.
+    seen: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["ua"] = request.headers.get("user-agent", "")
+        return httpx.Response(200, content=b"%PDF-1.4 fake")
+
+    with _client(handler) as client:
+        fetch_pdf_bytes("https://example.com/a.pdf", client=client)
+
+    assert seen["ua"].startswith("Mozilla/")
+    assert "python-httpx" not in seen["ua"]


### PR DESCRIPTION
## Root cause

The PDF step of the comment-text backfill (`enrich-pdf-text --target comments --use-iceberg`) errored on **every** attachment when run in GitHub Actions (`PDF enrichment: 0 ok, 0 empty, 0 encrypted, 25 error` for NARA).

`fetch_pdf_bytes` used httpx with no `User-Agent` override, so requests went out as `python-httpx/<ver>`. **`downloads.regulations.gov` returns `403 Forbidden` to that UA** (and to a blank one), which `fetch_pdf_bytes` maps to `None` → `status='error'`.

Verified directly against `https://downloads.regulations.gov/NARA-23-0011-0093/attachment_1.pdf`:

| User-Agent | HTTP status |
|---|---|
| curl default | 403 |
| `python-httpx/0.27.0` | 403 |
| empty | 403 |
| `Mozilla/5.0 ...` | **200** |

GH run logs (28876180666) show 25× `Client error '403 Forbidden'` from `fetch_pdf_bytes`.

## Fix

Add a `DEFAULT_HEADERS` browser-like `User-Agent` and send it on the request. Applies whether or not a shared client is passed. Added a unit test asserting the UA is sent and is not the httpx default.

- `uv run ruff check` — pass
- `uv run ty check` — pass
- `uv run pytest tests/test_fetch_pdf.py tests/test_enrich_pdf.py` — 17 passed