### PR TITLE
fix(unified-agenda): fetch+parse the real REGINFO_RIN_DATA XML export

### DIFF
--- a/src/spicy_regs/sources/unified_agenda.py
+++ b/src/spicy_regs/sources/unified_agenda.py
@@ -9,32 +9,60 @@ the upstream, forward-looking view of the rulemaking lifecycle: it lists actions
 that are *planned* long before any proposed or final rule reaches the Federal
 Register or opens a comment period on regulations.gov.
 
-The reader is a *pure source*: it yields raw Unified Agenda entry payloads (dicts)
-exactly as reginfo.gov returns them. Shaping them into the published 17-column
-schema is the job of
-:func:`~spicy_regs.transforms.build_unified_agenda.build_unified_agenda`.
+The reader is a *pure source*: it yields one dict per RIN record, with keys
+normalized to what :func:`~spicy_regs.transforms.build_unified_agenda._shape`
+reads. Shaping those dicts into the published 17-column schema is the job of
+that transform.
 
-reginfo.gov exposes the Unified Agenda through a public XML/JSON export keyed by
-"agenda edition" (e.g. ``202404`` for the Spring 2024 edition). No API key is
+Source of truth — the per-edition XML export
+--------------------------------------------
+reginfo.gov publishes each agenda edition as a single machine-readable XML file
+downloaded through ``XMLViewFileAction``::
+
+    https://www.reginfo.gov/public/do/XMLViewFileAction?f=REGINFO_RIN_DATA_{EDITION}.xml
+
+where ``EDITION`` is ``YYYYMM`` with MM in {04 (Spring), 10 (Fall)} — e.g.
+``REGINFO_RIN_DATA_202510.xml`` (Fall 2025), ``REGINFO_RIN_DATA_202410.xml``
+(Fall 2024). (One legacy file is ``REGINFO_RIN_DATA_2012.xml``.) No API key is
 required; reginfo.gov is fully open.
 
