### PR TITLE
fix(iceberg): bound dedupe memory by splitting large agencies into hash buckets

### DIFF
--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -456,6 +456,42 @@ def audit_duplicates(con, record_type: RecordType) -> list[tuple[str, int, int]]
     return [(r[0], r[1], r[2]) for r in rows]
 
 
+def _dedup_chunk_rows() -> int:
+    """Target upper bound on the rows any single dedup INSERT buffers.
+
+    Read at call time so ops can tune it via ``DEDUP_CHUNK_ROWS`` without a code
+    change (mirrors ``DEDUP_MEMORY_LIMIT`` / ``DEDUP_THREADS``).
+    """
+    return int(getenv("DEDUP_CHUNK_ROWS", "250000"))
+
+
+def _agency_chunk_count(con, source_tbl: str, where_agency: str) -> int:
+    """How many ``hash(key)`` buckets to split one agency's rows into.
+
+    Per-agency was assumed to fit, but the largest agencies (FDA ~1.8M comments,
+    each carrying full comment text) blow past the runner's memory as a single
+    INSERT — the ROW_NUMBER window sorts whole rows and the Iceberg writer buffers
+    the result. Splitting by ``hash(key) % chunks`` keeps every INSERT bounded.
+    """
+    n = con.execute(f"SELECT count(*) FROM {source_tbl} WHERE {where_agency}").fetchone()[0]
+    chunk = _dedup_chunk_rows()
+    if n <= chunk:
+        return 1
+    return (n + chunk - 1) // chunk
+
+
+def _key_bucket_predicates(where_agency: str, key: str, chunks: int) -> list[str]:
+    """Predicates splitting an agency into ``chunks`` disjoint ``hash(key)`` buckets.
+
+    All rows sharing a ``key`` fall in the same bucket (``hash`` is deterministic),
+    so per-bucket ``ROW_NUMBER() OVER (PARTITION BY key)`` dedup equals a per-agency
+    one. ``chunks == 1`` returns the agency predicate unchanged (no hashing cost).
+    """
+    if chunks <= 1:
+        return [where_agency]
+    return [f'({where_agency}) AND (hash("{key}") % {chunks}) = {k}' for k in range(chunks)]
+
+
 def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
     """Collapse the catalog table to one row per ``dedup_key`` (latest modify_date).
 
@@ -469,9 +505,11 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
       ``ROW_NUMBER() OVER (PARTITION BY key)`` OOMs the runner on the read side,
       and a single ``CREATE OR REPLACE ... AS SELECT`` of the whole table OOMs it
       on the Iceberg *write* side. Both the daily merge and the original seed only
-      ever write per-agency slices, which fit — so this does the same. Duplicates
-      only ever occur within one agency (a ``comment_id`` belongs to one agency),
-      so per-agency dedup equals a global one here.
+      ever write per-agency slices — but the biggest agencies no longer fit in one
+      slice either, so each agency is further split into ``hash(key)`` buckets of
+      at most ``DEDUP_CHUNK_ROWS`` rows. Duplicates only ever occur within one
+      agency (a ``comment_id`` belongs to one agency), and all rows for a key share
+      a bucket, so per-bucket dedup equals a global one here.
     * Never ``ALTER TABLE RENAME``. DuckDB's Iceberg REST integration does not
       implement it (``NotImplementedException: Alter Schema Entry``), so the swap
       replaces the live table by ``DROP`` + ``CREATE`` + per-agency ``INSERT``
@@ -509,7 +547,11 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
         con.execute(f"CREATE TABLE {tbl} ({col_defs});")
         for agency in sibling_agencies:
             where = "agency_code IS NULL" if agency is None else f"agency_code = '{_sql_str(agency)}'"
-            con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM {dedup_tbl} WHERE {where};")
+            # Chunk large agencies so the Iceberg write buffer stays bounded (the
+            # sibling is already deduped, so this is a plain copy — no QUALIFY).
+            chunks = _agency_chunk_count(con, dedup_tbl, where)
+            for pred in _key_bucket_predicates(where, key, chunks):
+                con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM {dedup_tbl} WHERE {pred};")
         rebuilt = con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]
         if rebuilt != expected:
             raise RuntimeError(
@@ -538,18 +580,25 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
     logger.info("iceberg: rebuilding {} deduplicated across {} agency bucket(s)", name, len(agencies))
     for agency in agencies:
         where = "agency_code IS NULL" if agency is None else f"agency_code = '{_sql_str(agency)}'"
-        con.execute(
-            f"""
-            INSERT INTO {dedup_tbl} ({col_list})
-            SELECT {col_list}
-            FROM {tbl}
-            WHERE {where}
-            QUALIFY ROW_NUMBER() OVER (
-                PARTITION BY "{key}"
-                ORDER BY modify_date DESC NULLS LAST
-            ) = 1;
-            """
-        )
+        # Split large agencies into hash(key) buckets so the window sort + Iceberg
+        # write of one INSERT stays within the runner's memory. All rows for a key
+        # share a bucket, so the per-bucket ROW_NUMBER dedup is still correct.
+        chunks = _agency_chunk_count(con, tbl, where)
+        if chunks > 1:
+            logger.info("iceberg: agency {} split into {} hash(key) bucket(s) for bounded memory", agency, chunks)
+        for pred in _key_bucket_predicates(where, key, chunks):
+            con.execute(
+                f"""
+                INSERT INTO {dedup_tbl} ({col_list})
+                SELECT {col_list}
+                FROM {tbl}
+                WHERE {pred}
+                QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY "{key}"
+                    ORDER BY modify_date DESC NULLS LAST
+                ) = 1;
+                """
+            )
 
     after = con.execute(f"SELECT count(*) FROM {dedup_tbl}").fetchone()[0]
 

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -483,6 +483,65 @@ def test_audit_and_dedupe_table(tmp_path, local_catalog) -> None:
     assert kept == "2025-03-09T00:00:00Z"
 
 
+def test_key_bucket_predicates_and_chunk_count(monkeypatch) -> None:
+    """The bounded-memory helpers: chunk count rounds rows up to DEDUP_CHUNK_ROWS,
+    and the bucket predicates are disjoint hash(key) slices (or a no-op at 1)."""
+    monkeypatch.setenv("DEDUP_CHUNK_ROWS", "100")
+    assert iceberg._dedup_chunk_rows() == 100
+
+    # chunks <= 1 leaves the agency predicate untouched (no hashing overhead).
+    assert iceberg._key_bucket_predicates("agency_code = 'EPA'", "comment_id", 1) == ["agency_code = 'EPA'"]
+
+    preds = iceberg._key_bucket_predicates("agency_code = 'EPA'", "comment_id", 3)
+    assert len(preds) == 3
+    assert all('hash("comment_id") % 3' in p for p in preds)
+    assert preds[0].endswith("= 0") and preds[-1].endswith("= 2")
+
+
+def test_dedupe_table_chunked_matches_unchunked(tmp_path, local_catalog, monkeypatch) -> None:
+    """A tiny DEDUP_CHUNK_ROWS forces each agency to split into several hash(key)
+    buckets. Dedup must still collapse to one row per comment_id and keep the
+    latest modify_date — proving the bounded-memory chunking (added because the
+    largest agencies OOM as a single per-agency INSERT) never changes the result.
+    If same-key rows were split across buckets, a duplicate would survive and
+    audit_duplicates would flag it."""
+    con = local_catalog
+    iceberg._ensure_table(con, COMMENT)
+
+    base = tmp_path / "seed.parquet"
+    pl.DataFrame(
+        [
+            _comment("c1", "EPA-1", "EPA", "2025-01-01T00:00:00Z", modify_date="2025-01-01T00:00:00Z"),
+            _comment("c2", "EPA-1", "EPA", "2025-01-02T00:00:00Z", modify_date="2025-01-02T00:00:00Z"),
+            _comment("c3", "EPA-1", "EPA", "2025-01-03T00:00:00Z", modify_date="2025-01-03T00:00:00Z"),
+            _comment("c4", "EPA-1", "EPA", "2025-01-04T00:00:00Z", modify_date="2025-01-04T00:00:00Z"),
+            _comment("c5", "OMB-1", "OMB", "2025-02-01T00:00:00Z", modify_date="2025-02-01T00:00:00Z"),
+        ],
+        schema=COMMENT.schema,
+    ).write_parquet(base)
+    # Load 3x to duplicate every row, then a newer c1 so dedup must keep the latest.
+    for _ in range(3):
+        iceberg.seed_comments_from_parquet(con, str(base), COMMENT)
+    newer = tmp_path / "newer.parquet"
+    pl.DataFrame(
+        [_comment("c1", "EPA-1", "EPA", "2025-06-01T00:00:00Z", modify_date="2025-06-01T00:00:00Z")],
+        schema=COMMENT.schema,
+    ).write_parquet(newer)
+    iceberg.seed_comments_from_parquet(con, str(newer), COMMENT)
+
+    # 1 row/chunk => the multi-row EPA agency splits into more than one bucket.
+    monkeypatch.setenv("DEDUP_CHUNK_ROWS", "1")
+    assert iceberg._agency_chunk_count(con, iceberg._qualified(COMMENT), "agency_code = 'EPA'") > 1
+
+    before, after = iceberg.dedupe_table(con, COMMENT)
+    assert after == 5  # c1..c5 distinct
+    assert iceberg.audit_duplicates(con, COMMENT) == []
+    kept = con.execute(
+        f"SELECT modify_date FROM {iceberg._qualified(COMMENT)} WHERE comment_id = 'c1'"
+    ).fetchone()[0]
+    assert kept == "2025-06-01T00:00:00Z"
+
+
 def test_upsert_comment_text_fills_in_place(tmp_path, local_catalog) -> None:
     """upsert_comment_text sets text_content + text_extraction_status for the
     matched rows, preserves other columns, never duplicates rows, and COALESCE


