### PR TITLE
Sub-batch catalog dedup by key hash to avoid runner OOM

### DIFF
--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -468,10 +468,13 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
     * Never touch tens of millions of rows in one statement. A global
       ``ROW_NUMBER() OVER (PARTITION BY key)`` OOMs the runner on the read side,
       and a single ``CREATE OR REPLACE ... AS SELECT`` of the whole table OOMs it
-      on the Iceberg *write* side. Both the daily merge and the original seed only
-      ever write per-agency slices, which fit — so this does the same. Duplicates
-      only ever occur within one agency (a ``comment_id`` belongs to one agency),
-      so per-agency dedup equals a global one here.
+      on the Iceberg *write* side. The build works per agency, and — because even
+      one large agency's dedup window buffers whole rows (comment text included)
+      and overflows the runner's memory limit despite on-disk spill — each agency
+      is further split into hash buckets of the dedup key sized to
+      ``DEDUP_ROWS_PER_BATCH`` rows. A key hashes to exactly one bucket and
+      duplicates only ever share a key, so per-bucket dedup equals per-agency
+      equals global dedup here; small agencies stay a single write.
     * Never ``ALTER TABLE RENAME``. DuckDB's Iceberg REST integration does not
       implement it (``NotImplementedException: Alter Schema Entry``), so the swap
       replaces the live table by ``DROP`` + ``CREATE`` + per-agency ``INSERT``
@@ -535,21 +538,33 @@ def dedupe_table(con, record_type: RecordType) -> tuple[int, int]:
     con.execute(f"CREATE TABLE {dedup_tbl} ({col_defs});")
 
     agencies = [r[0] for r in con.execute(f"SELECT DISTINCT agency_code FROM {tbl}").fetchall()]
+    counts = dict(con.execute(f"SELECT agency_code, count(*) FROM {tbl} GROUP BY agency_code").fetchall())
+    # A single agency's dedup window buffers whole rows (comment text included), so
+    # the largest agencies overflow the runner's memory limit even with spilling on.
+    # Split each agency into ceil(rows / DEDUP_ROWS_PER_BATCH) hash buckets of the
+    # dedup key to bound each window's input; a key hashes to one bucket and dupes
+    # share a key, so this doesn't change the result. Small agencies -> 1 bucket.
+    rows_per_batch = int(getenv("DEDUP_ROWS_PER_BATCH", "100000"))
     logger.info("iceberg: rebuilding {} deduplicated across {} agency bucket(s)", name, len(agencies))
     for agency in agencies:
         where = "agency_code IS NULL" if agency is None else f"agency_code = '{_sql_str(agency)}'"