-.. important::
-   **The exact reginfo.gov endpoint/params require live validation against
-   reginfo.gov with a real run.** The base URL and request parameters below are
-   encoded as clearly-named module constants precisely so a human can confirm
-   and adjust them once against the live service. The publicly documented export
-   lives under ``https://www.reginfo.gov/public/do/eAgendaXmlReport`` (the
-   "Agenda XML Report"); the pagination shape reginfo.gov uses for large editions
-   is likewise unverified here. Every network path is exercised only through
-   ``httpx`` with the constants below, and the tests are hermetic (no network),
-   so validating later is a matter of confirming these constants and the
-   response-envelope keys (:data:`_RESULTS_KEY`, :data:`_COUNT_KEY`,
-   :data:`_NEXT_KEY`) against a real response.
+.. note::
+   The older ``eAgendaXmlReport`` endpoint returns the **HTML listing page**, not
+   data — it is not a machine-readable export. ``XMLViewFileAction`` is the real
+   export and is what this reader fetches.
+
+Each file is a single ``<REGINFO_RIN_DATA>`` root containing many ``<RIN_INFO>``
+records. Files run to tens of MB, so the reader stream-parses with
+:func:`xml.etree.ElementTree.iterparse` and clears each record (and the root's
+accumulated child shells) as it goes, keeping memory bounded regardless of file
+size. Observed per-record structure (see ``_normalize``)::
+
+    <RIN_INFO>
+      <RIN>0503-AA80</RIN>
+      <PUBLICATION><PUBLICATION_ID>202410</PUBLICATION_ID>...</PUBLICATION>
+      <AGENCY><CODE>0503</CODE><NAME>...</NAME><ACRONYM>AgSEC</ACRONYM></AGENCY>
+      <PARENT_AGENCY>...</PARENT_AGENCY>
+      <RULE_TITLE>...</RULE_TITLE>
+      <ABSTRACT>...</ABSTRACT>
+      <PRIORITY_CATEGORY>...</PRIORITY_CATEGORY>
+      <RIN_STATUS>...</RIN_STATUS>
+      <RULE_STAGE>...</RULE_STAGE>
+      <MAJOR>No</MAJOR>
+      <CFR_LIST><CFR>7 CFR 1.900-1.903</CFR>...</CFR_LIST>
+      <LEGAL_AUTHORITY_LIST><LEGAL_AUTHORITY>5 U.S.C. 301</LEGAL_AUTHORITY>...</LEGAL_AUTHORITY_LIST>
+      <TIMETABLE_LIST>
+        <TIMETABLE><TTBL_ACTION>...</TTBL_ACTION><TTBL_DATE>11/20/2024</TTBL_DATE>
+                   <FR_CITATION>89 FR 91529</FR_CITATION></TIMETABLE>
+        ...
+      </TIMETABLE_LIST>
+    </RIN_INFO>
 """
 
 from __future__ import annotations
 
+import io
 import time
+import xml.etree.ElementTree as ET
 from collections.abc import Iterator
 
 import httpx
@@ -43,44 +71,33 @@ from loguru import logger
 from spicy_regs.sources.base import Reader
 
 # --------------------------------------------------------------------------- #
-# Endpoint constants — REQUIRE LIVE VALIDATION against reginfo.gov (see module
-# docstring). Grouped here so a human can confirm/adjust them in one place.
+# Endpoint constants — validated live against reginfo.gov (public, no API key).
 # --------------------------------------------------------------------------- #
 API_BASE = "https://www.reginfo.gov/public/do"
 
-# The Unified Agenda XML/JSON export endpoint. reginfo.gov publishes the agenda
-# as the "Agenda XML Report"; we request the JSON rendition where available.
-AGENDA_ENDPOINT = f"{API_BASE}/eAgendaXmlReport"
+# The per-edition Unified Agenda XML export. ``{edition}`` is YYYYMM; the file
+# name pattern is REGINFO_RIN_DATA_{edition}.xml served through XMLViewFileAction.
+XML_EXPORT_ENDPOINT = f"{API_BASE}/XMLViewFileAction"
+XML_FILE_TEMPLATE = "REGINFO_RIN_DATA_{edition}.xml"
 
-# Query-parameter names reginfo.gov uses to scope the export. Unverified — a
-# human validating against the live service should confirm these keys.
-PARAM_EDITION = "agendaEditionId"  # e.g. "202404" (Spring 2024)
-PARAM_OUTPUT = "output"  # request JSON rather than raw XML where supported
-
-# Response-envelope keys. Unverified against a live payload; kept as constants so
-# validation is a one-line change rather than a code hunt.
-_RESULTS_KEY = "results"
-_COUNT_KEY = "count"
-_NEXT_KEY = "next_page_url"
-
-# Max entries requested per page. Only a round-trip-count optimization; the
-# reader follows ``next_page_url`` until exhausted regardless.
-PER_PAGE = 1000
+# Root element and the repeated per-RIN record element in the export.
+_ROOT_TAG = "REGINFO_RIN_DATA"
+_RECORD_TAG = "RIN_INFO"
 
 # The most recent agenda edition to fetch when a caller does not specify one.
-# Editions are ``YYYYMM`` with MM in {04 (Spring), 10 (Fall)}. This default is a
-# placeholder for the "current edition" and should be validated live.
-DEFAULT_EDITION = "202404"
+# Editions are ``YYYYMM`` with MM in {04 (Spring), 10 (Fall)}. Fall 2025 is the
+# most recent edition validated against the live export.
+DEFAULT_EDITION = "202510"
 
 # Transport hygiene: bound every request and retry transient failures with
-# backoff so a flaky fetch fails slow-then-recovers rather than dropping entries.
-_TIMEOUT = httpx.Timeout(60.0, connect=30.0)
+# backoff so a flaky fetch fails slow-then-recovers rather than dropping records.
+_TIMEOUT = httpx.Timeout(300.0, connect=30.0)
 _MAX_RETRIES = 5
 _PROGRESS_EVERY = 5_000
 
 
 class UnifiedAgendaReader(Reader):
-    """Yields raw Unified Agenda entry dicts for one or more agenda editions.
+    """Yields normalized Unified Agenda RIN dicts for one or more agenda editions.
 
     ``editions`` defaults to :data:`DEFAULT_EDITION`. Callers doing incremental
     runs pass only the edition(s) newer than what is already stored; the
@@ -92,73 +109,80 @@ class UnifiedAgendaReader(Reader):
         self,
         *,
         editions: tuple[str, ...] | None = None,
-        per_page: int = PER_PAGE,
         verbose: bool = False,
     ) -> None:
         self.editions = editions or (DEFAULT_EDITION,)
-        self.per_page = per_page
         self.verbose = verbose
         self._client: httpx.Client | None = None
         self._seen = 0
 
     def iter_records(self) -> Iterator[dict]:
         logger.info("Unified Agenda: fetching editions {}", ", ".join(self.editions))
-        with httpx.Client(timeout=_TIMEOUT, headers={"Accept": "application/json"}) as client:
+        with httpx.Client(timeout=_TIMEOUT, follow_redirects=True) as client:
             self._client = client
             for edition in self.editions:
                 yield from self._fetch_edition(edition)
-        logger.info("Unified Agenda: yielded {:,} entries", self._seen)
+        logger.info("Unified Agenda: yielded {:,} records", self._seen)
 
     # -- edition fetching ----------------------------------------------------
 
     def _fetch_edition(self, edition: str) -> Iterator[dict]:
-        """Page through one agenda edition, following ``next_page_url``.
+        """Download one edition's XML export and stream-parse its RIN records.
 
         Each yielded dict is annotated with the ``agenda_edition`` it came from,
-        since the per-entry payload may not repeat the edition and it is half of
-        the (``rin``, ``agenda_edition``) dedup key.
+        since it is half of the (``rin``, ``agenda_edition``) dedup key.
         """
-        params: dict[str, object] = {
-            PARAM_EDITION: edition,
-            PARAM_OUTPUT: "json",
-            "per_page": self.per_page,
-        }
-        url = AGENDA_ENDPOINT
-        first = True
-        count = 0
+        data = self._download(edition)
+        if data is None:
+            return
         collected = 0
-        while url:
-            payload = self._get(url, params if first else None)
-            first = False
-            if payload is None:
-                break
-            count = payload.get(_COUNT_KEY, count)
-            for entry in payload.get(_RESULTS_KEY, []) or []:
-                # Stamp the edition so the transform always has the dedup key.
-                entry.setdefault("agenda_edition", edition)
-                collected += 1
-                self._seen += 1
-                if self._seen % _PROGRESS_EVERY == 0:
-                    logger.info("Unified Agenda: {:,} entries so far...", self._seen)
-                yield entry
-            url = payload.get(_NEXT_KEY) or ""
-        if count and collected < count:
-            # Make an incomplete edition loud rather than silent.
-            logger.warning("Unified Agenda: edition {} returned {}/{} entries", edition, collected, count)
 
