### PR TITLE
Stop marking failed downloads as processed in the ETL manifest

### DIFF
--- a/src/spicy_regs/manifest.py
+++ b/src/spicy_regs/manifest.py
@@ -11,12 +11,16 @@ It plays two composable roles:
   the persisted manifest.
 
 Membership is backed by a Bloom filter loaded from ``manifest.parquet`` (fetched
-from R2 when not present locally). A false positive only means a genuinely new
-file is skipped this run and picked up on the next one — never data loss.
+from R2 when not present locally). Bloom hashing is deterministic, so a false
+positive is *sticky*: the same never-seen key tests positive on every run and is
+skipped until a ``--full-refresh`` rebuilds the filter. At the 1e-7 rate over
+~30M keys the expected count is a handful of keys total — an accepted tradeoff
+for the ~150x memory saving over an exact set, not "picked up next run".
 """
 
 from array import array
 from collections.abc import Container, Iterable
+from datetime import datetime, timezone
 from hashlib import md5, sha1
 from math import log
 from pathlib import Path
@@ -32,10 +36,13 @@ from spicy_regs.sources.r2 import download_from_r2
 # ---------------------------------------------------------------------------
 # Bloom filter — stdlib-only, ~34 MB for 30M keys at 1e-7 FP rate.
 #
-# A false positive only means we skip a file that was actually new; the
-# next run will pick it up. This replaces a Python set that consumed
-# ~5 GB for 27M strings.
+# A false positive skips a genuinely new file *permanently*: the hashes are
+# deterministic, so the same key collides on every run — it is not "picked up
+# next run", only by a ``--full-refresh`` that rebuilds the filter. At 1e-7 over
+# ~30M keys the expected count is ~3 keys total, the accepted cost of replacing a
+# Python set that consumed ~5 GB for 27M strings with this ~34 MB bit array.
 # ---------------------------------------------------------------------------
+
 
 class BloomFilter:
     """Memory-efficient probabilistic set membership using a bit array."""
@@ -100,6 +107,41 @@ def save_manifest(output_dir: Path, new_keys: set[str]) -> None:
 
     total = existing_rows + len(new_keys)
     logger.info("Saved manifest: {:,} keys ({:,} existing + {:,} new)", total, existing_rows, len(new_keys))
+
+
+def save_failed_keys(output_dir: Path, transient: Iterable[str], parse: Iterable[str]) -> None:
+    """Write this run's failed keys to a local ``failed_keys.parquet`` diagnostic.
+
+    Deliberately *not* uploaded to R2 and overwritten every run: transient keys
+    already retry automatically via manifest exclusion, so the file's only jobs
+    are alerting (a nonzero ``transient`` count means downloads are failing) and
+    giving a replay list for ``parse`` keys (deterministically corrupt files a
+    future ``--replay-failed`` flag can reprocess). When both lists are empty any
+    stale file is removed so its mere presence signals "last run had failures".
+    """
+    transient = list(transient)
+    parse = list(parse)
+    failed_file = output_dir / "failed_keys.parquet"
+    if not transient and not parse:
+        failed_file.unlink(missing_ok=True)
+        return
+
+    run_at = datetime.now(timezone.utc).isoformat()
+    keys = transient + parse
+    kinds = ["transient"] * len(transient) + ["parse"] * len(parse)
+    table = pa.table(
+        {
+            "key": pa.array(keys, pa.large_string()),
+            "kind": pa.array(kinds, pa.string()),
+            "run_at": pa.array([run_at] * len(keys), pa.string()),
+        }
+    )
+    pq.write_table(table, failed_file, compression="zstd")
+    logger.info(
+        "Saved failed_keys.parquet: {} transient (retry next run) + {} parse (marked processed)",
+        len(transient),
+        len(parse),
+    )
 
 
 class Manifest:

--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -31,7 +31,7 @@ from cyclopts import App, Parameter
 from dotenv import load_dotenv
 from loguru import logger
 
-from spicy_regs.manifest import Manifest
+from spicy_regs.manifest import Manifest, save_failed_keys
 from spicy_regs.pipelines.base import Pipeline
 from spicy_regs.pipelines.staging import stage_agencies
 from spicy_regs.schemas import RECORD_TYPES, RecordType
@@ -138,6 +138,20 @@ class RegulationsPipeline(Pipeline):
             max_workers=self.max_workers,
         )
         manifest.record(result.consumed_keys)
+        # Transient download failures were already excluded from consumed_keys, so
+        # the manifest never marks them processed and the next run retries them;
+        # parse failures were staged as processed. Surface both and persist a
+        # local diagnostic (transient count doubles as a download-health alert).
+        if result.failed_keys or result.parse_failed_keys:
+            logger.warning(
+                "{} keys failed download (excluded from manifest, retried next run); "
+                "{} parse failures (marked processed)",
+                len(result.failed_keys),
+                len(result.parse_failed_keys),
+            )
+        else:
+            logger.info("0 download/parse failures this run")
+        save_failed_keys(output_dir, result.failed_keys, result.parse_failed_keys)
 
         # 3. Transform: merge per-agency staging into the deduplicated dataset.
         staged = result.rows_by_type
@@ -201,16 +215,45 @@ class RegulationsPipeline(Pipeline):
         total = len(keys)
         logger.info("[{}] comments: {} files, ingesting in chunks of {}", agency, total, self.chunk_size)
 
+        # Accumulate failures across chunks so the per-run diagnostic is written
+        # once for the whole agency (save_failed_keys overwrites per run).
+        agency_failures = mirrulations.DownloadFailures()
         for start in range(0, total, self.chunk_size):
             chunk = keys[start : start + self.chunk_size]
             label = f"[{agency}] comments {start + len(chunk)}/{total}"
-            payloads = mirrulations.download_keys(resource, mirrulations.BUCKET, chunk, label=label)
+            failures = mirrulations.DownloadFailures()
+            payloads = mirrulations.download_keys(resource, mirrulations.BUCKET, chunk, label=label, failures=failures)
             records = list(transform.apply(payloads))
+            # One in-run retry over transient failures before committing the chunk,
+            # mirroring the reader path (a huge agency's chunk shouldn't drop a
+            # record to a single transient blip).
+            if failures.transient:
+                retry = mirrulations.DownloadFailures()
+                retried = mirrulations.download_keys(
+                    resource, mirrulations.BUCKET, list(failures.transient), label=f"{label} retry", failures=retry
+                )
+                records.extend(transform.apply(retried))
+                failures.transient = retry.transient
+                failures.parse.extend(retry.parse)
             write_staging(agency, comment_rt.name, records, staging_dir, comment_rt.schema)
             iceberg.merge_comments(staging_dir, output_dir, comment_rt)
             rmtree(staging_dir / comment_rt.name, ignore_errors=True)
-            manifest.record(chunk)
+            # Exclude still-failing transient keys from the manifest so the next
+            # run re-lists them; parse failures stay recorded (marked processed).
+            dropped = set(failures.transient)
+            manifest.record([k for k in chunk if k not in dropped])
+            agency_failures.transient.extend(failures.transient)
+            agency_failures.parse.extend(failures.parse)
             logger.info("[{}] comments: committed {}/{}", agency, start + len(chunk), total)
+
+        if agency_failures.transient or agency_failures.parse:
+            logger.warning(
+                "[{}] comments: {} download failures (retry next run), {} parse failures (marked processed)",
+                agency,
+                len(agency_failures.transient),
+                len(agency_failures.parse),
+            )
+            save_failed_keys(output_dir, agency_failures.transient, agency_failures.parse)
 
     # -- regulations-specific wiring ---------------------------------------
 

--- a/src/spicy_regs/pipelines/staging.py
+++ b/src/spicy_regs/pipelines/staging.py
@@ -30,10 +30,19 @@ TransformFactory = Callable[[RecordType], Transform]
 
 @dataclass
 class StageResult:
-    """Outcome of a staging pass."""
+    """Outcome of a staging pass.
+
+    ``consumed_keys`` are safe to record in the manifest. ``failed_keys`` were
+    attempted but failed transiently — the caller must keep them out of the
+    manifest so the next run retries them. ``parse_failed_keys`` are
+    deterministically corrupt files: staged as processed, but reported so they
+    can be replayed deliberately after a fix.
+    """
 
     rows_by_type: dict[str, int]
     consumed_keys: set[str] = field(default_factory=set)
+    failed_keys: set[str] = field(default_factory=set)
+    parse_failed_keys: set[str] = field(default_factory=set)
 
 
 def stage_agencies(
@@ -51,27 +60,45 @@ def stage_agencies(
     ``transform_for`` is omitted the reader's records are staged as-is.
     """
 
