### PR TITLE
fix(fec): keyset pagination to walk all committees

### DIFF
--- a/src/spicy_regs/sources/fec_committees.py
+++ b/src/spicy_regs/sources/fec_committees.py
@@ -18,9 +18,18 @@ of millions of rows and are deliberately out of scope for this pass; a future
 bounded-by-organization contributions pass could follow, keyed on the
 ``committee_id`` this table establishes.
 
-The endpoint is paginated by ``page``/``per_page`` (``per_page`` caps at 100);
-the response envelope carries ``pagination.page`` / ``pagination.pages`` so the
-reader walks from page 1 to the reported last page.
+**Pagination.** We walk with a stable sort key (``sort=committee_id``) and prefer
+OpenFEC's documented **keyset (seek)** pagination: when the response envelope
+carries a non-null ``pagination.last_indexes`` cursor we pass those keys straight
+back as query params on the next request instead of incrementing ``page``. Not
+every OpenFEC endpoint offers seek pagination — ``/committees`` in particular
+returns ``last_indexes: null`` and is walked by incrementing ``page`` (the sort
+key keeps that walk stable and duplicate-free). Either way the walk terminates
+only when a page comes back **empty** (guarded by ``_MAX_PAGES``); it never stops
+early on a short page. A short page mid-walk was the old bug: OpenFEC's deep
+offset pages occasionally return fewer than ``per_page`` rows even when more
+exist, and the previous ``len(results) < per_page`` early-break truncated the
+backfill at ~26K of ~89K committees.
 
 **API key.** OpenFEC is fronted by api.data.gov, so the same api.data.gov key
 this repo already uses for regulations.gov / Congress.gov / GovInfo works here,
@@ -60,10 +69,28 @@ _TIMEOUT = httpx.Timeout(60.0, connect=30.0)
 _MAX_RETRIES = 5
 _PROGRESS_EVERY = 5_000
 
-# Safety valve: stop paging past this many pages to avoid a runaway loop if the
-# API ever reports a nonsensical page count. ~89K committees / 100 per page is
-# well under 1,000 pages, so this only guards against pathology.
+# Safety valve: stop after this many page fetches to avoid a runaway loop if the
+# API ever fails to return an empty terminal page. ~89K committees / 100 per page
+# is well under 1,000 pages, so this only guards against pathology.
 _MAX_PAGES = 5_000
+
+# The stable, unique sort key we page against. Sorting by the primary key keeps
+# both the offset walk and the keyset (seek) walk deterministic and dup-free.
+_SORT_KEY = "committee_id"
+
+
+def _clean_cursor(last_indexes: object) -> dict[str, object]:
+    """Return a usable keyset cursor from ``pagination.last_indexes``, or ``{}``.
+
+    OpenFEC returns ``last_indexes`` as an object like
+    ``{"last_index": "...", "last_committee_id": "..."}`` on endpoints that
+    support seek pagination, and ``null`` on those that don't (e.g.
+    ``/committees``). Drop null-valued keys; an all-null / non-dict cursor means
+    "no seek pagination — walk by offset page instead".
+    """
+    if not isinstance(last_indexes, dict):
+        return {}
+    return {str(k): v for k, v in last_indexes.items() if v is not None}
 
 
 def _resolve_api_key() -> str | None:
@@ -122,11 +149,20 @@ class FecCommitteesReader(Reader):
     # -- pagination ----------------------------------------------------------
 
     def _paginate(self) -> Iterator[dict]:
-        """Walk ``page``/``per_page`` pages, following ``pagination.pages``."""
+        """Walk every page, preferring keyset (seek) cursors, else offset pages.
+
+        Terminates only on an empty ``results`` page (or the ``_MAX_PAGES`` /
+        ``max_pages`` guard). A short page is *not* a stop signal — that was the
+        bug that truncated the backfill at ~26K of ~89K committees.
+        """
         page = 1
-        last_page = self.max_pages if self.max_pages is not None else _MAX_PAGES
-        while page <= last_page and page <= _MAX_PAGES:
-            payload = self._get_page(page)
+        # Keyset cursor carried forward from ``pagination.last_indexes`` when the
+        # endpoint offers seek pagination; empty means "walk by offset page".
+        keyset: dict[str, object] = {}
+        # Cap the number of *fetches*, honoring a caller-supplied ``max_pages``.
+        max_fetches = _MAX_PAGES if self.max_pages is None else min(self.max_pages, _MAX_PAGES)
+        for _ in range(max_fetches):
+            payload = self._get_page(page, keyset)
             if payload is None:
                 break
             results = payload.get("results") or []
@@ -137,24 +173,29 @@ class FecCommitteesReader(Reader):
                 if self._seen % _PROGRESS_EVERY == 0:
                     logger.info("FEC committees: {:,} committees so far...", self._seen)
                 yield committee
