### PR TITLE
docs: refresh table catalog for the 11 new data sources

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,20 +17,61 @@ regulations.gov  →  Mirrulations S3 mirror  →  Spicy Regs ETL  →  Parquet 
 ```
 
 The ETL flattens the raw regulations.gov JSON into a handful of flat tables and
-publishes them, plus a few small pre-computed rollups, to
-`https://r2.spicy-regs.dev`.
+publishes them, plus small pre-computed rollups, to `https://r2.spicy-regs.dev`.
+Alongside them it ingests a set of **complementary federal data sources** — the
+Federal Register, the Unified Agenda, Congress.gov, the CFR, SAM.gov, lobbying
+disclosures, the FEC, USASpending, federal-court litigation, and GAO/CRS reports
+— so the rulemaking lifecycle, the organizations that engage in it, and its
+downstream context can all be queried from one place.
 
 ## The tables
 
-| Table | Grain | Queryable via MCP |
+Every table below is published as `https://r2.spicy-regs.dev/<name>.parquet` and
+is queryable through the MCP server (`list_sources` / `describe_table` /
+`query_sql`).
+
+### Core regulations.gov tables
+
+| Table | Grain | Key |
 | --- | --- | --- |
-| [`dockets`](tables/dockets.md) | one row per docket | Yes |
-| [`documents`](tables/documents.md) | one row per document | Yes |
-| [`comments`](tables/comments.md) | one row per public comment | Yes |
-| [`comments_index`](tables/comments_index.md) | one row per comment partition | Yes |
-| [`feed_summary`](tables/feed_summary.md) | one row per docket (rollup) | Yes |
-| [`agency_stats`](tables/agency_stats.md) | one row per agency (rollup) | Yes |
-| [`agency_monthly_volume`](tables/agency_monthly_volume.md) | one row per agency/month/type (rollup) | Yes |
+| [`dockets`](tables/dockets.md) | one row per docket | `docket_id` |
+| [`documents`](tables/documents.md) | one row per document | `document_id` |
+| [`comments`](tables/comments.md) | one row per public comment | `comment_id` |
+| [`comments_index`](tables/comments_index.md) | one row per comment partition | — |
+
+### Rollups (pre-aggregated views of the core tables)
+
+| Table | Grain |
+| --- | --- |
+| [`feed_summary`](tables/feed_summary.md) | one row per docket |
+| [`agency_stats`](tables/agency_stats.md) | one row per agency |
+| [`agency_monthly_volume`](tables/agency_monthly_volume.md) | one row per agency / month / document type |
+
+### Rulemaking lifecycle (external sources)
+
+| Table | Grain | Key |
+| --- | --- | --- |
+| [`federal_register`](tables/federal_register.md) | one row per Federal Register document | `document_number` |
+| [`unified_agenda`](tables/unified_agenda.md) | one row per RIN per agenda edition | `rin` |
+| [`congress_bills`](tables/congress_bills.md) | one row per bill | `bill_id` |
+| [`cfr_sections`](tables/cfr_sections.md) | one row per CFR granule | `granule_id` |
+
+### Organizations & influence
+
+| Table | Grain | Key |
+| --- | --- | --- |
+| [`sam_entities`](tables/sam_entities.md) | one row per SAM-registered entity | `uei` |
+| [`lobbying_filings`](tables/lobbying_filings.md) | one row per LDA filing | `filing_uuid` |
+| [`fec_committees`](tables/fec_committees.md) | one row per FEC committee / PAC | `committee_id` |
+
+### Outcomes & context
+
+| Table | Grain | Key |
+| --- | --- | --- |
+| [`usaspending_recipients`](tables/usaspending_recipients.md) | one row per federal-award recipient | `recipient_id` |
+| [`court_dockets`](tables/court_dockets.md) | one row per federal-court docket | `cl_docket_id` |
+| [`gao_reports`](tables/gao_reports.md) | one row per GAO report | `report_id` |
+| [`crs_reports`](tables/crs_reports.md) | one row per CRS report | `report_id` |
 
 ## How the tables relate
 
@@ -48,6 +89,29 @@ dockets (docket_id)
   `agency_monthly_volume`) are pre-aggregated views built from the three core
   tables so consumers don't have to scan the tens-of-millions-of-rows comments
   dataset.
+
+The complementary sources are **reference tables** rather than strict children
+of `dockets`; they join to the corpus (and to each other) on a few shared keys:
+
+- **RIN** (Regulation Identifier Number) links `unified_agenda` (the planned
+  action) to `federal_register.regulation_id_numbers_json` (the published rule).
+- **CFR citations** link `cfr_sections` to `federal_register.cfr_references_json`
+  and `unified_agenda.cfr_references_json` (the codified text a rule amends).
+- **Docket IDs** in `federal_register.docket_ids_json` tie FR documents back to
+  regulations.gov dockets.
+- **UEI** (Unique Entity ID) links `sam_entities` and `usaspending_recipients`,
+  and is the anchor for resolving commenter/organization names to a canonical
+  entity.
+- **Organization name** bridges the softer influence sources — `lobbying_filings`
+  (registrant/client), `fec_committees`, and comment filers — where no shared id
+  exists.
+- **`agency_code` / agency name** appears across nearly every table.
+
+> Coverage notes: `sam_entities` is a partial sample (~5K of ~765K — the SAM API
+> caps pagination; full coverage needs chunked ingestion), `lobbying_filings`
+> covers 2024-onward, `usaspending_recipients` is the top ~100K recipients by
+> award amount, and `gao_reports` tracks GAO's recent-items RSS window (it grows
+> as the daily job runs). Each table page notes its own scope.
 
 ## How to query it
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -29,7 +29,10 @@ ETL dependencies (boto3, polars, prefect, ...) — keep the two in sync.
 | `query_sql(sql, max_rows=25)` | Run a SQL query against the R2 views |
 
 Available views: `dockets`, `documents`, `comments`, `comments_index`,