-    def stage_one_agency(agency: str) -> tuple[dict[str, int], list[str]]:
+    def stage_one_agency(agency: str) -> tuple[dict[str, int], list[str], list[str], list[str]]:
         rows: dict[str, int] = {}
         keys: list[str] = []
+        failed: list[str] = []
+        parse_failed: list[str] = []
         for record_type in record_types:
             reader = read(agency, record_type)
             records = reader.iter_records()
             if transform_for is not None:
                 records = transform_for(record_type).apply(records)
             writer = StagingWriter(agency, record_type, staging_dir)
+            # write() fully drains the generator, so the reader's key lists are
+            # final (including the in-run download retry) by the time we read them.
             writer.write(records)
             rows[record_type.name] = writer.rows_written
             keys.extend(reader.last_keys)
+            rt_failed = list(reader.failed_keys)
+            rt_parse_failed = list(getattr(reader, "parse_failed_keys", []))
+            failed.extend(rt_failed)
+            parse_failed.extend(rt_parse_failed)
+            if rt_failed or rt_parse_failed:
+                logger.warning(
+                    "[{}] {}: {} download failures (retry next run), {} parse failures (marked processed)",
+                    agency,
+                    record_type.name,
+                    len(rt_failed),
+                    len(rt_parse_failed),
+                )
             logger.info("[{}] {}: staged {} rows", agency, record_type.name, writer.rows_written)
-        return rows, keys
+        return rows, keys, failed, parse_failed
 
     result = StageResult(rows_by_type={rt.name: 0 for rt in record_types})
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [executor.submit(stage_one_agency, agency) for agency in agencies]
         for future in as_completed(futures):