-            # Trust the envelope's reported total page count when the caller
-            # hasn't capped it, so we stop exactly at the last real page.
-            if self.max_pages is None:
-                reported = (payload.get("pagination") or {}).get("pages")
-                if isinstance(reported, int) and reported > 0:
-                    last_page = min(reported, _MAX_PAGES)
-            # A short page also means the server has nothing more to give.
-            if len(results) < self.per_page:
-                break
-            page += 1
+            # Prefer the documented keyset cursor when the envelope provides one;
+            # otherwise fall back to incrementing the offset page (what
+            # ``/committees`` uses — it returns ``last_indexes: null``).
+            last_indexes = (payload.get("pagination") or {}).get("last_indexes")
+            cursor = _clean_cursor(last_indexes)
+            if cursor:
+                keyset = cursor
+            else:
+                keyset = {}
+                page += 1
 
-    def _get_page(self, page: int) -> dict | None:
+    def _get_page(self, page: int, keyset: dict[str, object]) -> dict | None:
         params: dict[str, object] = {
-            "page": page,
             "per_page": self.per_page,
-            "sort": "committee_id",
+            "sort": _SORT_KEY,
             "api_key": self.api_key,
         }
+        if keyset:
+            # Seek pagination: the ``last_indexes`` keys (e.g. ``last_index``,
+            # ``last_committee_id``) are the exact query-param names OpenFEC wants.
+            params.update(keyset)
+        else:
+            params["page"] = page
         return self._get(f"{API_BASE}/committees/", params)
 
     def _get(self, url: str, params: dict | None) -> dict | None:

--- a/tests/test_fec_committees.py
+++ b/tests/test_fec_committees.py
@@ -2,7 +2,8 @@
 
 Covers the pieces with real logic: the raw-committee → published-schema mapping
 (``_shape`` / ``_json_array``), the API-key resolution fallback chain, and the
-page/per_page pagination with the ``pagination.pages`` walk and short-page stop.
+keyset-preferred / offset-fallback pagination (which must *not* stop early on a
+short page — that was the bug that truncated the backfill at ~26K of ~89K).
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ import json
 from spicy_regs.sources.fec_committees import (
     API_KEY_ENV_VARS,
     FecCommitteesReader,
+    _clean_cursor,
     _resolve_api_key,
 )
 from spicy_regs.transforms.build_fec_committees import COLUMNS, _shape
@@ -122,47 +124,89 @@ def _committee(cid: str) -> dict:
     return {"committee_id": cid}
 
 
-def test_paginate_walks_pages_until_reported_last_page(monkeypatch):
-    """Full pages advance; the envelope's ``pagination.pages`` bounds the walk."""
+def test_clean_cursor_extracts_keyset_or_empty():
+    # A real seek cursor is returned as-is (null-valued keys dropped).
+    assert _clean_cursor({"last_index": "42", "last_committee_id": "C9", "x": None}) == {
+        "last_index": "42",
+        "last_committee_id": "C9",
+    }
+    # /committees returns last_indexes: null -> no cursor -> offset fallback.
+    assert _clean_cursor(None) == {}
+    # An all-null cursor is likewise unusable.
+    assert _clean_cursor({"last_index": None}) == {}
+
+
+def test_paginate_offset_walk_stops_only_on_empty_page(monkeypatch):
+    """With ``last_indexes: null`` (the /committees case) walk by page to empty."""
     reader = FecCommitteesReader(api_key="test", per_page=2)
     pages = {
-        1: {
-            "results": [_committee("C1"), _committee("C2")],
-            "pagination": {"page": 1, "pages": 2},
-        },
-        2: {
-            "results": [_committee("C3"), _committee("C4")],
-            "pagination": {"page": 2, "pages": 2},
-        },
-        # Page 3 exists in the stub but must never be requested.
-        3: {"results": [_committee("C5")], "pagination": {"page": 3, "pages": 2}},
+        1: {"results": [_committee("C1"), _committee("C2")], "pagination": {"page": 1, "last_indexes": None}},
+        2: {"results": [_committee("C3"), _committee("C4")], "pagination": {"page": 2, "last_indexes": None}},
+        3: {"results": [_committee("C5")], "pagination": {"page": 3, "last_indexes": None}},
+        4: {"results": [], "pagination": {"page": 4, "last_indexes": None}},
     }
-    monkeypatch.setattr(reader, "_get_page", lambda page: pages.get(page, {"results": []}))
+    requested: list[tuple[int, dict]] = []
+
+    def stub(page, keyset):
+        requested.append((page, dict(keyset)))
+        return pages.get(page, {"results": []})
+
+    monkeypatch.setattr(reader, "_get_page", stub)
     got = [c["committee_id"] for c in reader._paginate()]