-    def _get(self, url: str, params: dict | None) -> dict | None:
-        """GET with bounded retries + exponential backoff. Returns parsed JSON or None."""
+        # iterparse over the in-memory bytes; grab the root on the first event so
+        # we can drop processed record shells and keep the tree from growing.
+        context = ET.iterparse(io.BytesIO(data), events=("start", "end"))
+        _, root = next(context)  # first ("start", <REGINFO_RIN_DATA>)
+        for event, elem in context:
+            if event != "end" or elem.tag != _RECORD_TAG:
+                continue
+            record = _normalize(elem, edition)
+            collected += 1
+            self._seen += 1
+            if self._seen % _PROGRESS_EVERY == 0:
+                logger.info("Unified Agenda: {:,} records so far...", self._seen)
+            yield record
+            # Free this record's subtree and the root's accumulated child shells.
+            elem.clear()
+            root.clear()
+        logger.info("Unified Agenda: edition {} yielded {:,} records", edition, collected)
+
+    def _download(self, edition: str) -> bytes | None:
+        """GET one edition's XML file with bounded retries + exponential backoff.
+
+        Returns the raw XML bytes, or None if every attempt failed.
+        """
         assert self._client is not None
+        params = {"f": XML_FILE_TEMPLATE.format(edition=edition)}
         for attempt in range(1, _MAX_RETRIES + 1):
             try:
-                resp = self._client.get(url, params=params)
+                resp = self._client.get(XML_EXPORT_ENDPOINT, params=params)
                 if resp.status_code == 429 or resp.status_code >= 500:
                     raise httpx.HTTPStatusError("retryable", request=resp.request, response=resp)
                 resp.raise_for_status()
-                return resp.json()
+                data = resp.content
+                if not data.lstrip().startswith(b"<?xml"):
+                    # A non-XML body (e.g. the HTML listing page) means the edition
+                    # is missing or the endpoint changed — surface it, don't parse.
+                    logger.error(
+                        "Unified Agenda: edition {} did not return XML (got {} bytes starting {!r})",
+                        edition,
+                        len(data),
+                        data[:60],
+                    )
+                    return None
+                return data
             except (httpx.HTTPError, ValueError) as exc:
                 if attempt == _MAX_RETRIES:
-                    logger.error("Unified Agenda: giving up on {} after {} attempts: {}", url, attempt, exc)
+                    logger.error("Unified Agenda: giving up on edition {} after {} attempts: {}", edition, attempt, exc)
                     return None
                 backoff = min(2**attempt, 30)
                 logger.warning(
@@ -166,3 +190,61 @@ class UnifiedAgendaReader(Reader):
                 )
                 time.sleep(backoff)
         return None
+
+
+# --------------------------------------------------------------------------- #
+# XML → normalized dict. Keys here are exactly what ``_shape`` reads.
+# --------------------------------------------------------------------------- #
+
+
+def _text(elem: ET.Element | None, path: str) -> str | None:
+    """Return the stripped text at ``path`` under ``elem``, or None if empty."""
+    if elem is None:
+        return None
+    value = elem.findtext(path)
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _text_list(elem: ET.Element, path: str) -> list[str]:
+    """Return the stripped, non-empty text of every element matching ``path``."""
+    out: list[str] = []
+    for child in elem.findall(path):
+        if child.text and child.text.strip():
+            out.append(child.text.strip())
+    return out
+
+
+def _normalize(elem: ET.Element, edition: str) -> dict:
+    """Map one ``<RIN_INFO>`` element onto the keys ``_shape`` consumes.
+
+    ``agency_code``/``agency_name`` come from the RIN-owning ``<AGENCY>`` (its
+    ``<ACRONYM>``, falling back to the numeric ``<CODE>``, and ``<NAME>``).
+    """
+    agency = elem.find("AGENCY")
+    timetable = [
+        {
+            "action": _text(tt, "TTBL_ACTION"),
+            "date": _text(tt, "TTBL_DATE"),
+            "fr_citation": _text(tt, "FR_CITATION"),
+        }
+        for tt in elem.findall("TIMETABLE_LIST/TIMETABLE")
+    ]
+    return {
+        "rin": _text(elem, "RIN"),
+        "agency_code": _text(agency, "ACRONYM") or _text(agency, "CODE"),
+        "agency_name": _text(agency, "NAME"),
+        "title": _text(elem, "RULE_TITLE"),
+        "abstract": _text(elem, "ABSTRACT"),
+        "priority_category": _text(elem, "PRIORITY_CATEGORY"),
+        "rin_status": _text(elem, "RIN_STATUS"),
+        "rule_stage": _text(elem, "RULE_STAGE"),
+        "major": _text(elem, "MAJOR"),
+        "publication_id": _text(elem, "PUBLICATION/PUBLICATION_ID"),
+        "agenda_edition": edition,
+        "cfr_references": _text_list(elem, "CFR_LIST/CFR"),
+        "legal_authority": _text_list(elem, "LEGAL_AUTHORITY_LIST/LEGAL_AUTHORITY"),
+        "timetable": timetable,
+    }

--- a/src/spicy_regs/transforms/build_unified_agenda.py
+++ b/src/spicy_regs/transforms/build_unified_agenda.py
@@ -103,7 +103,10 @@ def _shape(doc: dict) -> dict:
     timetable = doc.get("timetable") or []
     dates = _iso_dates(timetable)
     first_action = dates[0] if dates else None