-            rows, keys = future.result()
+            rows, keys, failed, parse_failed = future.result()
             for name, count in rows.items():
                 result.rows_by_type[name] += count
             result.consumed_keys.update(keys)
+            result.failed_keys.update(failed)
+            result.parse_failed_keys.update(parse_failed)
     return result

--- a/src/spicy_regs/sources/base.py
+++ b/src/spicy_regs/sources/base.py
@@ -18,12 +18,15 @@ class Reader(ABC):
     and dedup semantics are the subclass's responsibility.
 
     Subclasses that pull from a keyed source (S3 keys, URLs, file paths)
-    should populate ``last_keys`` during ``iter_records`` so the caller
-    can append the consumed keys to a manifest. Default is an empty list
-    for sources without addressable keys.
+    should populate ``last_keys`` during ``iter_records`` with the keys
+    *successfully* consumed, so the caller can append them to a manifest.
+    Keys that were attempted but failed go on ``failed_keys`` instead — the
+    caller must NOT manifest these, so the next run retries them. Both default
+    to empty lists for sources without addressable keys.
     """
 
     last_keys: list[str] = []
+    failed_keys: list[str] = []
 
     @abstractmethod
     def iter_records(self) -> Iterator[dict]: ...

--- a/src/spicy_regs/sources/mirrulations.py
+++ b/src/spicy_regs/sources/mirrulations.py
@@ -14,6 +14,7 @@ into schema-shaped records is the job of the
 import re
 from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from json import loads
 from threading import Lock
 from typing import Any
@@ -182,13 +183,52 @@ def list_agency_files_by_type(
     return result
 
 
+class TransientDownloadError(Exception):
+    """S3 GET/read failed (network, throttle) — the key is retryable.
+
+    Raised when the object could not be fetched off S3 at all. The body was
+    never (fully) read, so the file may well succeed on a later attempt; the
+    caller must therefore *not* record the key as processed, leaving the next
+    incremental run free to re-list and re-download it.
+    """
+
+
+class PayloadParseError(Exception):
+    """Body downloaded but JSON decode / extract failed — deterministic, not retryable.
+
+    The bytes came off S3 fine; they just don't parse. Re-fetching yields the
+    same corrupt payload, so the caller marks the key processed (to stop it
+    retrying forever) and logs it for a deliberate replay after a fix.
+    """
+
+
+@dataclass
+class DownloadFailures:
+    """Per-key download failures, split by whether they're worth retrying.
+
+    ``transient`` keys are excluded from the manifest so the next run retries
+    them for free; ``parse`` keys are recorded as processed but surfaced for a
+    deliberate replay. A caller that doesn't care passes nothing (the default
+    ``failures=None`` on :func:`download_keys` keeps failures uncollected).
+    """
+
+    transient: list[str] = field(default_factory=list)
+    parse: list[str] = field(default_factory=list)
+
+
 def download_and_parse(
     s3_resource: Any,
     bucket_name: str,
     key: str,
     extract_fn: Callable[[dict], dict],
-) -> dict | None:
+) -> dict:
     """Download a single JSON file from S3 and parse it with the given extractor.
+
+    Failures are classified so the caller can retry the retryable ones: a GET or
+    read failure raises :class:`TransientDownloadError` (network/throttle — the
+    key may succeed next time), while a JSON-decode or extract failure raises
+    :class:`PayloadParseError` (the bytes are deterministically bad). Both wrap
+    the original exception and carry the offending key.
 
     The response body is closed on every path — including a failed read — so a
     transient error can't leak the connection into CLOSE_WAIT and starve the