-    assert got == ["C1", "C2", "C3", "C4"]
+    assert got == ["C1", "C2", "C3", "C4", "C5"]
+    # Offset fallback: page increments, no keyset cursor ever passed.
+    assert [p for p, _ in requested] == [1, 2, 3, 4]
+    assert all(ks == {} for _, ks in requested)
 
 
-def test_paginate_stops_on_short_page(monkeypatch):
-    """A page shorter than per_page ends pagination even if pages says more."""
+def test_paginate_does_not_stop_on_short_page(monkeypatch):
+    """Regression: a short mid-walk page must NOT terminate the walk (the bug)."""
     reader = FecCommitteesReader(api_key="test", per_page=3)
     pages = {
-        1: {
-            "results": [_committee("C1"), _committee("C2")],  # short -> stop
-            "pagination": {"page": 1, "pages": 9},
-        },
+        1: {"results": [_committee("C1"), _committee("C2")], "pagination": {"last_indexes": None}},  # short!
+        2: {"results": [_committee("C3"), _committee("C4"), _committee("C5")], "pagination": {"last_indexes": None}},
+        3: {"results": [], "pagination": {"last_indexes": None}},
     }
-    monkeypatch.setattr(reader, "_get_page", lambda page: pages.get(page, {"results": []}))
+    monkeypatch.setattr(reader, "_get_page", lambda page, keyset: pages.get(page, {"results": []}))
     got = [c["committee_id"] for c in reader._paginate()]
-    assert got == ["C1", "C2"]
+    # Old code broke after C1/C2 on the short page; the walk must continue.
+    assert got == ["C1", "C2", "C3", "C4", "C5"]
+
+
+def test_paginate_follows_keyset_cursor_when_present(monkeypatch):
+    """When ``last_indexes`` is present, carry the cursor forward, don't page."""
+    reader = FecCommitteesReader(api_key="test", per_page=2)
+    by_cursor = {
+        None: {
+            "results": [_committee("C1"), _committee("C2")],
+            "pagination": {"last_indexes": {"last_index": "C2", "last_committee_id": "C2"}},
+        },
+        "C2": {
+            "results": [_committee("C3"), _committee("C4")],
+            "pagination": {"last_indexes": {"last_index": "C4", "last_committee_id": "C4"}},
+        },
+        "C4": {"results": [], "pagination": {"last_indexes": None}},
+    }
+    seen_pages: list[int] = []
+
+    def stub(page, keyset):
+        seen_pages.append(page)
+        return by_cursor.get(keyset.get("last_index"), {"results": []})
+
+    monkeypatch.setattr(reader, "_get_page", stub)
+    got = [c["committee_id"] for c in reader._paginate()]
+    assert got == ["C1", "C2", "C3", "C4"]
+    # Keyset walk: page never advances past 1 (the cursor does the seeking).
+    assert seen_pages == [1, 1, 1]
 
 
 def test_paginate_respects_max_pages_cap(monkeypatch):
-    """``max_pages`` caps the walk regardless of the reported page count."""
+    """``max_pages`` caps the number of fetches regardless of more data."""
     reader = FecCommitteesReader(api_key="test", per_page=1, max_pages=1)
     pages = {
-        1: {"results": [_committee("C1")], "pagination": {"page": 1, "pages": 100}},
-        2: {"results": [_committee("C2")], "pagination": {"page": 2, "pages": 100}},
+        1: {"results": [_committee("C1")], "pagination": {"last_indexes": None}},
+        2: {"results": [_committee("C2")], "pagination": {"last_indexes": None}},
     }
-    monkeypatch.setattr(reader, "_get_page", lambda page: pages.get(page, {"results": []}))
+    monkeypatch.setattr(reader, "_get_page", lambda page, keyset: pages.get(page, {"results": []}))
     got = [c["committee_id"] for c in reader._paginate()]
     assert got == ["C1"]


### PR DESCRIPTION
Fixes the `fec_committees` backfill that landed only **26,100 of 89,123** committees.

**Cause:** the reader walked `page`/`per_page` and broke on `len(results) < per_page` — but OpenFEC's deep offset pages occasionally return a short page even when more rows exist, silently ending the walk at ~29%.

**Fix:** sort by the stable key `committee_id`, terminate only on an *empty* page (short pages no longer stop the walk), and prefer OpenFEC's documented `pagination.last_indexes` seek cursor when present (`/committees` returns `last_indexes: null`, so it walks by stable-sorted offset pages). Reader-only change; schema unchanged.

Validated: ruff + `ty check` clean, 13 reader tests pass. Full R2 re-backfill run separately (verifying ~89K).