-`feed_summary`, `agency_stats`, `agency_monthly_volume`.
+`feed_summary`, `agency_stats`, `agency_monthly_volume`, `federal_register`,
+`unified_agenda`, `congress_bills`, `cfr_sections`, `sam_entities`,
+`lobbying_filings`, `fec_committees`, `usaspending_recipients`, `court_dockets`,
+`gao_reports`, `crs_reports`. Call `list_sources` for the authoritative list.
 
 ## Landing page
 

--- a/plugins/spicyregs/skills/spicyregs/SKILL.md
+++ b/plugins/spicyregs/skills/spicyregs/SKILL.md
@@ -64,9 +64,19 @@ Use the helper script's `--describe` output for the exact schema. In this repo, 
 - `dockets`: `docket_id`, `agency_code`, `title`, `docket_type`, `modify_date`, `abstract`
 - `documents`: `document_id`, `docket_id`, `agency_code`, `title`, `document_type`, `posted_date`, `modify_date`, `comment_start_date`, `comment_end_date`, `file_url`
 - `comments`: `comment_id`, `docket_id`, `agency_code`, `title`, `comment`, `document_type`, `posted_date`, `modify_date`, `receive_date`, `attachments_json`
-- Optional summaries:
+- Optional summaries / rollups:
   - `comments_index`
   - `feed_summary`
+  - `agency_stats`
+  - `agency_monthly_volume`
+
+Complementary federal sources (all queryable by name; see the Data Dictionary for columns):
+
+- Rulemaking lifecycle: `federal_register` (published rules; RIN + CFR refs), `unified_agenda` (planned actions, keyed by `rin`), `congress_bills`, `cfr_sections`
+- Organizations & influence: `sam_entities` (entity registry, keyed by `uei`), `lobbying_filings`, `fec_committees`
+- Outcomes & context: `usaspending_recipients` (keyed by `uei`), `court_dockets`, `gao_reports`, `crs_reports`
+
+Join keys across sources: `rin` (unified_agenda ↔ federal_register), CFR citations (↔ cfr_sections), `uei` (sam_entities ↔ usaspending_recipients ↔ commenter orgs), and `agency_code`.
 
 ## Query Patterns
 

--- a/plugins/spicyregs/skills/spicyregs/references/data-layout.md
+++ b/plugins/spicyregs/skills/spicyregs/references/data-layout.md
@@ -14,12 +14,24 @@ Use this reference when you need a quick map of the remote or local data files b
 
 ## Expected parquet files
 
+Core regulations.gov tables + rollups:
+
 - `dockets.parquet`
 - `documents.parquet`
 - `comments.parquet`
 - `comments_index.parquet`
 - `feed_summary.parquet`
+- `agency_stats.parquet`
+- `agency_monthly_volume.parquet`
 - Local-only: `comments/` partitioned comment parquet files may exist instead of a monolithic `comments.parquet`
+
+Complementary federal sources (each also queryable by name via the MCP server):
+
+- Rulemaking lifecycle: `federal_register.parquet`, `unified_agenda.parquet`, `congress_bills.parquet`, `cfr_sections.parquet`
+- Organizations & influence: `sam_entities.parquet`, `lobbying_filings.parquet`, `fec_committees.parquet`
+- Outcomes & context: `usaspending_recipients.parquet`, `court_dockets.parquet`, `gao_reports.parquet`, `crs_reports.parquet`
+
+See the [Data Dictionary](https://civictechdc.github.io/spicy-regs/) for each table's columns, keys, and coverage/scope notes.
 
 > **Comments read surface.** `comments_index.parquet` (per-partition counts) is
 > always the source for comment *counts*. The row-level `comments` table is


### PR DESCRIPTION
Brings the hand-maintained docs in line with the expanded 18-table R2 surface (Tier 1/2/3 sources added across #125–#138). The generated data dictionary (`docs/tables/*.md`) and `descriptions.yaml` were already kept current by each PR's `spicy-regs-dict` gate — this covers the docs that enumerate the surface by hand:

- **`docs/index.md`** — full catalog regrouped (core · rollups · rulemaking lifecycle · organizations & influence · outcomes & context), with the cross-source join keys (RIN, CFR refs, UEI, agency) and per-source coverage/scope notes.
- **`mcp-server/README.md`** — all 18 available views listed.
- **plugin skill** (`SKILL.md`, `references/data-layout.md`) — complementary sources added so the AI skill surfaces them.

Data dictionary `check` passes (18 tables); no schema/code changes.