-        con.execute(
-            f"""
-            INSERT INTO {dedup_tbl} ({col_list})
-            SELECT {col_list}
-            FROM {tbl}
-            WHERE {where}
-            QUALIFY ROW_NUMBER() OVER (
-                PARTITION BY "{key}"
-                ORDER BY modify_date DESC NULLS LAST
-            ) = 1;
-            """
-        )
+        n_buckets = max(1, -(-counts.get(agency, 0) // rows_per_batch))  # ceil division
+        for bucket in range(n_buckets):
+            # hash() is UBIGINT, so the modulo is non-negative; skip the filter
+            # entirely for single-bucket agencies to keep their write unchanged.
+            bucket_filter = "" if n_buckets == 1 else f' AND hash("{key}") % {n_buckets} = {bucket}'
+            con.execute(
+                f"""
+                INSERT INTO {dedup_tbl} ({col_list})
+                SELECT {col_list}
+                FROM {tbl}
+                WHERE {where}{bucket_filter}
+                QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY "{key}"
+                    ORDER BY modify_date DESC NULLS LAST
+                ) = 1;
+                """
+            )
 
     after = con.execute(f"SELECT count(*) FROM {dedup_tbl}").fetchone()[0]
 

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -483,6 +483,43 @@ def test_audit_and_dedupe_table(tmp_path, local_catalog) -> None:
     assert kept == "2025-03-09T00:00:00Z"
 
 
+def test_dedupe_table_sub_batches_large_agency(tmp_path, local_catalog, monkeypatch) -> None:
+    """With DEDUP_ROWS_PER_BATCH forcing multiple hash buckets per agency, the
+    rebuild must still collapse to one row per comment_id (keeping the latest
+    modify_date) — bucketing by the key must not drop or duplicate any comment."""
+    con = local_catalog
+    iceberg._ensure_table(con, COMMENT)
+
+    # 20 distinct comments, each seeded twice (a duplicate copy) plus a newer
+    # version of one, so the dedup has real work per bucket.
+    rows = []
+    for i in range(20):
+        rows.append(_comment(f"c{i}", "EPA-1", "EPA", "2025-01-01T00:00:00Z", modify_date="2025-01-01T00:00:00Z"))
+    base = tmp_path / "seed.parquet"
+    pl.DataFrame(rows, schema=COMMENT.schema).write_parquet(base)
+    iceberg.seed_comments_from_parquet(con, str(base), COMMENT)
+    iceberg.seed_comments_from_parquet(con, str(base), COMMENT)  # duplicate every row
+
+    newer = tmp_path / "newer.parquet"
+    pl.DataFrame(
+        [_comment("c0", "EPA-1", "EPA", "2025-06-01T00:00:00Z", modify_date="2025-06-01T00:00:00Z")],
+        schema=COMMENT.schema,
+    ).write_parquet(newer)
+    iceberg.seed_comments_from_parquet(con, str(newer), COMMENT)
+
+    # Force several buckets per agency (41 rows / 5 -> 9 buckets) so the split path runs.
+    monkeypatch.setenv("DEDUP_ROWS_PER_BATCH", "5")
+    before, after = iceberg.dedupe_table(con, COMMENT)
+    assert before == 41  # 20*2 duplicates + 1 newer c0
+    assert after == 20  # one row per distinct comment_id
+
+    assert iceberg.audit_duplicates(con, COMMENT) == []
+    kept = con.execute(
+        f"SELECT modify_date FROM {iceberg._qualified(COMMENT)} WHERE comment_id = 'c0'"
+    ).fetchone()[0]
+    assert kept == "2025-06-01T00:00:00Z"  # newest version survived the bucketed dedup
+
+
 def test_upsert_comment_text_fills_in_place(tmp_path, local_catalog) -> None:
     """upsert_comment_text sets text_content + text_extraction_status for the
     matched rows, preserves other columns, never duplicates rows, and COALESCE


### PR DESCRIPTION
## Summary

The `Dedupe comments catalog (manual)` workflow's `--apply` path OOMs the CI runner, so the historical duplicate rows in the Iceberg `comments` table were never cleaned — which is why `Check comments freshness` has been red every night since 2026-07-08 (its uniqueness branch correctly flags ~60 agencies carrying duplicate `comment_id` rows, worst CFTC 1.55×).

`dedupe_table` rebuilt each agency in a single `INSERT ... QUALIFY ROW_NUMBER() OVER (PARTITION BY comment_id)` statement. Even with `preserve_insertion_order=false`, a memory cap, and on-disk spill (all already set), the largest agencies (ATF ~982k rows, BLM ~850k, …) overflow the runner: the dedup window buffers whole rows — comment `text_content` included — and DuckDB can't spill it under the cap. The apply run dies with `OutOfMemoryException: failed to pin block of size 256.0 KiB (4.6 GiB/4.6 GiB used)` (seen on the 07-04 and again on the 07-17 apply attempts).

This splits each agency into `ceil(rows / DEDUP_ROWS_PER_BATCH)` hash buckets of the dedup key so each window only sees a slice. A key hashes to exactly one bucket and duplicates only ever share a key, so per-bucket dedup equals per-agency equals global dedup — the result is unchanged. Small agencies stay a single write (one bucket), so their behavior and the existing tests are untouched. Batch size is tunable via `DEDUP_ROWS_PER_BATCH` (default 100k).

## Test plan

- [x] `uv run pytest tests/test_iceberg.py` — 20 passed (incl. new multi-bucket test)
- [x] `uv run ruff check` on changed files — all checks passed
- [x] `uv run ty check src/spicy_regs/sources/iceberg.py` — all checks passed
- [x] Added a test that forces multiple buckets per agency (`DEDUP_ROWS_PER_BATCH=5`) and verifies the rebuild still collapses to one row per `comment_id` with the latest `modify_date` kept

Note: the local test catalog is native DuckDB, so it exercises the dedup SQL/logic but not the R2 catalog's memory behavior — the end-to-end OOM fix is verified by re-running the dedup workflow from this branch against the real catalog.

## Checklist

- [x] My change is scoped to one concern
- [x] I added or updated tests for new behavior
- [x] I updated docs (updated the `dedupe_table` docstring reasoning)
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TeRKheCp4z53UB8q9MTr3

---
_Generated by [Claude Code](https://claude.ai/code/session_017TeRKheCp4z53UB8q9MTr3)_