### PR TITLE
fix(cfr): use GovInfo /published endpoint + derive section fields from IDs

### DIFF
--- a/src/spicy_regs/sources/cfr_sections.py
+++ b/src/spicy_regs/sources/cfr_sections.py
@@ -2,17 +2,18 @@
 
 Brings CFR *structure* ingestion in-repo. The CFR is the codified, subject-organized
 body of federal regulations; this reader yields one raw record per CFR *granule*
-(a section-level unit within a title's annual edition) so downstream consumers can
-join regulations.gov activity and Federal Register citations to the codified rules
-they touch.
+(a structural unit — section, appendix, node, TOC, … — within a title's annual
+edition) so downstream consumers can join regulations.gov activity and Federal
+Register citations to the codified rules they touch.
 
-The reader is a *pure source*: it yields raw GovInfo granule/summary payloads
-(dicts) roughly as the API returns them, plus the enclosing ``package_id``.
+The reader is a *pure source*: it yields raw GovInfo granule payloads (dicts)
+roughly as the API returns them, plus the enclosing package's ``_package_id`` /
+``_package_last_modified`` / ``_package_title`` (stamped onto each granule).
 Shaping them into the published all-VARCHAR schema is the job of
 :func:`~spicy_regs.transforms.build_cfr_sections.build_cfr_sections`.
 
 Scope — SECTION METADATA + CITATIONS ONLY, *not* full section text.
-    We collect each section's identity and citation (title / part / section /
+    We collect each granule's identity and citation (title / part / section /
     heading / CFR reference / structure level / edition + last-modified stamps +
     canonical URL). The full regulatory *text* of each section is far heavier
     (hundreds of MB per title-year of XML/HTML) and is deliberately **out of
@@ -27,14 +28,21 @@ API key.
     reader logs a clear warning and yields nothing, so a keyless CI run is a
     no-op rather than a crash.
 
-IMPORTANT — traversal requires live validation with a key.
-    The exact GovInfo package → granule → summary traversal (offset/pageSize
-    paging shapes, the precise field names on a granule *summary*, and how the
-    section citation is expressed) is documented from GovInfo's public API docs
-    but has **not** been exercised against the live service in this pass. The
-    endpoints below are captured as named constants and the field mapping lives
-    in the transform's ``_shape``; both should be confirmed against a real key
-    before enabling the R2 upload. All tests here are hermetic (no network).
+Traversal (live-validated).
+    Package listing uses the ``/published/{START}/{END}?collection=CFR`` endpoint
+    (``/collections/CFR`` alone 500s — do not use it). START/END are dates in
+    ``yyyy-MM-dd`` form; the API rejects the ``…THH:mm:ssZ`` datetime form. Each
+    package carries ``packageId`` / ``lastModified`` / ``title``. Granules come
+    from ``/packages/{packageId}/granules``. Both endpoints page via
+    ``offset`` + ``pageSize`` and signal more with ``nextPage``.
+
+    Everything the published schema needs is derived from **list-level** fields
+    plus the ID grammar — we deliberately do **not** call the per-granule
+    ``/summary`` endpoint (the only place ``cfrTitle`` / ``cfrPart`` / ``heading``
+    live), because that is an N+1 fetch across thousands of granules per package.
+    Granule IDs look like ``CFR-2024-title48-vol5-chap7-appA`` (edition year, CFR
+    title number, and — for many granules — ``part`` / ``sec`` tokens); the
+    transform's ``_shape`` parses them.
 
     Reference: https://api.govinfo.gov/docs/ and the keyless bulkdata mirror at
     https://www.govinfo.gov/bulkdata/CFR (an alternative that needs no key but
@@ -43,6 +51,7 @@ IMPORTANT — traversal requires live validation with a key.
 
 from __future__ import annotations
 
+import datetime as dt
 import os
 import time
 from collections.abc import Iterator
@@ -52,18 +61,17 @@ from loguru import logger
 
 from spicy_regs.sources.base import Reader
 