-    next_action = next((d for d in dates if d > first_action), None) if dates else None
+    next_action = None
+    if dates:
+        earliest = dates[0]  # str, not str | None — keeps the comparison well-typed
+        next_action = next((d for d in dates if d > earliest), None)
 
     rin = _s(doc.get("rin"))
     edition = _s(doc.get("agenda_edition"))

--- a/src/spicy_regs/transforms/build_unified_agenda.py
+++ b/src/spicy_regs/transforms/build_unified_agenda.py
@@ -18,16 +18,15 @@ Instead we:
 
 With no prior table (first run) step 3 keeps only the freshly fetched editions.
 
-.. note::
-   The reginfo.gov endpoint/params are **not** validated against a live run here
-   (see :mod:`spicy_regs.sources.unified_agenda`); the transform is exercised only
-   with hermetic fixtures. Field names read off each raw entry
-   (:func:`_shape`) likewise require confirmation against a real payload.
+The reginfo.gov XML export the reader parses is documented in
+:mod:`spicy_regs.sources.unified_agenda`; :func:`_shape` maps the reader's
+normalized per-RIN dict onto the pinned 17 columns.
 """
 
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pyarrow as pa
@@ -70,38 +69,66 @@ def _s(value: object) -> str | None:
     return str(value)
 
 
-def _first(doc: dict, *keys: str) -> object:
-    """Return the first present, non-None value among ``keys`` (source key drift)."""
-    for key in keys:
-        if key in doc and doc[key] is not None:
-            return doc[key]
-    return None
+# reginfo timetable dates are ``MM/DD/YYYY`` (day may be ``00`` for month-only);
+# anything else (e.g. ``To Be Determined``) is not a real date and is skipped.
+_MDY = re.compile(r"^(\d{1,2})/(\d{1,2})/(\d{4})$")
+
+
+def _iso_dates(timetable: list) -> list[str]:
+    """Return the timetable's parseable action dates as sorted ISO ``YYYY-MM-DD``."""
+    dates: set[str] = set()
+    for entry in timetable:
+        raw = (entry or {}).get("date")
+        if not isinstance(raw, str):
+            continue
+        m = _MDY.match(raw.strip())
+        if not m:
+            continue
+        month, day, year = int(m.group(1)), int(m.group(2)), m.group(3)
+        if not 1 <= month <= 12:
+            continue
+        day = min(max(day, 1), 31)  # clamp; ``00`` (month-only) becomes the 1st
+        dates.add(f"{year}-{month:02d}-{day:02d}")
+    return sorted(dates)
 
 
 def _shape(doc: dict) -> dict:
-    """Map one raw Unified Agenda entry onto the published column shape.
+    """Map one normalized Unified Agenda RIN dict onto the published column shape.
 
-    reginfo.gov's exact field names are unverified (see the source module), so
-    the common casings are accepted and the first present one wins.
+    The reader (:mod:`spicy_regs.sources.unified_agenda`) already normalizes the
+    XML tags onto these keys. ``first_action_date`` / ``next_action_date`` are
+    derived from the timetable (earliest action, then the earliest later action);
+    ``url`` is the deterministic per-RIN reginfo detail page.
     """
+    timetable = doc.get("timetable") or []
+    dates = _iso_dates(timetable)
+    first_action = dates[0] if dates else None
+    next_action = next((d for d in dates if d > first_action), None) if dates else None
+
+    rin = _s(doc.get("rin"))
+    edition = _s(doc.get("agenda_edition"))
+    url = None
+    if rin and edition:
+        url = f"https://www.reginfo.gov/public/do/eAgendaViewRule?pubId={edition}&RIN={rin}"
+
     return {
-        "rin": _s(_first(doc, "rin", "RIN")),
-        "agency_code": _s(_first(doc, "agency_code", "agencyCode")),
-        "agency_name": _s(_first(doc, "agency_name", "agencyName", "agency")),
-        "title": _s(_first(doc, "title", "ruleTitle")),
-        "abstract": _s(_first(doc, "abstract")),
-        "rin_status": _s(_first(doc, "rin_status", "rinStatus", "status")),
-        "rule_stage": _s(_first(doc, "rule_stage", "ruleStage", "stage")),
-        "priority_category": _s(_first(doc, "priority_category", "priorityCategory", "priority")),
-        "agenda_edition": _s(_first(doc, "agenda_edition", "agendaEdition", "publication")),
-        "major": _s(_first(doc, "major")),
-        "publication_id": _s(_first(doc, "publication_id", "publicationId")),
-        "timetable_json": json.dumps(_first(doc, "timetable", "timetables") or []),
-        "cfr_references_json": json.dumps(_first(doc, "cfr_references", "cfrReferences") or []),
-        "legal_authority_json": json.dumps(_first(doc, "legal_authority", "legalAuthority") or []),
-        "first_action_date": _s(_first(doc, "first_action_date", "firstActionDate")),
-        "next_action_date": _s(_first(doc, "next_action_date", "nextActionDate")),
-        "url": _s(_first(doc, "url")),
+        "rin": rin,
+        "agency_code": _s(doc.get("agency_code")),
+        "agency_name": _s(doc.get("agency_name")),
+        "title": _s(doc.get("title")),
+        "abstract": _s(doc.get("abstract")),
+        "rin_status": _s(doc.get("rin_status")),
+        "rule_stage": _s(doc.get("rule_stage")),
+        "priority_category": _s(doc.get("priority_category")),
+        "agenda_edition": edition,
+        "major": _s(doc.get("major")),
+        "publication_id": _s(doc.get("publication_id")),
+        "timetable_json": json.dumps(timetable),
+        "cfr_references_json": json.dumps(doc.get("cfr_references") or []),
+        "legal_authority_json": json.dumps(doc.get("legal_authority") or []),
+        "first_action_date": first_action,
+        "next_action_date": next_action,
+        "url": url,
     }
 
 

--- a/tests/test_unified_agenda.py
+++ b/tests/test_unified_agenda.py
@@ -11,6 +11,7 @@ so no network is touched.
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 from spicy_regs.sources import unified_agenda
 from spicy_regs.sources.unified_agenda import UnifiedAgendaReader
@@ -100,14 +101,10 @@ def _read_fixture(edition: str = "202510") -> list[dict]:
         return _FIXTURE_XML
 
     # Patch the bound method on the class so iter_records exercises the real
-    # iterparse + _normalize path against the fixture bytes.
-    original = UnifiedAgendaReader._download
-    try:
-        UnifiedAgendaReader._download = fake_download  # type: ignore[method-assign]
-        reader._client = object()  # _download asserts a client is set; it's stubbed
+    # iterparse + _normalize path against the fixture bytes. The stubbed
+    # _download ignores the HTTP client, so none needs to be set.
+    with patch.object(UnifiedAgendaReader, "_download", fake_download):
         return list(reader._fetch_edition(edition))
-    finally:
-        UnifiedAgendaReader._download = original  # type: ignore[method-assign]
 
 
 def test_reader_parses_records_and_stamps_edition():
@@ -187,7 +184,7 @@ def test_download_rejects_non_xml_body(monkeypatch):
         def get(self, url, params=None):
             return _Resp()
 
-    reader._client = _Client()  # type: ignore[assignment]
+    monkeypatch.setattr(reader, "_client", _Client())
     assert reader._download("202510") is None
     assert list(reader._fetch_edition("202510")) == []
 

--- a/tests/test_unified_agenda.py
+++ b/tests/test_unified_agenda.py
@@ -1,118 +1,198 @@
 """Hermetic tests for the Unified Agenda ingest (no network).
 