### PR DESCRIPTION
## Problem
The `Dedupe comments catalog` apply path OOMs on the runner. Observed in a production run (2026-07-17 14:10):
```
_duckdb.OutOfMemoryException: Out of Memory Error: failed to pin block of size 256.0 KiB (4.6 GiB/4.6 GiB used)
  ... iceberg.py:541 in dedupe_table
```
`dedupe_table` builds the deduped sibling one agency at a time, assuming a single agency's slice fits in memory. It no longer does — the largest agencies (FDA ~1.8M comments, each with full comment text) blow past the cap on a single INSERT: the `ROW_NUMBER` window sorts whole rows and the Iceberg writer buffers the result.

**No data was lost** in the failed run: the OOM struck during the sibling build, *before* the live-table swap — but the apply could never complete, leaving ~104k duplicate rows (101 agencies) uncleaned and `check-comments-freshness` red daily.

## Fix
Split each agency into `ceil(rows / DEDUP_CHUNK_ROWS)` `hash(key)` buckets and run one bounded INSERT per bucket — in both the sibling build and the sibling→live copy. All rows for a `comment_id` share a bucket (hash is deterministic), so per-bucket `ROW_NUMBER` dedup equals the per-agency result. `DEDUP_CHUNK_ROWS` (default 250k) tunes the ceiling, alongside the existing `DEDUP_MEMORY_LIMIT` / `DEDUP_THREADS` knobs.

## Tests
- `test_dedupe_table_chunked_matches_unchunked`: with `DEDUP_CHUNK_ROWS=1` (forcing multi-bucket splits) dedup still collapses duplicates to one row per `comment_id` and keeps the latest `modify_date` — proving same-key co-location.
- `test_key_bucket_predicates_and_chunk_count`: unit coverage of the bucket-count / predicate helpers.
- Full `tests/test_iceberg.py` (21) green.

Part of the "stale HHS data" triage (companion to the ETL batch-starvation fix). After merge, the dedupe apply can run in the post-ETL quiet window to clear the ~104k dupes.