-# Primary (keyed) GovInfo API. Traversal: collections/CFR -> packages ->
-# granules -> granule summary. See module docstring: shapes need live validation.
+# Primary (keyed) GovInfo API. Traversal: /published (packages) -> /packages/{id}/granules.
 API_BASE = "https://api.govinfo.gov"
 
 # Keyless alternative (per-title-year bulk XML). Documented for operators; this
 # reader targets the keyed API above. See module docstring.
 BULKDATA_BASE = "https://www.govinfo.gov/bulkdata/CFR"
 
-# The CFR collection code in the GovInfo collections API.
+# The CFR collection code in the GovInfo published/collections API.
 COLLECTION = "CFR"
 
-# Max records the collections/granules endpoints accept per page.
+# Max records the published/granules endpoints accept per page.
 PAGE_SIZE = 100
 
 # api.data.gov env var fallback chain — the same key powers all three services.
@@ -92,9 +100,14 @@ def _resolve_api_key() -> str | None:
 class CfrSectionsReader(Reader):
     """Yields raw GovInfo CFR granule dicts for editions in ``[since_year, until_year]``.
 
-    Each yielded dict carries the granule's own fields plus the enclosing
-    ``_package_id`` (and, when a per-granule summary was fetched, its fields
-    merged in). The transform maps these onto the published all-VARCHAR schema.
+    Each yielded dict carries the granule's own list-level fields plus the
+    enclosing package's ``_package_id`` / ``_package_last_modified`` /
+    ``_package_title``. The transform maps these onto the published all-VARCHAR
+    schema, deriving the CFR title/part/section from the granule ID grammar.
+
+    CFR editions are annual, so the default window is *last year through this
+    year* (``since_year = current_year - 1``, ``until_year = current_year``); a
+    full backfill passes an early ``since_year``.
 
     With no api.data.gov key resolvable from the environment the reader logs a
     warning and yields nothing — a keyless run (e.g. CI) is a no-op, not a crash.
@@ -109,8 +122,9 @@ class CfrSectionsReader(Reader):
         page_size: int = PAGE_SIZE,
         verbose: bool = False,
     ) -> None:
-        self.since_year = since_year
-        self.until_year = until_year
+        current_year = dt.date.today().year
+        self.until_year = until_year if until_year is not None else current_year
+        self.since_year = since_year if since_year is not None else current_year - 1
         self.api_key = api_key if api_key is not None else _resolve_api_key()
         self.page_size = page_size
         self.verbose = verbose
@@ -128,41 +142,51 @@ class CfrSectionsReader(Reader):
         logger.info("CFR: fetching {} granules (editions {}..{})", COLLECTION, self.since_year, self.until_year)
         with httpx.Client(timeout=_TIMEOUT, headers={"Accept": "application/json"}) as client:
             self._client = client
-            for package_id in self._iter_package_ids():
-                yield from self._iter_granules(package_id)
+            for package in self._iter_packages():
+                yield from self._iter_granules(package)
         logger.info("CFR: yielded {:,} granules", self._seen)
 
-    # -- traversal (shapes require live validation; see module docstring) ------
+    # -- traversal (live-validated; see module docstring) ----------------------
 
-    def _iter_package_ids(self) -> Iterator[str]:
-        """Page the collections/CFR endpoint, yielding CFR package ids.
+    def _iter_packages(self) -> Iterator[dict]:
+        """Page the ``/published/{START}/{END}?collection=CFR`` endpoint.
 
-        NOTE: exact response shape (``packages[].packageId``, ``nextPage``) is
-        from GovInfo's public docs and needs live validation with a key.
+        Yields one small dict per CFR package with ``packageId``, ``lastModified``
+        and ``title`` so the transform can populate ``last_modified`` without an
+        extra per-package call. START/END are ``yyyy-MM-dd`` (the API rejects the
+        ``…THH:mm:ssZ`` datetime form).
         """
+        start = f"{self.since_year}-01-01"
+        end = f"{self.until_year}-12-31"
+        url = f"{API_BASE}/published/{start}/{end}"
         offset = 0
         while True:
-            payload = self._get(
-                f"{API_BASE}/collections/{COLLECTION}",
-                {"offset": offset, "pageSize": self.page_size},
-            )
+            payload = self._get(url, {"collection": COLLECTION, "offset": offset, "pageSize": self.page_size})
             if payload is None:
                 return
             packages = payload.get("packages") or []
             for pkg in packages:
-                package_id = pkg.get("packageId") if isinstance(pkg, dict) else None
+                if not isinstance(pkg, dict):
+                    continue
+                package_id = pkg.get("packageId")
                 if package_id:
-                    yield package_id
+                    yield {
+                        "packageId": package_id,
+                        "lastModified": pkg.get("lastModified"),
+                        "title": pkg.get("title"),
+                    }
             if not payload.get("nextPage") or not packages:
                 return
             offset += self.page_size
 
-    def _iter_granules(self, package_id: str) -> Iterator[dict]:
+    def _iter_granules(self, package: dict) -> Iterator[dict]:
         """Page one package's granules, yielding raw granule dicts.
 
-        NOTE: exact response shape (``granules[].granuleId``, ``nextPage``) is
-        from GovInfo's public docs and needs live validation with a key.
+        Each granule is stamped with ``_package_id`` / ``_package_last_modified``
+        / ``_package_title`` from the enclosing package so the transform never
+        needs a second lookup.
         """