-Covers the two pieces with real logic: the raw-entry → published-schema mapping
-(``_shape``) and the edition-pagination loop the reader uses (following
-``next_page_url`` and stamping the ``agenda_edition`` dedup key).
+Covers the two pieces with real logic: parsing the reginfo.gov
+``REGINFO_RIN_DATA`` XML export into normalized RIN dicts
+(``UnifiedAgendaReader._fetch_edition`` / ``_normalize``) and mapping those onto
+the published 17-column schema (``_shape``, including timetable-date derivation
+and the deterministic per-RIN URL). The reader's HTTP download is monkeypatched
+so no network is touched.
 """
 
 from __future__ import annotations
 
 import json
 
+from spicy_regs.sources import unified_agenda
 from spicy_regs.sources.unified_agenda import UnifiedAgendaReader
 from spicy_regs.transforms.build_unified_agenda import COLUMNS, _shape
 
-_RAW_ENTRY = {
-    "rin": "2060-AV12",
-    "agency_code": "EPA",
-    "agency_name": "Environmental Protection Agency",
-    "title": "A Planned Rule",
-    "abstract": "Plans to do a thing.",
-    "rin_status": "Active",
-    "rule_stage": "Proposed Rule",
-    "priority_category": "Other Significant",
-    "agenda_edition": "202404",
-    "major": True,
-    "publication_id": "PUB-123",
-    "timetable": [{"action": "NPRM", "date": "2024-06-00"}],
-    "cfr_references": [{"title": 40, "part": 60}],
-    "legal_authority": ["42 U.S.C. 7401"],
-    "first_action_date": "2024-06-01",
-    "next_action_date": "2024-12-01",
-    "url": "https://www.reginfo.gov/public/do/eAgendaViewRule?RIN=2060-AV12",
-}
+# A two-record slice of the real export, matching the observed tag structure:
+# <REGINFO_RIN_DATA> root, repeated <RIN_INFO> records, nested AGENCY / CFR_LIST /
+# LEGAL_AUTHORITY_LIST / TIMETABLE_LIST. The second record exercises empty lists
+# and an unparseable ("To Be Determined") timetable date.
+_FIXTURE_XML = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<REGINFO_RIN_DATA RUN_DATE="2025-11-01-05:00">
+    <RIN_INFO>
+        <RIN>2060-AV12</RIN>
+        <PUBLICATION>
+            <PUBLICATION_ID>202510</PUBLICATION_ID>
+            <PUBLICATION_TITLE>The Unified Agenda</PUBLICATION_TITLE>
+        </PUBLICATION>
+        <AGENCY>
+            <CODE>2060</CODE>
+            <NAME>Environmental Protection Agency</NAME>
+            <ACRONYM>EPA</ACRONYM>
+        </AGENCY>
+        <PARENT_AGENCY>
+            <CODE>2000</CODE>
+            <NAME>Environmental Protection Agency</NAME>
+            <ACRONYM>EPA</ACRONYM>
+        </PARENT_AGENCY>
+        <RULE_TITLE>A Planned Rule</RULE_TITLE>
+        <ABSTRACT>Plans to do a thing.</ABSTRACT>
+        <PRIORITY_CATEGORY>Other Significant</PRIORITY_CATEGORY>
+        <RIN_STATUS>Active</RIN_STATUS>
+        <RULE_STAGE>Proposed Rule Stage</RULE_STAGE>
+        <MAJOR>Yes</MAJOR>
+        <CFR_LIST>
+            <CFR>40 CFR 60</CFR>
+            <CFR>40 CFR 63</CFR>
+        </CFR_LIST>
+        <LEGAL_AUTHORITY_LIST>
+            <LEGAL_AUTHORITY>42 U.S.C. 7401</LEGAL_AUTHORITY>
+        </LEGAL_AUTHORITY_LIST>
+        <TIMETABLE_LIST>
+            <TIMETABLE>
+                <TTBL_ACTION>NPRM</TTBL_ACTION>
+                <TTBL_DATE>06/15/2024</TTBL_DATE>
+                <FR_CITATION>89 FR 12345</FR_CITATION>
+            </TIMETABLE>
+            <TIMETABLE>
+                <TTBL_ACTION>NPRM Comment Period End</TTBL_ACTION>
+                <TTBL_DATE>08/14/2024</TTBL_DATE>
+            </TIMETABLE>
+            <TIMETABLE>
+                <TTBL_ACTION>Final Rule</TTBL_ACTION>
+                <TTBL_DATE>03/01/2025</TTBL_DATE>
+            </TIMETABLE>
+        </TIMETABLE_LIST>
+    </RIN_INFO>
+    <RIN_INFO>
+        <RIN>1234-AB56</RIN>
+        <PUBLICATION>
+            <PUBLICATION_ID>202510</PUBLICATION_ID>
+        </PUBLICATION>
+        <AGENCY>
+            <CODE>1234</CODE>
+            <NAME>Some Agency</NAME>
+        </AGENCY>
+        <RULE_TITLE>Another Rule</RULE_TITLE>
+        <RULE_STAGE>Long-Term Actions</RULE_STAGE>
+        <CFR_LIST/>
+        <LEGAL_AUTHORITY_LIST/>
+        <TIMETABLE_LIST>
+            <TIMETABLE>
+                <TTBL_ACTION>Interim Final Rule</TTBL_ACTION>
+                <TTBL_DATE>To Be Determined</TTBL_DATE>
+            </TIMETABLE>
+        </TIMETABLE_LIST>
+    </RIN_INFO>
+</REGINFO_RIN_DATA>
+"""
+
+
+def _read_fixture(edition: str = "202510") -> list[dict]:
+    """Run the reader over the inline fixture with the network download stubbed."""
+    reader = UnifiedAgendaReader(editions=(edition,))
+
+    def fake_download(self, ed):
+        assert ed == edition
+        return _FIXTURE_XML
+
+    # Patch the bound method on the class so iter_records exercises the real
+    # iterparse + _normalize path against the fixture bytes.
+    original = UnifiedAgendaReader._download
+    try:
+        UnifiedAgendaReader._download = fake_download  # type: ignore[method-assign]
+        reader._client = object()  # _download asserts a client is set; it's stubbed
+        return list(reader._fetch_edition(edition))
+    finally:
+        UnifiedAgendaReader._download = original  # type: ignore[method-assign]
+
+
+def test_reader_parses_records_and_stamps_edition():
+    records = _read_fixture("202510")
+    assert [r["rin"] for r in records] == ["2060-AV12", "1234-AB56"]
+    # Edition is stamped on every record (half the dedup key).
+    assert all(r["agenda_edition"] == "202510" for r in records)
+    # AGENCY/ACRONYM wins for agency_code, falling back to CODE when absent.
+    assert records[0]["agency_code"] == "EPA"
+    assert records[1]["agency_code"] == "1234"
+    assert records[0]["agency_name"] == "Environmental Protection Agency"
+
+
+def test_reader_normalizes_lists_and_timetable():
+    rec = _read_fixture("202510")[0]
+    assert rec["cfr_references"] == ["40 CFR 60", "40 CFR 63"]
+    assert rec["legal_authority"] == ["42 U.S.C. 7401"]
+    assert rec["timetable"][0] == {
+        "action": "NPRM",
+        "date": "06/15/2024",
+        "fr_citation": "89 FR 12345",
+    }
+    # Optional child (FR_CITATION) absent -> None.
+    assert rec["timetable"][1]["fr_citation"] is None
 
 
 def test_shape_produces_exact_schema():
