### PR TITLE
fix(congress): drop always-null policy_area (list endpoint omits it)

### DIFF
--- a/data_dictionary/descriptions.yaml
+++ b/data_dictionary/descriptions.yaml
@@ -171,7 +171,6 @@ tables:
       latest_action_text: "Text describing the most recent action on the bill."
       update_date: "Date the Congress.gov record was last updated (ISO 8601 string). Incremental window key."
       url: "Congress.gov API URL for the bill's detail resource."
-      policy_area: "Congress.gov policy-area label for the bill (e.g. `Health`). Often null."
   unified_agenda:
     summary: >-
       One row per Regulation Identifier Number (RIN) per agenda edition, ingested

--- a/docs/tables/congress_bills.md
+++ b/docs/tables/congress_bills.md
@@ -19,4 +19,3 @@ One row per congressional bill, ingested from the Congress.gov v3 REST API (`/bi
 | `latest_action_text` | `VARCHAR` | Text describing the most recent action on the bill. |
 | `update_date` | `VARCHAR` | Date the Congress.gov record was last updated (ISO 8601 string). Incremental window key. |
 | `url` | `VARCHAR` | Congress.gov API URL for the bill's detail resource. |
-| `policy_area` | `VARCHAR` | Congress.gov policy-area label for the bill (e.g. `Health`). Often null. |

--- a/src/spicy_regs/data_dictionary.py
+++ b/src/spicy_regs/data_dictionary.py
@@ -138,7 +138,6 @@ DERIVED_SCHEMAS: dict[str, list[tuple[str, str]]] = {
         ("latest_action_text", "VARCHAR"),
         ("update_date", "VARCHAR"),
         ("url", "VARCHAR"),
-        ("policy_area", "VARCHAR"),
     ],
     # Ingested from reginfo.gov (build_unified_agenda); all columns are stored as
     # VARCHAR, array fields serialized as JSON strings. Keyed by (rin, agenda_edition).

--- a/src/spicy_regs/transforms/build_congress_bills.py
+++ b/src/spicy_regs/transforms/build_congress_bills.py
@@ -1,6 +1,6 @@
 """Transform: build ``congress_bills.parquet`` from the Congress.gov REST API.
 
-Produces an 11-column all-VARCHAR schema keyed on ``bill_id`` (e.g.
+Produces a 10-column all-VARCHAR schema keyed on ``bill_id`` (e.g.
 ``118-hr-1234``), the legislative record complementary to the regulations.gov
 ``dockets``/``documents`` view.
 
@@ -38,8 +38,12 @@ OUTPUT = "congress_bills.parquet"
 # updated after our previous run's cutoff are picked up.
 OVERLAP_DAYS = 3
 
-# The published schema: 11 columns, all VARCHAR, in a fixed order. ``bill_id`` is
+# The published schema: 10 columns, all VARCHAR, in a fixed order. ``bill_id`` is
 # the primary / dedup key.
+#
+# ``policy_area`` is intentionally omitted — the ``/bill`` list endpoint doesn't
+# return it (it's a detail-endpoint-only field); it could be added later via a
+# per-bill detail enrichment pass.
 COLUMNS = (
     "bill_id",
     "congress",
@@ -51,7 +55,6 @@ COLUMNS = (
     "latest_action_text",
     "update_date",
     "url",
-    "policy_area",
 )
 _SCHEMA = pa.schema([(c, pa.string()) for c in COLUMNS])
 
@@ -76,7 +79,6 @@ def _bill_id(doc: dict) -> str | None:
 def _shape(doc: dict) -> dict:
     """Map one raw Congress.gov bill onto the published column shape."""
     latest_action = doc.get("latestAction") or {}
-    policy_area = doc.get("policyArea") or {}
     return {
         "bill_id": _bill_id(doc),
         "congress": _s(doc.get("congress")),
@@ -88,7 +90,6 @@ def _shape(doc: dict) -> dict:
         "latest_action_text": latest_action.get("text"),
         "update_date": doc.get("updateDate"),
         "url": doc.get("url"),
-        "policy_area": policy_area.get("name"),
     }
 
 

--- a/tests/test_congress_bills.py
+++ b/tests/test_congress_bills.py
@@ -25,14 +25,14 @@ _RAW_BILL = {
     "latestAction": {"actionDate": "2024-03-01", "text": "Referred to committee."},
     "updateDate": "2024-03-05",
     "url": "https://api.congress.gov/v3/bill/118/hr/1234?format=json",
-    "policyArea": {"name": "Health"},
 }
 
 
 def test_shape_produces_exact_schema():
     row = _shape(_RAW_BILL)
-    # Every published column present, and nothing extra.
+    # Every published column present, and nothing extra (10-column schema).
     assert set(row) == set(COLUMNS)
+    assert len(COLUMNS) == 10
 
 
 def test_shape_maps_and_serializes_fields():
@@ -44,11 +44,10 @@ def test_shape_maps_and_serializes_fields():
     assert row["bill_number"] == "1234"  # int stringified
     assert row["title"] == "A Bill To Do A Thing"
     assert row["origin_chamber"] == "House"
-    # Nested latestAction / policyArea are flattened.
+    # Nested latestAction is flattened.
     assert row["latest_action_date"] == "2024-03-01"
     assert row["latest_action_text"] == "Referred to committee."
     assert row["update_date"] == "2024-03-05"
-    assert row["policy_area"] == "Health"
 
 
 def test_shape_handles_missing_nested_and_scalars():
@@ -57,7 +56,6 @@ def test_shape_handles_missing_nested_and_scalars():
     # Missing nested objects degrade to null, not KeyError.
     assert row["latest_action_date"] is None
     assert row["latest_action_text"] is None
-    assert row["policy_area"] is None
     assert row["origin_chamber"] is None
 
 


### PR DESCRIPTION
## What
Removes the `policy_area` column from the `congress_bills` corpus everywhere it's declared:
- `transforms/build_congress_bills.py` — dropped from the `COLUMNS` tuple and the `_shape` mapping (added a note explaining the omission); schema is now 10 columns.
- `data_dictionary.py` — removed the `("policy_area", "VARCHAR")` entry from `DERIVED_SCHEMAS["congress_bills"]`.
- `data_dictionary/descriptions.yaml` — removed the `policy_area:` description.
- `docs/tables/congress_bills.md` — regenerated via `spicy-regs-dict generate` (policy_area row gone).
- `tests/test_congress_bills.py` — dropped `policyArea` from the fixture and the two assertions; the shaped row is now asserted against the trimmed 10-column schema.

## Why
`policy_area` was **always NULL**. The Congress.gov `/bill` LIST endpoint doesn't return `policyArea` — it's only present on the per-bill *detail* endpoint. Populating it would require an N+1 detail fetch across hundreds of thousands of bills, which the ingest deliberately avoids (list-level only, no N+1). Rather than publish a permanently-null column, we drop it.

It can be re-added later via a dedicated per-bill detail enrichment pass (noted in the transform's `COLUMNS` comment).

## Validation
- `ruff check .` — clean
- `spicy-regs-dict check` — passes (every column described, none extra)
- `spicy-regs-dict generate` — docs regenerated
- `pytest tests/test_congress_bills.py tests/test_mcp_server.py tests/test_data_dictionary.py` — 44 passed, 1 deselected

The reader (`sources/congress_bills.py`) was left unchanged — it never handled `policyArea`.