+        package_id = package["packageId"]
         offset = 0
         while True:
             payload = self._get(
@@ -175,7 +199,12 @@ class CfrSectionsReader(Reader):
             for granule in granules:
                 if not isinstance(granule, dict):
                     continue
-                granule = {**granule, "_package_id": package_id}
+                granule = {
+                    **granule,
+                    "_package_id": package_id,
+                    "_package_last_modified": package.get("lastModified"),
+                    "_package_title": package.get("title"),
+                }
                 self._seen += 1
                 if self._seen % _PROGRESS_EVERY == 0:
                     logger.info("CFR: {:,} granules so far...", self._seen)

--- a/src/spicy_regs/transforms/build_cfr_sections.py
+++ b/src/spicy_regs/transforms/build_cfr_sections.py
@@ -21,13 +21,21 @@ Instead we:
 With no prior table (first run) step 2 becomes a full backfill. Incremental
 freshness is driven by ``edition_year`` / ``last_modified``.
 
-IMPORTANT: the GovInfo granule → summary field mapping in ``_shape`` is captured
-from GovInfo's public API docs but has **not** been validated against the live
-service; confirm it with a real api.data.gov key before enabling R2 upload.
+Field derivation (live-validated, no N+1). ``_shape`` derives every published
+column from the granule's **list-level** fields plus the ID grammar — it never
+calls the per-granule ``/summary`` endpoint (the only place ``cfrTitle`` /
+``cfrPart`` / ``heading`` live), which would be an N+1 fetch across thousands of
+granules per package. CFR title comes from the ``title(\\d+)`` token in the
+package/granule ID, edition year from the ``CFR-(\\d{4})`` token, and part /
+section from the ``part(\\d+)`` / ``sec(…)`` tokens on the granule ID (both
+nullable — section granularity varies by CFR title, so ``section`` is often
+null; some titles express sections as ``CONTENT`` granules with no ``part``
+token, leaving ``part`` null too).
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pyarrow as pa
@@ -66,39 +74,67 @@ def _s(value: object) -> str | None:
 
 def _cfr_ref(title: object, part: object, section: object) -> str | None:
     """Compose a compact CFR citation like ``40-60.1`` from title/part/section."""
-    if title is None:
+    if title is None or part is None:
         return None
-    if part is None:
-        return _s(title)
     if section is None:
         return f"{title}-{part}"
     return f"{title}-{part}.{section}"
 
 
-def _shape(granule: dict) -> dict:
-    """Map one raw GovInfo CFR granule (+ merged summary) onto the published shape.
+# ID-grammar parsers. GovInfo CFR IDs look like:
+#   package: CFR-2024-title48-vol5
+#   granule: CFR-2024-title48-vol5-chap7-appA / …-part700 / …-sec60-1
+# Everything the schema needs is derivable from these tokens — no /summary call.
+_EDITION_RE = re.compile(r"CFR-(\d{4})")
+_TITLE_RE = re.compile(r"title(\d+)")
+_PART_RE = re.compile(r"part(\d+)")
+_SECTION_RE = re.compile(r"sec([\w.-]+)")
 
-    NOTE: field names below are from GovInfo's public API docs and need live
-    validation with a key (see module docstring). We read defensively so an
-    unexpected shape yields NULLs rather than raising.
+
+def _first(pattern: re.Pattern[str], text: str | None) -> str | None:
+    """Return the first capture group of ``pattern`` in ``text``, else None."""
+    if not text:
+        return None
+    match = pattern.search(text)
+    return match.group(1) if match else None
+
+
+def _shape(granule: dict) -> dict:
+    """Map one raw GovInfo CFR granule onto the published all-VARCHAR shape.
+
+    Derives everything from **list-level** fields + the ID grammar (no per-granule
+    ``/summary`` call — see module docstring). Reads defensively so an unexpected
+    shape yields NULLs rather than raising.
     """
-    # GovInfo's granule ``title`` field is the section *heading* text; the CFR
-    # title *number* comes from ``cfrTitle`` (falling back to ``titleNumber``).
-    title_num = granule.get("cfrTitle") or granule.get("titleNumber")
-    part = granule.get("cfrPart") or granule.get("part")
-    section = granule.get("cfrSection") or granule.get("section")
+    granule_id = _s(granule.get("granuleId"))
+    package_id = _s(granule.get("_package_id") or granule.get("packageId"))
+
+    # CFR title number + edition year: prefer the package id (always well-formed),
+    # fall back to the granule id, then dateIssued's leading year for the edition.
+    id_for_meta = package_id or granule_id
+    edition_year = _first(_EDITION_RE, id_for_meta)
+    if edition_year is None:
+        date_issued = _s(granule.get("dateIssued"))
+        edition_year = date_issued[:4] if date_issued else None
+    title_num = _first(_TITLE_RE, id_for_meta)
+
+    # Part / section from the granule id (both nullable — see module docstring).
+    part = _first(_PART_RE, granule_id)
+    section = _first(_SECTION_RE, granule_id)
+
     return {
-        "granule_id": _s(granule.get("granuleId")),
-        "package_id": _s(granule.get("_package_id") or granule.get("packageId")),
+        "granule_id": granule_id,
+        "package_id": package_id,
         "cfr_ref": _cfr_ref(title_num, part, section),
-        "title": _s(title_num),
-        "part": _s(part),
-        "section": _s(section),
-        "heading": granule.get("heading") or granule.get("title"),
-        "structure_level": _s(granule.get("granuleClass") or granule.get("structureLevel")),
-        "edition_year": _s(granule.get("editionYear") or granule.get("dateIssued")),
-        "last_modified": _s(granule.get("lastModified") or granule.get("dateModified")),
-        "url": _s(granule.get("detailsLink") or granule.get("granuleLink")),
+        "title": title_num,
+        "part": part,
+        "section": section,
+        # The granule list-level ``title`` field is the heading text.
+        "heading": _s(granule.get("title")),
+        "structure_level": _s(granule.get("granuleClass")),
+        "edition_year": edition_year,
+        "last_modified": _s(granule.get("_package_last_modified") or granule.get("lastModified")),
+        "url": f"https://www.govinfo.gov/app/details/{package_id}/{granule_id}" if package_id and granule_id else None,
     }
 
 

--- a/tests/test_cfr_sections.py
+++ b/tests/test_cfr_sections.py
@@ -1,26 +1,56 @@
 """Hermetic tests for the GovInfo CFR section ingest (no network).
 
-Covers the two pieces with real logic: the api.data.gov key resolution fallback
-chain, the reader's keyless no-op behavior, and the raw-granule → published-schema
-mapping (``_shape``). No live network calls are made.
+Covers the pieces with real logic: the api.data.gov key resolution fallback
+chain, the reader's keyless no-op behavior + default edition window, and the
+raw-granule → published-schema mapping (``_shape``), which derives CFR
+title/part/section purely from the granule ID grammar + list-level fields (no
+per-granule ``/summary`` call). No live network calls are made.
 """
 
 from __future__ import annotations
 
+import datetime as dt
+
 from spicy_regs.sources.cfr_sections import API_KEY_ENV_VARS, CfrSectionsReader, _resolve_api_key
 from spicy_regs.transforms.build_cfr_sections import COLUMNS, _cfr_ref, _shape
 
-_RAW_GRANULE = {
-    "granuleId": "CFR-2024-title40-vol9-sec60-1",
-    "_package_id": "CFR-2024-title40-vol9",
-    "cfrTitle": 40,
-    "cfrPart": 60,
-    "cfrSection": "1",
-    "heading": "Applicability and designation of affected facility.",
-    "granuleClass": "SECTION",
-    "editionYear": 2024,
-    "lastModified": "2024-01-05T12:00:00Z",
-    "detailsLink": "https://api.govinfo.gov/packages/CFR-2024-title40-vol9/granules/CFR-2024-title40-vol9-sec60-1/summary",
+# A CONTENT/section granule with real list-level fields + package stamps, using
+# the real GovInfo ID grammar. Note: no cfrTitle/cfrPart/cfrSection fields exist
+# on list-level granules — everything is parsed from the IDs.
+_SECTION_GRANULE = {
+    "granuleId": "CFR-2024-title40-vol1-sec1-1",
+    "granuleClass": "CONTENT",
+    "title": "Definitions.",
+    "dateIssued": "2024-07-01",
+    "granuleLink": "https://api.govinfo.gov/packages/CFR-2024-title40-vol1/granules/CFR-2024-title40-vol1-sec1-1/summary",
+    "_package_id": "CFR-2024-title40-vol1",
+    "_package_last_modified": "2026-07-16T20:57:39Z",
+    "_package_title": "Protection of Environment",
+}
+
+# A part-level CONTENT granule (part token present, no section).
+_PART_GRANULE = {
+    "granuleId": "CFR-2024-title48-vol5-part700",
+    "granuleClass": "CONTENT",
+    "title": "Reserved",
+    "_package_id": "CFR-2024-title48-vol5",
+    "_package_last_modified": "2026-01-02T00:00:00Z",
+}
+
+# A chapter appendix granule (part token present via app parent, section absent).
+_APPENDIX_GRANULE = {
+    "granuleId": "CFR-2024-title48-vol1-part3-app1",
+    "granuleClass": "APPENDIX",
+    "title": "Cost Accounting Standards.",
+    "_package_id": "CFR-2024-title48-vol1",
+}
+
+# A NODE granule (chapter) — no part, no section.
+_NODE_GRANULE = {
+    "granuleId": "CFR-2024-title48-vol5-chap7",
+    "granuleClass": "NODE",
+    "title": "AGENCY FOR INTERNATIONAL DEVELOPMENT",
+    "_package_id": "CFR-2024-title48-vol5",
 }
 
 
@@ -67,46 +97,105 @@ def test_reader_keyless_is_noop(monkeypatch):
     assert list(reader.iter_records()) == []
 
 
+def test_reader_default_edition_window():
+    """Default window is last-year..this-year (CFR editions are annual)."""
+    reader = CfrSectionsReader(api_key="x")
+    this_year = dt.date.today().year
+    assert reader.until_year == this_year
+    assert reader.since_year == this_year - 1
+
+
 # -- raw granule -> published schema mapping ----------------------------------
 
 
 def test_shape_produces_exact_schema():
-    row = _shape(_RAW_GRANULE)
+    row = _shape(_SECTION_GRANULE)
     assert set(row) == set(COLUMNS)
 
 
-def test_shape_maps_and_stringifies_fields():
-    row = _shape(_RAW_GRANULE)
-    assert row["granule_id"] == "CFR-2024-title40-vol9-sec60-1"
-    assert row["package_id"] == "CFR-2024-title40-vol9"
-    # Numeric title/part stringify (schema is all-VARCHAR).
+def test_shape_parses_section_granule():
+    row = _shape(_SECTION_GRANULE)
+    assert row["granule_id"] == "CFR-2024-title40-vol1-sec1-1"
+    assert row["package_id"] == "CFR-2024-title40-vol1"
+    # CFR title number parsed from the id, not the (heading) ``title`` field.
     assert row["title"] == "40"
-    assert row["part"] == "60"
-    assert row["section"] == "1"
-    assert row["heading"] == "Applicability and designation of affected facility."
-    assert row["structure_level"] == "SECTION"
     assert row["edition_year"] == "2024"
-    assert row["last_modified"] == "2024-01-05T12:00:00Z"
-    assert row["url"].endswith("/summary")
+    # This title expresses sections as CONTENT granules with no ``part`` token.
+    assert row["part"] is None
+    assert row["section"] == "1-1"
+    assert row["heading"] == "Definitions."
+    assert row["structure_level"] == "CONTENT"
+    # last_modified comes from the enclosing package stamp.
+    assert row["last_modified"] == "2026-07-16T20:57:39Z"
+    # Canonical govinfo details URL built from package + granule ids.
+    assert row["url"] == "https://www.govinfo.gov/app/details/CFR-2024-title40-vol1/CFR-2024-title40-vol1-sec1-1"
 
 
-def test_shape_composes_cfr_ref():
-    row = _shape(_RAW_GRANULE)
-    assert row["cfr_ref"] == "40-60.1"
+def test_shape_parses_part_granule():
+    row = _shape(_PART_GRANULE)
+    assert row["title"] == "48"
+    assert row["part"] == "700"
+    assert row["section"] is None
+    assert row["cfr_ref"] == "48-700"
+    assert row["structure_level"] == "CONTENT"
+    assert row["edition_year"] == "2024"
+
+
+def test_shape_parses_appendix_granule():
+    row = _shape(_APPENDIX_GRANULE)
+    assert row["title"] == "48"
+    assert row["part"] == "3"
+    assert row["section"] is None
+    assert row["cfr_ref"] == "48-3"
+    assert row["structure_level"] == "APPENDIX"
+
+
+def test_shape_node_granule_has_no_part_or_section():
+    row = _shape(_NODE_GRANULE)
+    assert row["title"] == "48"
+    assert row["part"] is None
+    assert row["section"] is None
+    # No part -> no cfr_ref.
+    assert row["cfr_ref"] is None
+    assert row["structure_level"] == "NODE"
+
+
+def test_shape_edition_year_falls_back_to_date_issued():
+    row = _shape({"granuleId": "weird-id", "dateIssued": "2019-03-04"})
+    assert row["edition_year"] == "2019"
+
+
+def test_shape_cfr_ref_full_citation():
+    # A section granule that also carries a part token yields a full title-part.section ref.
+    row = _shape(
+        {
+            "granuleId": "CFR-2024-title21-vol1-part1-sec5",
+            "granuleClass": "SECTION",
+            "_package_id": "CFR-2024-title21-vol1",
+        }
+    )
+    assert row["title"] == "21"
+    assert row["part"] == "1"
+    assert row["section"] == "5"
+    assert row["cfr_ref"] == "21-1.5"
 
 
 def test_cfr_ref_degrades_gracefully():
-    # Full citation, part-only, title-only, and empty.
-    assert _cfr_ref(40, 60, "1") == "40-60.1"
-    assert _cfr_ref(40, 60, None) == "40-60"
-    assert _cfr_ref(40, None, None) == "40"
+    # Full citation, part-only, then null when title or part is missing.
+    assert _cfr_ref("40", "60", "1") == "40-60.1"
+    assert _cfr_ref("40", "60", None) == "40-60"
+    assert _cfr_ref("40", None, None) is None
     assert _cfr_ref(None, None, None) is None
 
 
 def test_shape_handles_missing_fields():
     row = _shape({"granuleId": "x"})
     assert row["granule_id"] == "x"
+    assert row["package_id"] is None
     assert row["cfr_ref"] is None
     assert row["title"] is None
+    assert row["part"] is None
+    assert row["section"] is None
     assert row["heading"] is None
+    # No package id -> no canonical url.
     assert row["url"] is None


### PR DESCRIPTION
## What

Fixes the `cfr_sections` source, whose GovInfo endpoint and field-shaping were wrong.

- **Endpoint:** `_iter_package_ids` pointed at `/collections/CFR`, which **500s** on the live service. Replaced with `/published/{START}/{END}?collection=CFR` (`_iter_packages`), paging via `offset`/`pageSize` + `nextPage`. START/END are built from `since_year`/`until_year` as `yyyy-MM-dd` — the API **rejects** the `…THH:mm:ssZ` datetime form (`{"message":"Use proper date format: yyyy-MM-dd'T'HH:mm:ss'Z' or yyyy-MM-dd"}`). Default window is last-year..this-year (CFR editions are annual); a full backfill passes an early `since_year`.
- **No N+1:** the old `_shape` read `cfrTitle`/`cfrPart`/`cfrSection`/`heading`, which **do not exist** on list-level granules — they only appear on the per-granule `/summary` endpoint (an N+1 across thousands of granules per package). Rewrote `_shape` to derive every column from **list-level fields + the ID grammar**:
  - `edition_year` ← `CFR-(\d{4})`, `title` ← `title(\d+)` (from package id)
  - `part` ← `part(\d+)`, `section` ← `sec([\w.-]+)` (from granule id; both nullable)
  - `heading` ← granule list `title`, `structure_level` ← `granuleClass`
  - `last_modified` ← package `lastModified` (stamped onto each granule, no extra call)
  - `url` ← `https://www.govinfo.gov/app/details/{package_id}/{granule_id}`
  - `cfr_ref` ← `{title}-{part}[.{section}]`, null when no part.
- Packages now carry `lastModified`/`title` through to the transform; granules are stamped `_package_id` / `_package_last_modified` / `_package_title`.

Same **11-column all-VARCHAR schema** (data dictionary unchanged). Docstrings updated to drop the "traversal needs live validation" caveat.

## Why

`/collections/CFR` 500s and the granule *list* payload has no `cfrTitle`/`cfrPart`/`cfrSection`/`heading` — so the prior code would have produced all-null title/part/section/heading even once the endpoint worked. Deriving from IDs avoids an N+1 `/summary` fetch entirely.

## Live validation (api.data.gov key, `since_year=2024, until_year=2024`)

First granules of `CFR-2024-title48-vol5`:

```
granule_id                              cfr_ref  title part section structure_level  heading
CFR-2024-title48-vol5-toc-id2           null     48    null null    TOC              Table Of Contents
CFR-2024-title48-vol5-chap7             null     48    null null    NODE             AGENCY FOR INTERNATIONAL DEVELOPMENT
CFR-2024-title48-vol5-chap7-appA        null     48    null null    APPENDIX         [Reserved]
CFR-2024-title48-vol5-part700           48-700   48    700  null    CONTENT          Reserved
CFR-2024-title48-vol5-part701           48-701   48    701  null    NODE             FEDERAL ACQUISITION REGULATION SYSTEM
```

`edition_year=2024`, `last_modified=2026-07-16T20:57:39Z` (from package stamp), `url=https://www.govinfo.gov/app/details/CFR-2024-title48-vol5/…` all populate. No `/summary` calls made.

## Tests

`uv run pytest -q tests/test_cfr_sections.py tests/test_mcp_server.py tests/test_data_dictionary.py` → **49 passed, 1 deselected**. `ruff check .` clean; `spicy-regs-dict check` passes.

## Caveats

- **Section granularity varies by CFR title.** Structural granules (TOC/NODE/APPENDIX) have no part/section; some titles express sections as `CONTENT` granules with IDs like `-sec1-1` and **no `part` token**, so `part` (and thus `cfr_ref`) is null for those — `section` is populated but `cfr_ref` requires a part. This is expected given list-level-only derivation.