-    row = _shape(_RAW_ENTRY)
-    # Every published column present, and nothing extra.
+    row = _shape(_read_fixture("202510")[0])
     assert set(row) == set(COLUMNS)
 
 
-def test_shape_maps_and_serializes_fields():
-    row = _shape(_RAW_ENTRY)
+def test_shape_maps_serializes_and_derives():
+    row = _shape(_read_fixture("202510")[0])
     assert row["rin"] == "2060-AV12"
-    assert row["agenda_edition"] == "202404"
-    assert row["rule_stage"] == "Proposed Rule"
+    assert row["agenda_edition"] == "202510"
+    assert row["rule_stage"] == "Proposed Rule Stage"
+    assert row["priority_category"] == "Other Significant"
+    assert row["major"] == "Yes"
+    assert row["publication_id"] == "202510"
     # Array fields serialize to JSON strings.
     assert json.loads(row["timetable_json"])[0]["action"] == "NPRM"
-    assert json.loads(row["cfr_references_json"])[0]["part"] == 60
+    assert json.loads(row["cfr_references_json"]) == ["40 CFR 60", "40 CFR 63"]
     assert json.loads(row["legal_authority_json"]) == ["42 U.S.C. 7401"]
-    # Scalars stringify (schema is all-VARCHAR).
-    assert row["major"] == "True"
-    assert row["url"].startswith("https://www.reginfo.gov/")
+    # Timetable dates -> ISO; first = earliest, next = earliest later action.
+    assert row["first_action_date"] == "2024-06-15"
+    assert row["next_action_date"] == "2024-08-14"
+    # Deterministic per-RIN reginfo detail URL.
+    assert row["url"] == "https://www.reginfo.gov/public/do/eAgendaViewRule?pubId=202510&RIN=2060-AV12"
 
 
-def test_shape_accepts_camelcase_key_drift():
-    """reginfo.gov field names are unverified, so common casings must resolve."""
-    row = _shape(
-        {
-            "RIN": "1234-AB56",
-            "agencyName": "Some Agency",
-            "ruleStage": "Final Rule",
-            "agendaEdition": "202410",
-            "nextActionDate": "2025-01-15",
-        }
-    )
-    assert row["rin"] == "1234-AB56"
-    assert row["agency_name"] == "Some Agency"
-    assert row["rule_stage"] == "Final Rule"
-    assert row["agenda_edition"] == "202410"
-    assert row["next_action_date"] == "2025-01-15"
-
-
-def test_shape_handles_missing_arrays():
-    row = _shape({"rin": "x", "agenda_edition": "202404"})
-    assert row["timetable_json"] == "[]"
+def test_shape_handles_missing_and_unparseable_dates():
+    row = _shape(_read_fixture("202510")[1])
+    # No parseable timetable dates -> both action dates null.
+    assert row["first_action_date"] is None
+    assert row["next_action_date"] is None
+    # Empty lists still serialize to "[]".
     assert row["cfr_references_json"] == "[]"
     assert row["legal_authority_json"] == "[]"
