### PR TITLE
perf: make R2 corpus edge-cacheable and prune docket scans

### DIFF
--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -182,11 +182,17 @@ def upload_file(local_path: Path, remote_key: str | None = None) -> None:
     remote_size = _get_remote_size(client, bucket, remote_key)
     _assert_upload_safe(local_size_bytes, remote_size, remote_key)
 
+    # Cache-Control makes the objects eligible for Cloudflare edge caching on
+    # the public custom domain (without it every browser range request pays a
+    # full edge->R2 origin round-trip, measured at ~130-180ms each). The corpus
+    # refreshes roughly daily; max-age bounds staleness after a republish and
+    # stale-while-revalidate keeps the edge fast across the refresh boundary.
+    cache_control = getenv("R2_CACHE_CONTROL", "public, max-age=3600, stale-while-revalidate=86400")
     client.upload_file(
         str(local_path),
         bucket,
         remote_key,
-        ExtraArgs={"ContentType": "application/octet-stream"},
+        ExtraArgs={"ContentType": "application/octet-stream", "CacheControl": cache_control},
     )
 
     public_url = getenv("R2_PUBLIC_URL", "")

--- a/src/spicy_regs/transforms/merge_staging_files.py
+++ b/src/spicy_regs/transforms/merge_staging_files.py
@@ -81,6 +81,13 @@ def merge_staging_files(
         files_sql = ", ".join(f"'{str(p).replace(chr(39), chr(39) * 2)}'" for p in valid_files)
         col_select = ", ".join(f'CAST("{c}" AS VARCHAR) AS "{c}"' for c in target_columns)
 
+        # Cluster the output by docket_id so consumers filtering on it (the UI
+        # docket page reads documents/dockets with `WHERE docket_id = ?` over
+        # HTTP range requests) can prune to a few row groups via the parquet
+        # min/max stats instead of scanning the whole file. Without the sort
+        # every row group spans the full docket_id range and nothing prunes.
+        sort_clause = 'ORDER BY "docket_id"' if "docket_id" in target_columns else ""
+
         query = f"""
         COPY (
             SELECT {col_select}
@@ -89,8 +96,9 @@ def merge_staging_files(
                 PARTITION BY "{key_col}"
                 ORDER BY modify_date DESC NULLS LAST
             ) = 1
+            {sort_clause}
         ) TO '{str(temp_output).replace(chr(39), chr(39) * 2)}'
-        (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 500000);
+        (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 100000);
         """
 
         spill_dir = output_dir / ".duckdb_tmp"


### PR DESCRIPTION
## Summary

Two ETL-side changes that speed up **spicy-regs-ui**, which reads the published R2 corpus directly from the browser via DuckDB-WASM over HTTP range requests. Found via a multi-agent load-time audit of the UI; these are the source-side fixes.

## Changes

**R2 edge caching** (`src/spicy_regs/sources/r2.py`)
- `upload_file` now sets a `Cache-Control` header (overridable via `R2_CACHE_CONTROL`, default `public, max-age=3600, stale-while-revalidate=86400`).
- Without it, every browser range request returns `cf-cache-status: DYNAMIC` and pays a full edge→R2-origin round-trip (**~130–180ms measured**, per request, and DuckDB issues several per file). With it the tiny rollups become edge-cacheable.
- Takes effect as objects are re-uploaded by the daily ETL.

**Docket-scan pruning** (`src/spicy_regs/transforms/merge_staging_files.py`)
- Cluster the merged output by `docket_id` (top-level `ORDER BY`) and shrink `ROW_GROUP_SIZE` 500000 → 100000.
- The UI docket page reads `documents.parquet` (~80MB) and `dockets.parquet` (~14MB) with `WHERE docket_id = ?`. Unsorted, every row group spans the full `docket_id` range, so nothing prunes and the whole file is scanned (**~960ms each, measured**). Sorted, the parquet min/max stats prune to a few row groups.
- Comments do not flow through this merge (only `dockets`/`documents`), so the sort is safe and cheap here.

## Follow-up needed
A **Cloudflare Cache Rule** matching `*.parquet` on the `r2.spicy-regs.dev` custom domain is likely still required to actually cache range requests at the edge — the `Cache-Control` metadata is the prerequisite, not necessarily sufficient on its own for 206 responses.

## Note
The two `TestUploadShrinkGuard` failures seen locally are pre-existing env contamination (`R2_ALLOW_SHRINK=1` in a local `.env`), not caused by this change — verified identical on the unmodified tree.

## Companion PR
UI-side consumption of these gains: ekim1394/spicy-regs-ui#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)