@@ -203,9 +243,12 @@ def download_and_parse(
             content = body.read()
         finally:
             body.close()
+    except Exception as exc:
+        raise TransientDownloadError(key) from exc
+    try:
         return extract_fn(loads(content))
-    except Exception:
-        return None
+    except Exception as exc:
+        raise PayloadParseError(key) from exc
 
 
 def discover_agencies() -> list[str]:
@@ -218,6 +261,25 @@ def _identity(payload: dict) -> dict:
     return payload
 
 
+def _record_failure(exc: Exception, key: str, label: str, failures: DownloadFailures | None) -> None:
+    """Log a per-key download failure and, when collecting, bucket it by kind.
+
+    Transient failures are surfaced at ``warning`` because they cost a retry;
+    parse failures are deterministic corruption the operator may want to replay.
+    A ``TransientDownloadError``/``PayloadParseError`` carries its own key, but
+    ``key`` is passed explicitly so the caller stays authoritative.
+    """
+    where = f"{label}: " if label else ""
+    if isinstance(exc, PayloadParseError):
+        logger.warning("{}parse failure, marking processed: {}", where, key)
+        if failures is not None:
+            failures.parse.append(key)
+    else:
+        logger.warning("{}download failed, will retry: {}", where, key)
+        if failures is not None:
+            failures.transient.append(key)
+
+
 def download_keys(
     s3_resource: Any,
     bucket_name: str,
@@ -225,6 +287,7 @@ def download_keys(
     workers: int = DEFAULT_DOWNLOAD_WORKERS,
     *,
     label: str = "",
+    failures: DownloadFailures | None = None,
 ) -> Iterator[dict]:
     """Concurrently download + parse the given keys, yielding raw payloads.
 
@@ -233,26 +296,35 @@ def download_keys(
     huge agency never buffers all its records at once). Order is not preserved —
     dedup happens later by key. With ``label`` set, emits a progress line every
     ``_PROGRESS_EVERY`` files.
+
+    When ``failures`` is provided, each key that couldn't be produced is appended
+    to it — transient (retryable) vs. parse (deterministic) — instead of being
+    silently dropped, so the caller can exclude the retryable ones from the
+    manifest. ``failures=None`` keeps the historical drop-and-continue behavior
+    for callers that don't track keys.
     """
     total = len(keys)
     n = max(1, min(workers, total)) if total else 1
     if n <= 1:
         for key in keys:
-            payload = download_and_parse(s3_resource, bucket_name, key, _identity)
-            if payload is not None:
-                yield payload
+            try:
+                yield download_and_parse(s3_resource, bucket_name, key, _identity)
+            except (TransientDownloadError, PayloadParseError) as exc:
+                _record_failure(exc, key, label, failures)
         return
 
     done = 0
     with ThreadPoolExecutor(max_workers=n) as executor:
-        futures = [executor.submit(download_and_parse, s3_resource, bucket_name, key, _identity) for key in keys]
-        for future in as_completed(futures):
+        # Map future -> key so as_completed can attribute an exception to its key.
+        submitted = {executor.submit(download_and_parse, s3_resource, bucket_name, key, _identity): key for key in keys}
+        for future in as_completed(submitted):
             done += 1
             if label and done % _PROGRESS_EVERY == 0:
                 logger.info("{}: downloaded {}/{}", label, done, total)
-            payload = future.result()
-            if payload is not None:
-                yield payload
+            try:
+                yield future.result()
+            except (TransientDownloadError, PayloadParseError) as exc:
+                _record_failure(exc, submitted[future], label, failures)
 
 
 class MirrulationsReader(Reader):
@@ -289,6 +361,10 @@ class MirrulationsReader(Reader):
         # single-scan listing); otherwise the reader lists them itself.
         self.key_lister = key_lister
         self.last_keys: list[str] = []
+        # Keys attempted but not consumed, so the caller can keep them out of the
+        # manifest (transient) or surface them for replay (parse).
+        self.failed_keys: list[str] = []
+        self.parse_failed_keys: list[str] = []
 
     def iter_records(self) -> Iterator[dict]:
         if self.record_type.path_pattern is None:
@@ -297,9 +373,9 @@ class MirrulationsReader(Reader):
                 f"but {self.record_type.name!r} has no path_pattern."
             )
         if self.key_lister is not None:
-            self.last_keys = self.key_lister()
+            keys = self.key_lister()
         else:
-            self.last_keys = list_json_files(
+            keys = list_json_files(
                 self.s3_resource,
                 self.bucket,
                 self.prefix,
@@ -310,10 +386,39 @@ class MirrulationsReader(Reader):
                 self.verbose,
                 self.since_year,
             )
+        # Populate immediately so a caller inspecting last_keys before the
+        # generator is fully drained still sees the listing; it's narrowed to the
+        # consumed keys once downloading (and the retry pass) completes.
+        self.last_keys = list(keys)
+
         # Fan the per-file GETs across a thread pool via the shared engine —
         # independent, I/O-bound round trips; order is irrelevant (dedup by key).
         label = f"[{self.agency}] {self.record_type.name}"
-        yield from download_keys(self.s3_resource, self.bucket, self.last_keys, self.download_workers, label=label)
+        failures = DownloadFailures()
+        yield from download_keys(
+            self.s3_resource, self.bucket, keys, self.download_workers, label=label, failures=failures
+        )
+        # One in-run retry pass over transient failures; whatever still fails is
+        # left out of last_keys so the next incremental run re-lists it for free.
+        if failures.transient:
+            retry = DownloadFailures()
+            yield from download_keys(
+                self.s3_resource,
+                self.bucket,
+                list(failures.transient),
+                self.download_workers,
+                label=f"{label} retry",
+                failures=retry,
+            )
+            failures.transient = retry.transient
+            failures.parse.extend(retry.parse)
+
+        self.failed_keys = list(failures.transient)
+        self.parse_failed_keys = list(failures.parse)
+        # Transient failures are excluded (retried next run); parse failures stay
+        # marked processed — a deterministically corrupt file would retry forever.
+        dropped = set(failures.transient)
+        self.last_keys = [k for k in keys if k not in dropped]
 
 
 class _AgencyListingCache:

--- a/tests/test_manifest_class.py
+++ b/tests/test_manifest_class.py
@@ -47,3 +47,23 @@ def test_load_with_no_manifest_is_empty(tmp_output: Path, monkeypatch: pytest.Mo
 def test_empty_save_is_noop(tmp_output: Path) -> None:
     Manifest.empty().save(tmp_output)
     assert not (tmp_output / "manifest.parquet").exists()
+
+
+def test_save_failed_keys_writes_parquet(tmp_output: Path) -> None:
+    import polars as pl
+
+    from spicy_regs.manifest import save_failed_keys
+
+    save_failed_keys(tmp_output, ["t1", "t2"], ["p1"])
+    failed_file = tmp_output / "failed_keys.parquet"
+    assert failed_file.exists()
+
+    df = pl.read_parquet(failed_file)
+    assert set(df["key"].to_list()) == {"t1", "t2", "p1"}
+    kinds = dict(zip(df["key"].to_list(), df["kind"].to_list()))
+    assert kinds == {"t1": "transient", "t2": "transient", "p1": "parse"}
+    assert df["run_at"].n_unique() == 1  # one timestamp for the whole run
+
+    # A clean run removes any stale file so its presence signals "last run failed".
+    save_failed_keys(tmp_output, [], [])
+    assert not failed_file.exists()

--- a/tests/test_mirrulations_reader.py
+++ b/tests/test_mirrulations_reader.py
@@ -1,5 +1,6 @@
 """Tests for MirrulationsReader using a fake in-memory S3 resource."""
 
+from collections.abc import Iterable
 from json import dumps
 
 import pytest
@@ -95,7 +96,7 @@ class _FlakyResource(_FakeS3Resource):
     Listing (``Bucket``) is untouched, so the keys still appear in the listing.
     """
 
-    def __init__(self, store: dict[str, bytes], transient_fail: object = (), fail_once: bool = False) -> None:
+    def __init__(self, store: dict[str, bytes], transient_fail: Iterable[str] = (), fail_once: bool = False) -> None:
         super().__init__(store)
         self._transient_fail = set(transient_fail)
         self._fail_once = fail_once

--- a/tests/test_mirrulations_reader.py
+++ b/tests/test_mirrulations_reader.py
@@ -2,6 +2,8 @@
 
 from json import dumps
 
+import pytest
+
 from spicy_regs.schemas import COMMENT, DOCKET, DOCUMENT
 from spicy_regs.sources import MirrulationsReader
 
@@ -68,6 +70,42 @@ class _FakeS3Resource:
         return _FakeBucket(self._store)
 
     def Object(self, name: str, key: str) -> _FakeObj:  # noqa: N802 — mirrors boto3 API
+        return _FakeObj(key, self._store[key])
+
+
+class _RaisingObj:
+    """An S3 object whose body read fails — a transient download error."""
+
+    def get(self) -> dict:
+        class _Body:
+            def read(self) -> bytes:
+                raise OSError("connection reset by peer")
+
+            def close(self) -> None:
+                pass
+
+        return {"Body": _Body()}
+
+
+class _FlakyResource(_FakeS3Resource):
+    """Fake S3 that fails ``read()`` for chosen keys (all attempts, or just the first).
+
+    ``fail_once`` makes a key fail on its first fetch and succeed thereafter, so a
+    single instance can prove the in-run retry pass recovers a transient blip.
+    Listing (``Bucket``) is untouched, so the keys still appear in the listing.
+    """
+
+    def __init__(self, store: dict[str, bytes], transient_fail: object = (), fail_once: bool = False) -> None:
+        super().__init__(store)
+        self._transient_fail = set(transient_fail)
+        self._fail_once = fail_once
+        self._attempts: dict[str, int] = {}
+
+    def Object(self, name: str, key: str):  # noqa: N802 — mirrors boto3 API
+        self._attempts[key] = self._attempts.get(key, 0) + 1
+        first_attempt = self._attempts[key] == 1
+        if key in self._transient_fail and (not self._fail_once or first_attempt):
+            return _RaisingObj()
         return _FakeObj(key, self._store[key])
 
 
@@ -238,15 +276,17 @@ def test_download_keys_yields_payloads() -> None:
 
 
 def test_download_and_parse_closes_body_on_read_error() -> None:
-    """A failed download must still close the response body.
+    """A failed download raises TransientDownloadError but still closes the body.
 
     If ``read()`` raises (timeout, connection reset) and the body is left open,
     the underlying S3 connection leaks into CLOSE_WAIT instead of returning to
     the pool. Enough leaks exhaust the pool and later downloads block forever
     acquiring a connection — the low-CPU / CLOSE_WAIT-pileup hang seen on large
-    agencies. Closing the body on every path keeps the pool healthy.
+    agencies. Closing the body on every path keeps the pool healthy; raising
+    (rather than returning None) lets the caller keep the key out of the manifest
+    so it's retried next run.
     """
-    from spicy_regs.sources.mirrulations import download_and_parse
+    from spicy_regs.sources.mirrulations import TransientDownloadError, download_and_parse
 
     closed = {"value": False}
 
@@ -265,10 +305,102 @@ def test_download_and_parse_closes_body_on_read_error() -> None:
         def Object(self, bucket: str, key: str) -> _Obj:  # noqa: N802
             return _Obj()
 
-    result = download_and_parse(_Res(), BUCKET, "some/key.json", lambda d: d)
+    with pytest.raises(TransientDownloadError):
+        download_and_parse(_Res(), BUCKET, "some/key.json", lambda d: d)
 
-    assert result is None  # the error is swallowed (record skipped this run)
     assert closed["value"] is True  # ...but the body was closed, so no leak
+
+
+def test_download_and_parse_raises_parse_error_on_bad_json() -> None:
+    """A body that decodes/extracts badly raises PayloadParseError, not transient.
+
+    The bytes came off S3 fine — retrying just re-fetches the same corrupt
+    payload — so this is a distinct, non-retryable failure class.
+    """
+    from spicy_regs.sources.mirrulations import PayloadParseError, download_and_parse
+
+    store = {"bad/key.json": b"{ not valid json"}
+    with pytest.raises(PayloadParseError):
+        download_and_parse(_FakeS3Resource(store), BUCKET, "bad/key.json", lambda d: d)
+
+
+def _mixed_failure_store() -> tuple[dict[str, bytes], str, str, str]:
+    """A store with one good, one parse-failing, and one transient-failing key."""
+    good = _docket_key("EPA-2024-0001")
+    parse_bad = _docket_key("EPA-2025-0002")
+    transient_bad = _docket_key("EPA-2024-0003")
+    store = {
+        good: dumps(_docket_payload("EPA-2024-0001")).encode(),
+        parse_bad: b"{ broken json",
+        transient_bad: dumps(_docket_payload("EPA-2024-0003")).encode(),
+    }
+    return store, good, parse_bad, transient_bad
+
+
+@pytest.mark.parametrize("workers", [1, 4])
+def test_download_keys_reports_failed_keys(workers: int) -> None:
+    """download_keys buckets each unyielded key by failure kind (both branches).
+
+    ``workers=1`` exercises the serial branch, ``workers=4`` the thread-pool
+    branch (future->key attribution) — both must report the same split.
+    """
+    from spicy_regs.sources.mirrulations import DownloadFailures, download_keys
+
+    store, good, parse_bad, transient_bad = _mixed_failure_store()
+    resource = _FlakyResource(store, transient_fail=[transient_bad])
+    failures = DownloadFailures()
+    payloads = list(
+        download_keys(resource, BUCKET, [good, parse_bad, transient_bad], workers=workers, failures=failures)
+    )
+
+    assert [p["data"]["id"] for p in payloads] == ["EPA-2024-0001"]
+    assert failures.transient == [transient_bad]
+    assert failures.parse == [parse_bad]
+
+
+def test_iter_records_excludes_transient_failures_from_last_keys() -> None:
+    """A transient download failure is kept out of last_keys (and reported)."""
+    store = _make_store()
+    bad = _docket_key("EPA-2025-0002")
+    resource = _FlakyResource(store, transient_fail=[bad])
+    reader = MirrulationsReader(resource, BUCKET, PREFIX, AGENCY, DOCKET, download_workers=1)
+
+    records = list(reader.iter_records())
+
+    assert [_raw_id(r) for r in records] == ["EPA-2024-0001"]
+    assert reader.last_keys == [_docket_key("EPA-2024-0001")]  # bad key excluded
+    assert reader.failed_keys == [bad]
+    assert reader.parse_failed_keys == []
+
+
+def test_iter_records_retries_transient_failure_once() -> None:
+    """The in-run retry recovers a key that fails its first fetch, succeeds next."""
+    store = _make_store()
+    flaky = _docket_key("EPA-2025-0002")
+    resource = _FlakyResource(store, transient_fail=[flaky], fail_once=True)
+    reader = MirrulationsReader(resource, BUCKET, PREFIX, AGENCY, DOCKET, download_workers=1)
+
+    records = list(reader.iter_records())
+
+    assert sorted(_raw_id(r) for r in records) == ["EPA-2024-0001", "EPA-2025-0002"]
+    assert reader.failed_keys == []  # recovered on retry
+    assert sorted(reader.last_keys) == sorted([_docket_key("EPA-2024-0001"), flaky])
+
+
+def test_iter_records_keeps_parse_failures_in_last_keys() -> None:
+    """A parse failure stays in last_keys (marked processed) but is reported."""
+    store = _make_store()
+    bad = _docket_key("EPA-2025-0002")
+    store[bad] = b"{ broken json"
+    reader = MirrulationsReader(_FakeS3Resource(store), BUCKET, PREFIX, AGENCY, DOCKET, download_workers=1)
+
+    records = list(reader.iter_records())
+
+    assert [_raw_id(r) for r in records] == ["EPA-2024-0001"]
+    assert reader.parse_failed_keys == [bad]
+    assert reader.failed_keys == []
+    # Deterministically corrupt -> stays processed so it doesn't retry forever.
+    assert sorted(reader.last_keys) == sorted([_docket_key("EPA-2024-0001"), bad])
 
 
 def test_s3_resource_configures_retries() -> None:

--- a/tests/test_regulations_pipeline.py
+++ b/tests/test_regulations_pipeline.py
@@ -78,6 +78,38 @@ class _FakeS3Resource:
         return _FakeObj(key, self._store[key])
 
 
+class _RaisingObj:
+    """An S3 object whose body read fails — a transient download error."""
+
+    def get(self) -> dict:
+        class _Body:
+            def read(self) -> bytes:
+                raise OSError("connection reset by peer")
+
+            def close(self) -> None:
+                pass
+
+        return {"Body": _Body()}
+
+
+class _FlakyResource(_FakeS3Resource):
+    """Fake S3 that fails ``read()`` for ``fail_keys`` while ``fail["active"]``.
+
+    A shared mutable flag lets one test flip the failure off between runs, so the
+    same key can fail on run 1 (excluded from the manifest) and succeed on run 2.
+    """
+
+    def __init__(self, store: dict[str, bytes], fail_keys: set[str], active: dict[str, bool]) -> None:
+        super().__init__(store)
+        self._fail_keys = fail_keys
+        self._active = active
+
+    def Object(self, name: str, key: str):  # noqa: N802 — mirrors boto3 API
+        if self._active["active"] and key in self._fail_keys:
+            return _RaisingObj()
+        return _FakeObj(key, self._store[key])
+
+
 def _docket_payload(docket_id: str, modify_date: str, agency: str = AGENCY) -> dict:
     return {
         "data": {
@@ -242,6 +274,99 @@ def test_full_refresh_reprocesses_despite_manifest(tmp_output: Path, monkeypatch
     )
     _run(tmp_output, full_refresh=True)
     assert merge_calls == [1]  # reprocessed even though the key is in the manifest
+
+
+# --- failed-key handling ---------------------------------------------------
+
+
+def test_failed_download_is_not_committed_to_manifest_and_retries_next_run(
+    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient download failure must not be marked processed, so the next
+    incremental run re-lists and re-downloads it."""
+    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
+    good = _docket_key("EPA-2024-0001")
+    flaky = _docket_key("EPA-2025-0002")
+    store = {
+        good: dumps(_docket_payload("EPA-2024-0001", "2024-01-01")).encode(),
+        flaky: dumps(_docket_payload("EPA-2025-0002", "2025-01-01")).encode(),
+    }
+    active = {"active": True}
+    monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FlakyResource(store, {flaky}, active))
+
+    # Run 1: the flaky key fails every attempt -> only the good docket lands.
+    _run(tmp_output)
+    df = pl.read_parquet(tmp_output / "dockets.parquet")
+    assert df["docket_id"].to_list() == ["EPA-2024-0001"]
+    reloaded = Manifest.load(tmp_output)
+    assert good in reloaded
+    assert flaky not in reloaded  # excluded so the next run retries it
+
+    # Run 2: failure cleared -> the previously-failed key is re-listed and lands.
+    active["active"] = False
+    _run(tmp_output)
+    df = pl.read_parquet(tmp_output / "dockets.parquet")
+    assert sorted(df["docket_id"].to_list()) == ["EPA-2024-0001", "EPA-2025-0002"]
+
+
+def test_parse_failure_is_committed_to_manifest(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A deterministically corrupt file is marked processed (so it doesn't retry
+    forever) and recorded in failed_keys.parquet with kind=parse."""
+    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
+    good = _docket_key("EPA-2024-0001")
+    corrupt = _docket_key("EPA-2025-0002")
+    store = {
+        good: dumps(_docket_payload("EPA-2024-0001", "2024-01-01")).encode(),
+        corrupt: b"{ broken json",
+    }
+    monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
+
+    _run(tmp_output)
+
+    reloaded = Manifest.load(tmp_output)
+    assert corrupt in reloaded  # parse failure stays processed
+    assert good in reloaded
+
+    failed = pl.read_parquet(tmp_output / "failed_keys.parquet")
+    row = failed.filter(pl.col("key") == corrupt)
+    assert row.height == 1
+    assert row["kind"].to_list() == ["parse"]
+
+
+def test_chunked_comments_exclude_failed_keys_from_manifest(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The chunked ingest path excludes transient failures from the manifest too."""
+    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
+    keys = {f"c{i}": _comment_key(f"c{i}", "EPA-2026-0001") for i in range(3)}
+    store = {
+        keys[f"c{i}"]: dumps(_comment_payload(f"c{i}", "EPA-2026-0001", "2026-01-01T00:00:00Z")).encode()
+        for i in range(3)
+    }
+    flaky = keys["c1"]
+    active = {"active": True}
+    monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FlakyResource(store, {flaky}, active))
+    monkeypatch.setattr(regulations.iceberg, "merge_comments", lambda sd, od, rt: None)
+
+    pipe = RegulationsPipeline(
+        agency=AGENCY,
+        output_dir=tmp_output,
+        only_comments=True,
+        use_iceberg=True,
+        enrich_text=False,
+        chunk_size=2,
+        skip_upload=True,
+    )
+    staging_dir = tmp_output / "staging"
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    manifest = Manifest.empty()
+    pipe._ingest_comments_chunked(AGENCY, tmp_output, staging_dir, manifest)
+
+    recorded = manifest.new_keys
+    assert flaky not in recorded  # excluded -> retried next run
+    assert keys["c0"] in recorded
+    assert keys["c2"] in recorded
+    # The transient failure is surfaced in the local diagnostic.
+    failed = pl.read_parquet(tmp_output / "failed_keys.parquet")
+    assert flaky in failed["key"].to_list()
 
 
 # --- parallelism -----------------------------------------------------------

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -11,11 +11,19 @@ from spicy_regs.sources.base import Reader
 
 
 class _FakeReader(Reader):
-    """Yields canned records and reports the keys it 'consumed'."""
+    """Yields canned records and reports the keys it 'consumed' (and failed)."""
 
-    def __init__(self, records: list[dict], keys: list[str]) -> None:
+    def __init__(
+        self,
+        records: list[dict],
+        keys: list[str],
+        failed: list[str] | None = None,
+        parse_failed: list[str] | None = None,
+    ) -> None:
         self._records = records
         self.last_keys = keys
+        self.failed_keys = failed or []
+        self.parse_failed_keys = parse_failed or []
 
     def iter_records(self) -> Iterator[dict]:
         yield from self._records
@@ -53,6 +61,26 @@ def test_stage_agencies_aggregates_rows_and_keys(tmp_output: Path) -> None:
     fda = pl.read_parquet(tmp_output / "staging" / "dockets" / "FDA.parquet")
     assert epa.height == 1
     assert fda.height == 2
+
+
+def test_stage_agencies_aggregates_failed_keys(tmp_output: Path) -> None:
+    """Transient + parse failures from each agency's reader are aggregated,
+    kept separate from consumed_keys so the caller can exclude the retryable ones
+    from the manifest."""
+    data = {
+        "EPA": ([_docket("EPA-1")], ["k-epa"], ["fail-epa"], []),
+        "FDA": ([_docket("FDA-1")], ["k-fda"], ["fail-fda"], ["parse-fda"]),
+    }
+
+    def read(agency: str, record_type: RecordType) -> _FakeReader:
+        records, keys, failed, parse = data[agency]
+        return _FakeReader(records, keys, failed, parse)
+
+    result = stage_agencies(["EPA", "FDA"], [DOCKET], tmp_output / "staging", read, max_workers=2)
+
+    assert result.consumed_keys == {"k-epa", "k-fda"}
+    assert result.failed_keys == {"fail-epa", "fail-fda"}
+    assert result.parse_failed_keys == {"parse-fda"}
 
 
 def test_stage_agencies_empty_agency_is_zero(tmp_output: Path) -> None:


### PR DESCRIPTION
## The bug

The main regulations ETL was permanently losing records to transient download failures.

- `download_and_parse` (`sources/mirrulations.py`) did `except Exception: return None`, so a network/S3 read failure was indistinguishable from a corrupt-JSON failure — both silently dropped.
- `MirrulationsReader.iter_records` set `last_keys` to the **full listing before downloading**, so a key that failed to download was still reported as consumed.
- `stage_agencies` fed `last_keys` into `manifest.record(...)`. The manifest is an **append-only Bloom filter**, and Bloom hashing is deterministic — once a key is recorded, it tests positive on *every* future run. A failed download was therefore marked "processed" forever (recoverable only via `--full-refresh`). Silent data loss.

## The fix

Classify download failures and only exclude the **retryable** ones from the manifest, so cross-run retry is free (the next incremental run re-lists and re-downloads any key not in the manifest).

- **Failure classification** — `download_and_parse` now raises `TransientDownloadError` (GET/read failed — network/throttle, retryable) vs `PayloadParseError` (bytes came off S3 fine but decode/extract failed — deterministic, not retryable). The response body is still closed on every path (keeps the CLOSE_WAIT pool-leak fix intact).
- **Per-key reporting** — `download_keys` accepts an optional `DownloadFailures` sink and buckets each unyielded key by kind in **both** the serial and thread-pool branches (the pool branch maps `future -> key` so `as_completed` can attribute the exception). `failures=None` keeps external callers backward-compatible.
- **In-run retry + manifest exclusion** — `iter_records` does one in-run retry pass over transient failures, then leaves still-failing transient keys out of `last_keys`. **Parse failures stay in `last_keys`** (marked processed): a deterministically corrupt file would otherwise retry forever. Reader exposes `failed_keys` / `parse_failed_keys`.
- **Reader contract** — `Reader` gains a backward-compatible `failed_keys` class attribute (default `[]`); existing subclasses/test fakes need no change.
- **Aggregation & wiring** — `StageResult` aggregates `failed_keys` / `parse_failed_keys`; the pipeline's main path *and* the chunked comment-ingest path exclude transient failures from `manifest.record`, log a summary line, and persist a diagnostic.
- **failed_keys.parquet** — new `manifest.save_failed_keys(output_dir, transient, parse)` writes `(key, kind, run_at)`. **Local-only, overwrite-per-run, not uploaded to R2**: transient keys already retry automatically, so the file's value is alerting (a nonzero transient count = downloads are failing) and a replay list for parse failures (a future `--replay-failed`). A clean run removes any stale file.
- **Bloom comment fix** — corrected the wrong "false positive picked up next run" comments in `manifest.py`. False positives are *sticky* (deterministic hashing); at 1e-7 over ~30M keys the expected count is ~a handful, an accepted tradeoff recoverable only via `--full-refresh`.

## Tests

New/updated coverage: failure classification (transient vs parse, body still closed), per-key reporting parametrized over serial + pool branches, in-run retry recovery, `last_keys` exclusion of transient vs retention of parse, staging aggregation, pipeline non-commit + cross-run retry of a failed key, parse-failure commit + `failed_keys.parquet` contents, chunked-path manifest exclusion, and `save_failed_keys`.

`uv run ruff format --check` + `uv run ruff check .` clean. `uv run pytest`: **255 passed**. The only failures locally are 2 pre-existing `tests/test_load.py::TestUploadShrinkGuard` cases, unrelated to this change and untouched here — they fail because of a leaked `R2_ALLOW_SHRINK=1` in the local shell (log shows `R2_ALLOW_SHRINK=1: bypassing shrink guard`), not on CI.