+    # Absent fields are null.
     assert row["abstract"] is None
-    assert row["url"] is None
+    assert row["priority_category"] is None
 
 
-def test_reader_paginates_and_stamps_edition(monkeypatch):
-    """The reader must follow ``next_page_url`` and stamp the agenda_edition key.
+def test_download_rejects_non_xml_body(monkeypatch):
+    """A non-XML body (e.g. the old eAgendaXmlReport HTML page) yields nothing."""
 
-    We simulate a two-page edition response. Entries missing an inline edition
-    must still receive one (it is half of the dedup key); an entry that already
-    carries an edition is left untouched.
-    """
-    reader = UnifiedAgendaReader(editions=("202404",))
+    class _Resp:
+        status_code = 200
+        content = b"<!DOCTYPE html><html><body>listing page</body></html>"
 
-    pages = {
-        None: {
-            "count": 3,
-            "results": [{"rin": "A"}, {"rin": "B"}],
-            "next_page_url": "PAGE2",
-        },
-        "PAGE2": {
-            "count": 3,
-            "results": [{"rin": "C", "agenda_edition": "209999"}],
-            "next_page_url": None,
-        },
-    }
+        def raise_for_status(self):
+            return None
 
-    def fake_get(url, params):
-        # First call passes params (url is the endpoint); paged calls pass the url token.
-        key = None if params is not None else url
-        return pages[key]
+    reader = UnifiedAgendaReader(editions=("202510",))
 
-    monkeypatch.setattr(reader, "_get", fake_get)
-    entries = list(reader._fetch_edition("202404"))
+    class _Client:
+        def get(self, url, params=None):
+            return _Resp()
 
-    assert [e["rin"] for e in entries] == ["A", "B", "C"]
-    # Entries without an inline edition are stamped with the fetched edition.
-    assert entries[0]["agenda_edition"] == "202404"
-    assert entries[1]["agenda_edition"] == "202404"
-    # An entry that already carried an edition is left as-is (setdefault).
-    assert entries[2]["agenda_edition"] == "209999"
+    reader._client = _Client()  # type: ignore[assignment]
+    assert reader._download("202510") is None
+    assert list(reader._fetch_edition("202510")) == []
+
+
+def test_default_edition_is_yyyymm():
+    ed = unified_agenda.DEFAULT_EDITION
+    assert len(ed) == 6 and ed.isdigit()
+    assert ed[4:] in {"04", "10"}


### PR DESCRIPTION
## What

Rewrites the `unified_agenda` reader to fetch and stream-parse reginfo.gov's real per-edition XML export instead of the dead `eAgendaXmlReport` endpoint.

## Why

The reader on `main` hit `https://www.reginfo.gov/public/do/eAgendaXmlReport`, which returns the **HTML listing page**, not data — so the reader yielded nothing and the endpoint/params/response-envelope constants were flagged "require live validation."

The real machine-readable Unified Agenda is a per-edition XML file:

```
https://www.reginfo.gov/public/do/XMLViewFileAction?f=REGINFO_RIN_DATA_{EDITION}.xml
```

where `EDITION` is `YYYYMM`, MM ∈ {04 Spring, 10 Fall}. Validated live: `202510`, `202504`, `202410`, `202404` all return XML (`content-type: application/xml`, ~15 MB each).

## Changes

- **`sources/unified_agenda.py`** — replace JSON pagination with per-edition XML download + `iterparse` streaming. Each `<RIN_INFO>` record (and the root's accumulated child shells) is `.clear()`ed as it's yielded, so tens-of-MB files stay memory-bounded. Reader normalizes XML tags → dict keys `_shape` reads, stamping `agenda_edition`. Retry/backoff + timeout kept; a non-XML body (e.g. the old HTML page) is rejected loudly rather than parsed. `DEFAULT_EDITION` → `202510` (Fall 2025, most recent validated). Removed the "requires live validation" caveat.
- **`transforms/build_unified_agenda.py`** — `_shape` maps the normalized keys onto the 17 columns, JSON-serializes `timetable`/`cfr_references`/`legal_authority`, derives `first_action_date` (earliest timetable date) and `next_action_date` (earliest later date) from `MM/DD/YYYY` timetable dates (month-only `MM/00/YYYY` clamps to the 1st), and builds `url = .../eAgendaViewRule?pubId={edition}&RIN={rin}`. `(rin, agenda_edition)` dedup key unchanged.
- **`tests/test_unified_agenda.py`** — hermetic: an inline `REGINFO_RIN_DATA` XML fixture matching the real tag structure, download monkeypatched, asserts the parsed + shaped rows. No network.

## Observed XML tag structure

```
<REGINFO_RIN_DATA RUN_DATE="...">           # root
  <RIN_INFO>                                # one per RIN (the record)
    <RIN>0503-AA80</RIN>
    <PUBLICATION><PUBLICATION_ID>202410</PUBLICATION_ID>...</PUBLICATION>
    <AGENCY><CODE>0503</CODE><NAME>Office of the Secretary</NAME><ACRONYM>AgSEC</ACRONYM></AGENCY>
    <PARENT_AGENCY><CODE>0500</CODE><NAME>Department of Agriculture</NAME><ACRONYM>USDA</ACRONYM></PARENT_AGENCY>
    <RULE_TITLE>...</RULE_TITLE>
    <ABSTRACT>...</ABSTRACT>               # HTML-wrapped
    <PRIORITY_CATEGORY>Other Significant</PRIORITY_CATEGORY>
    <RIN_STATUS>...</RIN_STATUS>
    <RULE_STAGE>Final Rule Stage</RULE_STAGE>
    <MAJOR>No</MAJOR>
    <CFR_LIST><CFR>7 CFR 1.900-1.903</CFR>...</CFR_LIST>
    <LEGAL_AUTHORITY_LIST><LEGAL_AUTHORITY>5 U.S.C. 301</LEGAL_AUTHORITY>...</LEGAL_AUTHORITY_LIST>
    <TIMETABLE_LIST>
      <TIMETABLE><TTBL_ACTION>...</TTBL_ACTION><TTBL_DATE>11/20/2024</TTBL_DATE><FR_CITATION>89 FR 91529</FR_CITATION></TIMETABLE>
      ...
    </TIMETABLE_LIST>
  </RIN_INFO>
  ...
</REGINFO_RIN_DATA>
```

Column mapping: `rin`←RIN, `agency_code`←AGENCY/ACRONYM (fallback CODE), `agency_name`←AGENCY/NAME, `title`←RULE_TITLE, `abstract`←ABSTRACT, `priority_category`←PRIORITY_CATEGORY, `rin_status`←RIN_STATUS, `rule_stage`←RULE_STAGE, `major`←MAJOR, `publication_id`←PUBLICATION/PUBLICATION_ID, `cfr_references_json`←CFR_LIST/CFR, `legal_authority_json`←LEGAL_AUTHORITY_LIST/LEGAL_AUTHORITY, `timetable_json`←TIMETABLE_LIST/TIMETABLE (action/date/fr_citation).

## Live validation (edition 202510, first 5 RINs via islice → shaped)

```
#2 rin=0503-AA80  agency_code=AgSEC  title="Implementation of HAVANA Act of 2021"
   priority=Substantive, Nonsignificant  rule_stage=Final Rule Stage
   first_action_date=2024-11-20  next_action_date=2025-01-21
   cfr=["7 CFR 1.900-1.903"]  legal=["5 U.S.C. 301","22 U.S.C. 2680b"]
   timetable=4 entries  url=.../eAgendaViewRule?pubId=202510&RIN=0503-AA80
#3 rin=0503-AA82  first=2024-06-27 next=2024-07-25  timetable=6 entries
#1 rin=0503-AA90  timetable date "11/00/2026" -> first_action_date=2026-11-01 (month-only clamp)
```

All of rin / title / agency / priority / status / stage / dates / cfr / legal / url populate. No full backfill, no R2 upload.

## Tests

`test_unified_agenda.py` (7) + `test_mcp_server.py` + `test_data_dictionary.py` → 41 passed, 1 deselected. `ruff check .` clean. `spicy-regs-dict check` passes; `generate` produced no doc changes (existing column descriptions already fit).

## Caveats

- Each edition XML is ~15 MB (some larger). Handled by `iterparse` + `.clear()`; the reader downloads the full file into memory once (retryable) then streams the parse.
- `abstract` is HTML-wrapped (`<!DOCTYPE html>...`) as delivered; stored raw (no stripping) per the raw-source contract.
- `agency_code` uses the RIN-owning sub-agency ACRONYM (e.g. `AgSEC`), which may not match regulations.gov's department-level codes; PARENT_AGENCY (e.g. USDA) is not among the 17 published columns.