### PR TITLE
feat(sam): full-coverage ingestion (partitioned walk)

### DIFF
--- a/src/spicy_regs/pipelines/rollups/sam_entities.py
+++ b/src/spicy_regs/pipelines/rollups/sam_entities.py
@@ -5,13 +5,60 @@ reading base tables from R2, so ``inputs`` is empty — the bounded fetch +
 incremental merge with the prior published table happens inside
 ``build_sam_entities``. The base class still handles the shrink-guarded R2 upload
 of the single output.
+
+**Bounded, accretive scheduled run.** The active registry (~765K entities) is far
+past the ~5K synchronous pagination ceiling, so full coverage comes from SAM's bulk
+extract walked over ``registrationDate`` year windows (see
+:mod:`spicy_regs.sources.sam_entities`). To keep each *scheduled* run bounded while
+still converging on full coverage, the default run fetches a **single rotating
+year window** (chosen from the run date), and the transform's merge accretes each
+window into the prior table across runs. Over one rotation period every year is
+covered; subsequent cycles refresh it.
+
+**Full backfill / overrides** via env vars (read here so the shared rollup CLI stays
+minimal):
+
+- ``SAM_INGEST_MODE``   — ``extract`` (default) or ``partition``.
+- ``SAM_SINCE_YEAR`` / ``SAM_UNTIL_YEAR`` — explicit registrationDate year range;
+  set both to walk a range in one run (e.g. ``2000``..current for a full backfill).
+- ``SAM_MAX_RECORDS``   — bound the run (blank/``0`` = unbounded).
+
+A full backfill is therefore a single ``workflow_dispatch`` (or local) run with
+``SAM_SINCE_YEAR=2000 SAM_UNTIL_YEAR=<current-year>`` and ``SAM_MAX_RECORDS`` unset.
 """
 
+import os
+from datetime import date
 from pathlib import Path
 from typing import ClassVar
 
+from loguru import logger
+
 from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.sources.sam_entities import _MIN_REGISTRATION_YEAR
 from spicy_regs.transforms import build_sam_entities
+
+
+def _rotating_year(today: date) -> int:
+    """Pick one registrationDate year to fetch this run, rotating by day.
+
+    Cycles across ``[_MIN_REGISTRATION_YEAR, today.year]`` so successive scheduled
+    runs advance coverage one bounded year-window at a time (and keep refreshing
+    once the cycle wraps). Deterministic from the date — no persisted cursor.
+    """
+    span = today.year - _MIN_REGISTRATION_YEAR + 1
+    return _MIN_REGISTRATION_YEAR + (today.toordinal() % span)
+
+
+def _int_env(name: str) -> int | None:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("SAM rollup: ignoring non-integer {}={!r}", name, raw)
+        return None
 
 
 class SamEntitiesRollup(RollupPipeline):
@@ -22,7 +69,25 @@ class SamEntitiesRollup(RollupPipeline):
     output: ClassVar[str] = "sam_entities.parquet"
 
     def build(self, output_dir: Path) -> Path:
-        return build_sam_entities(output_dir)
+        mode = os.environ.get("SAM_INGEST_MODE", "extract").strip() or "extract"
+        since = _int_env("SAM_SINCE_YEAR")
+        until = _int_env("SAM_UNTIL_YEAR")
+        max_records = _int_env("SAM_MAX_RECORDS")  # blank/0 -> unbounded within the window(s)
+
+        if since is None and until is None:
+            # Default scheduled run: one bounded, rotating year window.
+            since = until = _rotating_year(date.today())
+            logger.info("SAM rollup: scheduled default — rotating year window {}", since)
+        else:
+            logger.info("SAM rollup: explicit year range {}..{} (max_records={})", since, until, max_records)
+
+        return build_sam_entities(
+            output_dir,
+            mode=mode,
+            since_year=since,
+            until_year=until,
+            max_records=max_records if max_records else None,
+        )
 
 
 app = make_rollup_app(SamEntitiesRollup)

--- a/src/spicy_regs/sources/sam_entities.py
+++ b/src/spicy_regs/sources/sam_entities.py
@@ -8,43 +8,73 @@ same UEI the dashboard uses to tie a commenting organization to its registered
 identity.
 
 The reader is a *pure source*: it yields raw entity payloads (dicts) exactly as
-the list endpoint returns them under ``entityData[]``. Shaping them into the
-published 18-column schema is the job of
+the API returns them under ``entityData[]``. Shaping them into the published
+18-column schema is the job of
 :func:`~spicy_regs.transforms.build_sam_entities.build_sam_entities`.
 
-The ``/entities`` list endpoint is paginated by a 0-based ``page`` and a ``size``
-(the API caps a synchronous page at 10 records — ``size`` values above 10 are
-rejected with HTTP 400). Each response carries a ``links.nextLink`` pointing at
-the next page; the reader follows that link until it is absent (or a page comes
-back empty), so a full run can walk the entire active registry. We filter to
-public active registrations (``registrationStatus=A``) so the published table
-stays to the public-display surface.
+Full coverage — the pagination ceiling problem
+-----------------------------------------------
+The active registry is ~765,000 entities, but the *synchronous* ``/entities``
+list endpoint cannot walk it: ``size`` hard-caps at 10 records/page and a single
+filtered query only paginates to ~5,000 records (``links.nextLink`` stops there),
+regardless of ``totalRecords``. Naively following ``nextLink`` therefore tops out
+around 5K — a tiny slice of the registry. To get (near-)full coverage this reader
+supports two mechanisms:
 
-Note: SAM masks the ``api_key`` in the returned ``nextLink`` (it comes back as a
-placeholder), so the reader re-injects the real key when following it.
+**A. Bulk extract (default, ``mode="extract"``).** The same ``/entities`` endpoint,
+called with ``format=json``, switches to SAM's *asynchronous extract* path: instead
+of an inline page it returns a download URL (with the literal ``REPLACE_WITH_API_KEY``
+placeholder to swap for a real key), and that file can hold up to 1,000,000 records —
+far past the 5K synchronous ceiling. One extract request thus returns an entire
+partition of the registry. To keep any single downloaded file bounded in memory,
+the reader loops the extract over ``registrationDate`` *year windows* by default
+(each year is well under the 1M cap and json-loadable); each window is one extract
+request, and windows are disjoint by registration date so no dedup is needed within
+a run. A single unwindowed extract is also supported (``year_windows=False``).
+
+**B. Partitioned walk (``mode="partition"``, fallback).** When the extract path is
+unavailable, the reader partitions the query space by ``registrationDate`` window and
+walks each window with the paginated endpoint, **adaptively subdividing** any window
+whose ``totalRecords`` exceeds the ~5K reachable ceiling (halving down to a single
+day, like ``federal_register``'s date-window recursion). Because each sub-window
+stays under the ceiling, every matching entity in it is reachable via ``nextLink``.
+Windows are disjoint by registration date, so the union is the full registry.
+
+Both mechanisms accept ``max_records`` to bound a run, and an explicit
+``[since_year, until_year]`` range so scheduled runs can advance coverage window by
+window; the transform's merge accretes coverage across runs (dedup on ``uei``).
+
+Note: SAM masks the ``api_key`` in returned links (``nextLink`` for pages, the
+``REPLACE_WITH_API_KEY`` placeholder for extracts), so the reader re-injects the
+real key when following them.
 
 **API key.** SAM.gov requires an api.data.gov key sent as the ``api_key`` query
 param — but note the key must additionally be *associated with a SAM.gov account
-that has the Entity API role*; a generic api.data.gov key that works against
-regulations.gov / Congress.gov is **not** automatically authorized here, and
-SAM's gateway returns a bare ``404`` (not ``401``/``403``) for an unauthorized or
-invalid key. We resolve the key from a fallback chain of the env vars this repo
-already uses (:func:`_resolve_api_key`). If no key is set the reader logs a clear
-warning and yields nothing — a keyless CI run is a no-op, not a crash.
+that has the Entity API role* (a role-holding non-federal key is rate-limited to
+1,000 requests/day; the bulk-extract path is what keeps a full backfill within that
+budget). A generic api.data.gov key that works against regulations.gov / Congress.gov
+is **not** automatically authorized here, and SAM's gateway returns a bare ``404``
+(not ``401``/``403``) for an unauthorized or invalid key. We resolve the key from a
+fallback chain of the env vars this repo already uses (:func:`_resolve_api_key`). If
+no key is set the reader logs a clear warning and yields nothing — a keyless CI run
+is a no-op, not a crash.
 
-**Unbounded by default, bounded on request.** The reader walks every page by
-default (a full extract is ~hundreds of thousands of entities, capped only by the
-runaway page guard). Callers that only need a bounded slice — the transform's
-scheduled window, validation probes, tests — pass ``max_records`` to stop early;
-a full backfill is never run implicitly by the scheduled transform, which always
-passes a bounded ``max_records``.
+**Bounded by default, full on request.** Callers that only need a bounded slice — the
+transform's scheduled window, validation probes, tests — pass ``max_records`` to stop
+early. A full backfill is never run implicitly by the scheduled transform, which
+always passes a bounded ``max_records``.
 """
 
 from __future__ import annotations
 
+import gzip
+import io
+import json
 import os
 import time
+import zipfile
 from collections.abc import Iterator
+from datetime import date
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import httpx
@@ -56,6 +86,20 @@ API_BASE = "https://api.sam.gov/entity-information/v4"
 
 # Max records the synchronous /entities page accepts per request.
 PER_PAGE = 10
+
+# The synchronous list endpoint stops paginating around this many records for a
+# single filtered query, no matter how large ``totalRecords`` is. The partitioned
+# walk subdivides any window whose ``totalRecords`` exceeds this so every matching
+# entity stays reachable via ``nextLink``.
+PAGE_CEILING = 5_000
+
+# Earliest plausible registrationDate year to window over for a full extract. SAM
+# registrations (carried over from the CCR/DUNS era) predate the UEI transition, so
+# we start comfortably early; empty early windows are cheap (one extract each).
+_MIN_REGISTRATION_YEAR = 2000
+
+# The literal placeholder SAM embeds in the extract download URL in place of the key.
+_API_KEY_PLACEHOLDER = "REPLACE_WITH_API_KEY"
 
 # Env vars checked in order for the api.data.gov key. SAM.gov needs a key that is
 # specifically associated with a SAM.gov account holding the Entity API role, so
@@ -70,13 +114,18 @@ API_KEY_ENV_VARS = (
 
 # Transport hygiene: bound every request and retry transient failures with
 # backoff so a flaky page fails slow-then-recovers rather than dropping entities.
-_TIMEOUT = httpx.Timeout(60.0, connect=30.0)
+_TIMEOUT = httpx.Timeout(120.0, connect=30.0)
 _MAX_RETRIES = 5
 _PROGRESS_EVERY = 5_000
 
 # Safety cap on pages walked in a single run, independent of ``max_records`` — a
 # backstop against a runaway loop on an unexpectedly large window.
 _MAX_PAGES = 100_000
+
+# Async extracts are generated server-side; the download URL may not be ready on
+# the first GET. Poll it with backoff up to this many attempts before giving up.
+_EXTRACT_POLL_MAX = 60
+_EXTRACT_POLL_INTERVAL = 10.0
 
 
 def _resolve_api_key() -> str | None:
@@ -89,24 +138,37 @@ def _resolve_api_key() -> str | None:
 
 
 class SamEntitiesReader(Reader):
-    """Yields raw SAM.gov entity dicts (the ``entityData[]`` records), page by page.
+    """Yields raw SAM.gov entity dicts (the ``entityData[]`` records).
 
-    ``max_records`` bounds a run so a scheduled ingest never attempts a full
-    backfill; ``registration_status`` filters the extract (``A`` = active). The
-    transform handles merging with the prior published table. With no key
-    configured the reader yields nothing.
+    ``mode`` selects the ingest mechanism: ``"extract"`` (default) uses SAM's bulk
+    async extract (``format=json``) — one request per ``registrationDate`` window,
+    up to 1M records each, well past the 5K synchronous ceiling; ``"partition"``
+    walks the paginated endpoint, adaptively subdividing windows so each stays under
+    that ceiling. ``max_records`` bounds a run; ``since_year``/``until_year`` bound
+    the window range so scheduled runs can advance coverage. With no key configured
+    the reader yields nothing.
     """
 
     def __init__(
         self,
         *,
+        mode: str = "extract",
         registration_status: str = "A",
+        since_year: int | None = None,
+        until_year: int | None = None,
+        year_windows: bool = True,
         max_records: int | None = None,
         per_page: int = PER_PAGE,
         api_key: str | None = None,
         verbose: bool = False,
     ) -> None:
+        if mode not in ("extract", "partition"):
+            raise ValueError(f"mode must be 'extract' or 'partition', got {mode!r}")
+        self.mode = mode
         self.registration_status = registration_status
+        self.since_year = since_year
+        self.until_year = until_year
+        self.year_windows = year_windows
         self.max_records = max_records
         self.per_page = min(per_page, PER_PAGE)
         self.api_key = api_key or _resolve_api_key()
@@ -122,68 +184,207 @@ class SamEntitiesReader(Reader):
             )
             return
         logger.info(
-            "SAM entities: fetching registrationStatus={} (max_records={})",
+            "SAM entities: mode={} registrationStatus={} years={}..{} (max_records={})",
+            self.mode,
             self.registration_status,
+            self.since_year if self.since_year is not None else "min",
+            self.until_year if self.until_year is not None else "now",
             self.max_records if self.max_records is not None else "all",
         )
-        with httpx.Client(timeout=_TIMEOUT, headers={"Accept": "application/json"}) as client:
+        # follow_redirects: extract download URLs commonly 302 to a signed blob URL.
+        with httpx.Client(timeout=_TIMEOUT, headers={"Accept": "application/json"}, follow_redirects=True) as client:
             self._client = client
-            yield from self._paginate()
+            if self.mode == "extract":
+                yield from self._iter_extract()
+            else:
+                yield from self._iter_partitioned()
         logger.info("SAM entities: yielded {:,} entities", self._seen)
 
-    # -- pagination ----------------------------------------------------------
+    # -- shared helpers ------------------------------------------------------
 
-    def _paginate(self) -> Iterator[dict]:
-        """Follow ``links.nextLink`` until exhausted, ``max_records``, or the cap.
+    def _year_range(self) -> tuple[int, int]:
+        """Inclusive [since, until] year range to window over."""
+        since = self.since_year if self.since_year is not None else _MIN_REGISTRATION_YEAR
+        until = self.until_year if self.until_year is not None else date.today().year
+        return since, until
 
-        The first request is built from ``page=0``; every subsequent page is the
-        server-provided ``nextLink`` (with the real api_key re-injected, since SAM
-        masks it in the returned link). Walking stops when a page is empty, when
-        there is no ``nextLink``, or at the ``_MAX_PAGES`` runaway backstop.
-        """
-        url = f"{API_BASE}/entities"
-        params: dict[str, object] | None = {
-            "api_key": self.api_key,
-            "page": 0,
-            "size": self.per_page,
-        }
+    def _budget_left(self) -> bool:
+        return self.max_records is None or self._seen < self.max_records
+
+    def _emit(self, record: dict) -> Iterator[dict]:
+        """Yield one record honouring ``max_records`` and progress logging."""
+        if not self._budget_left():
+            return
+        self._seen += 1
+        if self._seen % _PROGRESS_EVERY == 0:
+            logger.info("SAM entities: {:,} entities so far...", self._seen)
+        yield record
+
+    def _base_params(self) -> dict[str, object]:
+        params: dict[str, object] = {"api_key": self.api_key}
         if self.registration_status:
             params["registrationStatus"] = self.registration_status
+        return params
+
+    # -- A. bulk extract -----------------------------------------------------
+
+    def _iter_extract(self) -> Iterator[dict]:
+        """Fetch the registry via SAM's async extract, one window per request.
+
+        By default windows over ``registrationDate`` years so no single downloaded
+        file is unbounded in memory; ``year_windows=False`` requests a single extract
+        for the whole ``registrationStatus`` filter.
+        """
+        if not self.year_windows:
+            yield from self._extract_window(None)
+            return
+        since, until = self._year_range()
+        for year in range(since, until + 1):
+            if not self._budget_left():
+                return
+            if self.verbose:
+                logger.debug("SAM entities: extract window year={}", year)
+            yield from self._extract_window(year)
+
+    def _extract_window(self, year: int | None) -> Iterator[dict]:
+        """Request + download one extract (optionally scoped to a registration year)."""
+        params = self._base_params()
+        params["format"] = "json"
+        if year is not None:
+            params["registrationDate"] = _year_range_literal(year)
+        trigger = self._get(f"{API_BASE}/entities", params)
+        if trigger is None:
+            return
+        download_url = _find_download_url(trigger)
+        if download_url:
+            records: Iterator[dict] = self._download_extract(download_url)
+        else:
+            # No extract URL: a small window may have come back inline instead. Fall
+            # back to any ``entityData`` in the trigger; only warn if there's nothing.
+            inline = trigger.get("entityData")
+            if not inline:
+                logger.warning(
+                    "SAM entities: extract response for year={} had no download URL or inline data — skipping",
+                    year,
+                )
+                return
+            records = iter(r for r in inline if isinstance(r, dict))
+        for record in records:
+            if not self._budget_left():
+                return
+            yield from self._emit(record)
+
+    def _download_extract(self, download_url: str) -> Iterator[dict]:
+        """Download an extract file and yield its entity records (defensive parse)."""
+        assert self._client is not None
+        url = self._reinject_key(download_url)
+        for attempt in range(1, _EXTRACT_POLL_MAX + 1):
+            try:
+                resp = self._client.get(url)
+            except httpx.HTTPError as exc:
+                logger.warning("SAM entities: extract download error {} (attempt {})", exc, attempt)
+                time.sleep(_EXTRACT_POLL_INTERVAL)
+                continue
+            # The file may still be generating: SAM answers 202/404 until ready.
+            if resp.status_code in (202, 404, 429) or resp.status_code >= 500:
+                if attempt == _EXTRACT_POLL_MAX:
+                    logger.error("SAM entities: extract not ready after {} polls — giving up", attempt)
+                    return
+                time.sleep(_EXTRACT_POLL_INTERVAL)
+                continue
+            resp.raise_for_status()
+            yield from _parse_extract_bytes(resp.content)
+            return
+
+    # -- B. partitioned walk -------------------------------------------------
+
+    def _iter_partitioned(self) -> Iterator[dict]:
+        """Adaptive ``registrationDate`` window recursion over the paginated endpoint."""
+        since, until = self._year_range()
+        yield from self._fetch_window(date(since, 1, 1), date(until, 12, 31))
+
+    def _fetch_window(self, gte: date, lte: date) -> Iterator[dict]:
+        """Walk one registration-date window, subdividing when it exceeds the ceiling.
+
+        We first read the window's ``totalRecords``; if it is above
+        :data:`PAGE_CEILING` the paginated walk cannot reach every record, so we halve
+        the window and recurse (down to a single day). Otherwise we page it fully.
+        """
+        if not self._budget_left():
+            return
+        total = self._window_total(gte, lte)
+        if total is None:
+            return
+        if total > PAGE_CEILING and gte < lte:
+            mid = gte + (lte - gte) // 2
+            if self.verbose:
+                logger.debug(
+                    "SAM entities: window {}..{} has {} > {}, splitting at {}", gte, lte, total, PAGE_CEILING, mid
+                )
+            yield from self._fetch_window(gte, mid)
+            yield from self._fetch_window(_next_day(mid), lte)
+            return
+        if total > PAGE_CEILING:
+            # A single day still exceeds the ceiling — accept the reachable slice but
+            # make the residual gap loud rather than silent.
+            logger.warning(
+                "SAM entities: single day {} has {} entities > {} ceiling — some unreachable", gte, total, PAGE_CEILING
+            )
+        yield from self._page_window(gte, lte)
+
+    def _window_total(self, gte: date, lte: date) -> int | None:
+        """Return ``totalRecords`` for a registration-date window (a cheap size=1 probe)."""
+        params = self._base_params()
+        params["registrationDate"] = _range_literal(gte, lte)
+        params["page"] = 0
+        params["size"] = 1
+        payload = self._get(f"{API_BASE}/entities", params)
+        if payload is None:
+            return None
+        return int(payload.get("totalRecords") or 0)
+
+    def _page_window(self, gte: date, lte: date) -> Iterator[dict]:
+        """Follow ``links.nextLink`` through one window until exhausted or the ceiling."""
+        url = f"{API_BASE}/entities"
+        params: dict[str, object] | None = self._base_params()
+        assert params is not None
+        params["registrationDate"] = _range_literal(gte, lte)
+        params["page"] = 0
+        params["size"] = self.per_page
 
         for _ in range(_MAX_PAGES):
+            if not self._budget_left():
+                return
             payload = self._get(url, params)
             if payload is None:
-                break
+                return
             records = payload.get("entityData") or []
             if not records:
-                break
+                return
             for record in records:
-                if self.max_records is not None and self._seen >= self.max_records:
-                    if self.verbose:
-                        logger.debug("SAM entities: reached max_records={} — stopping", self.max_records)
+                if not self._budget_left():
                     return
-                self._seen += 1
-                if self._seen % _PROGRESS_EVERY == 0:
-                    logger.info("SAM entities: {:,} entities so far...", self._seen)
-                yield record
-            # Prefer the server's own pagination link; fall back to page-count
-            # exhaustion when a short page signals there is nothing more.
+                yield from self._emit(record)
             next_link = (payload.get("links") or {}).get("nextLink")
             if not next_link or len(records) < self.per_page:
-                break
-            url = self._authorize_next_link(next_link)
+                return
+            url = self._reinject_key(next_link)
             params = None  # nextLink already carries page/size/filter as a query string
         else:
             logger.warning("SAM entities: hit the _MAX_PAGES={} runaway guard — stopping", _MAX_PAGES)
 
-    def _authorize_next_link(self, next_link: str) -> str:
-        """Return ``next_link`` with the real api_key re-injected.
+    # -- transport -----------------------------------------------------------
 
-        SAM returns the ``nextLink`` with its ``api_key`` masked as a placeholder,
-        so following it verbatim would 404. We overwrite that query param with the
-        configured key and leave the rest of the link (page/size/filter) intact.
+    def _reinject_key(self, link: str) -> str:
+        """Return ``link`` with the real api_key re-injected.
+
+        SAM returns links with their ``api_key`` masked — either as a query-param
+        placeholder (``nextLink``) or as the literal ``REPLACE_WITH_API_KEY`` token
+        (extract download URLs). We overwrite the query param and swap the token so
+        the link is usable, leaving the rest (page/size/filter/fileName) intact.
         """
-        parts = urlparse(next_link)
+        link = link.replace(_API_KEY_PLACEHOLDER, self.api_key or "")
+        parts = urlparse(link)
         query = parse_qs(parts.query, keep_blank_values=True)
         query["api_key"] = [self.api_key or ""]
         return urlunparse(parts._replace(query=urlencode(query, doseq=True)))
@@ -216,3 +417,129 @@ class SamEntitiesReader(Reader):
                 logger.warning("SAM entities: {} (attempt {}/{}), retrying in {}s", exc, attempt, _MAX_RETRIES, backoff)
                 time.sleep(backoff)
         return None
+
+
+# -- module-level pure helpers (unit-testable without a client) ---------------
+
+
+def _us_date(d: date) -> str:
+    """Format a date as SAM's MM/DD/YYYY."""
+    return f"{d.month:02d}/{d.day:02d}/{d.year}"
+
+
+def _range_literal(gte: date, lte: date) -> str:
+    """SAM ``registrationDate`` range literal ``[MM/DD/YYYY,MM/DD/YYYY]``."""
+    return f"[{_us_date(gte)},{_us_date(lte)}]"
+
+
+def _year_range_literal(year: int) -> str:
+    """SAM ``registrationDate`` range literal spanning a whole calendar year."""
+    return _range_literal(date(year, 1, 1), date(year, 12, 31))
+
+
+def _next_day(d: date) -> date:
+    return date.fromordinal(d.toordinal() + 1)
+
+
+def _find_download_url(payload: object) -> str | None:
+    """Recursively locate an extract download URL in a trigger response.
+
+    SAM returns the async-extract download link embedded in the JSON envelope,
+    carrying the literal ``REPLACE_WITH_API_KEY`` placeholder. The exact key path
+    has varied across API versions, so we walk the structure and return the first
+    string that looks like that download URL (placeholder preferred; otherwise any
+    http(s) URL that mentions download/extract).
+    """
+    fallback: str | None = None
+
+    def walk(node: object) -> str | None:
+        nonlocal fallback
+        if isinstance(node, str):
+            if _API_KEY_PLACEHOLDER in node and node.startswith("http"):
+                return node
+            if (
+                fallback is None
+                and node.startswith("http")
+                and ("download" in node.lower() or "extract" in node.lower())
+            ):
+                fallback = node
+            return None
+        if isinstance(node, dict):
+            for value in node.values():
+                hit = walk(value)
+                if hit:
+                    return hit
+        elif isinstance(node, list):
+            for value in node:
+                hit = walk(value)
+                if hit:
+                    return hit
+        return None
+
+    return walk(payload) or fallback
+
+
+def _parse_extract_bytes(raw: bytes) -> Iterator[dict]:
+    """Yield entity dicts from a downloaded extract file (defensive across formats).
+
+    Handles gzip- and zip-compressed payloads, then parses the inner text as either
+    a JSON envelope (``{"entityData": [...]}``), a bare JSON array of entities, or
+    newline-delimited JSON. Anything unrecognisable yields nothing.
+    """
+    text = _decompress_extract(raw)
+    if not text:
+        return
+    stripped = text.lstrip()
+    if stripped[:1] in ("{", "["):
+        try:
+            doc = json.loads(stripped)
+        except ValueError:
+            yield from _iter_ndjson(text)
+            return
+        if isinstance(doc, dict):
+            records = doc.get("entityData")
+            if isinstance(records, list):
+                yield from (r for r in records if isinstance(r, dict))
+            elif _looks_like_entity(doc):
+                yield doc
+            return
+        if isinstance(doc, list):
+            yield from (r for r in doc if isinstance(r, dict))
+            return
+    yield from _iter_ndjson(text)
+
+
+def _decompress_extract(raw: bytes) -> str:
+    """Return the extract's inner text, transparently decompressing gzip/zip."""
+    if raw[:2] == b"\x1f\x8b":  # gzip magic
+        try:
+            return gzip.decompress(raw).decode("utf-8", "replace")
+        except OSError:
+            return ""
+    if raw[:2] == b"PK":  # zip magic
+        try:
+            with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+                names = zf.namelist()
+                if not names:
+                    return ""
+                return zf.read(names[0]).decode("utf-8", "replace")
+        except zipfile.BadZipFile:
+            return ""
+    return raw.decode("utf-8", "replace")
+
+
+def _iter_ndjson(text: str) -> Iterator[dict]:
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def _looks_like_entity(doc: dict) -> bool:
+    return "entityRegistration" in doc or "ueiSAM" in doc

--- a/src/spicy_regs/transforms/build_sam_entities.py
+++ b/src/spicy_regs/transforms/build_sam_entities.py
@@ -15,10 +15,20 @@ short run. Instead we:
 
 With no prior table (first run) step 2 seeds the table; subsequent runs refresh
 and extend coverage. A full backfill is never triggered implicitly — raise
-``max_records`` deliberately for a wider pull.
+``max_records`` (and widen the year range) deliberately for a wider pull.
+
+Coverage mechanism (``mode``). The default ``"extract"`` mode fetches via SAM's
+bulk async extract (``format=json``), one request per ``registrationDate`` year,
+each returning up to 1M records — so full coverage of the ~765K active registry
+is reachable within the 1,000 req/day key budget (≈20 year-window requests) rather
+than the ~76,000 paginated requests the 10-record synchronous page would need. The
+``"partition"`` fallback walks the paginated endpoint with adaptive date-window
+subdivision (see :mod:`spicy_regs.sources.sam_entities`). Both are bounded by
+``max_records`` and the ``[since_year, until_year]`` window range, so a scheduled
+run advances coverage and the merge accretes it across runs.
 
 Scope is deliberately **list-level only**: every column comes from the
-``/entities`` list payload, so there are no per-entity detail fetches.
+``/entities`` payload, so there are no per-entity detail fetches.
 """
 
 from __future__ import annotations
@@ -110,8 +120,18 @@ def build_sam_entities(
     *,
     max_records: int | None = DEFAULT_MAX_RECORDS,
     registration_status: str = "A",
+    mode: str = "extract",
+    since_year: int | None = None,
+    until_year: int | None = None,
+    year_windows: bool = True,
 ) -> Path:
-    """Build ``sam_entities.parquet`` (incremental merge with the prior table)."""
+    """Build ``sam_entities.parquet`` (incremental merge with the prior table).
+
+    ``mode`` selects the coverage mechanism (``"extract"`` bulk async extract, the
+    default, or ``"partition"`` paginated adaptive walk); ``since_year``/``until_year``
+    bound the ``registrationDate`` window range walked this run. See the module
+    docstring and :mod:`spicy_regs.sources.sam_entities` for the full-coverage story.
+    """
     import duckdb
 
     out_file = output_dir / OUTPUT
@@ -125,7 +145,14 @@ def build_sam_entities(
         logger.info("SAM entities: no prior table found — seeding a new table")
 
     # 2. Fetch + shape into a "new rows" parquet.
-    reader = SamEntitiesReader(registration_status=registration_status, max_records=max_records)
+    reader = SamEntitiesReader(
+        mode=mode,
+        registration_status=registration_status,
+        since_year=since_year,
+        until_year=until_year,
+        year_windows=year_windows,
+        max_records=max_records,
+    )
     rows = [_shape(doc) for doc in reader.iter_records()]
     new_file = output_dir / "_sam_new.parquet"
     table = pa.Table.from_pylist(rows, schema=_SCHEMA) if rows else _SCHEMA.empty_table()

--- a/tests/test_sam_entities.py
+++ b/tests/test_sam_entities.py
@@ -1,19 +1,36 @@
 """Hermetic tests for the SAM.gov entity ingest (no network).
 
 Covers the pieces with real logic: the raw-entity -> published-schema mapping
-(``_shape``), the API-key resolution fallback chain, the keyless no-op, and the
-page walk with early stop at ``max_records``. The fixture below is a trimmed but
-faithful copy of a real ``entityData[]`` record from the v4 ``/entities`` list
-response.
+(``_shape``), the API-key resolution fallback chain, the keyless no-op, the bulk
+*extract* path (trigger -> download-URL discovery -> defensive file parse, with
+``registrationDate`` year-windowing and ``max_records`` bounding), and the
+*partition* path's adaptive date-window subdivision + paginated walk. The fixture
+below is a trimmed but faithful copy of a real ``entityData[]`` record from the v4
+``/entities`` response.
 """
 
 from __future__ import annotations
 
+import gzip
+import io
+import json
+import zipfile
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from spicy_regs.sources import sam_entities as sam
 from spicy_regs.sources.sam_entities import (
     API_KEY_ENV_VARS,
     PER_PAGE,
     SamEntitiesReader,
+    _find_download_url,
+    _parse_extract_bytes,
+    _range_literal,
     _resolve_api_key,
+    _us_date,
+    _year_range_literal,
 )
 from spicy_regs.transforms.build_sam_entities import COLUMNS, _shape
 
@@ -150,11 +167,315 @@ def test_reader_caps_page_size():
     assert reader.per_page == PER_PAGE
 
 
-# -- pagination --------------------------------------------------------------
+def test_reader_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="mode must be"):
+        SamEntitiesReader(mode="bogus")
+
+
+# -- date literals -----------------------------------------------------------
+
+
+def test_us_date_and_range_literals():
+    assert _us_date(date(2020, 1, 5)) == "01/05/2020"
+    assert _range_literal(date(2020, 1, 1), date(2020, 12, 31)) == "[01/01/2020,12/31/2020]"
+    assert _year_range_literal(2021) == "[01/01/2021,12/31/2021]"
+
+
+# -- extract: download-URL discovery -----------------------------------------
+
+
+def test_find_download_url_prefers_placeholder_link():
+    payload = {
+        "totalRecords": 764850,
+        "links": {"selfLink": "https://api.sam.gov/entity-information/v4/entities?api_key=X"},
+        "download": "https://api.sam.gov/comp/extracts/ENTITY_123.json?api_key=REPLACE_WITH_API_KEY",
+    }
+    assert _find_download_url(payload) == payload["download"]
+
+
+def test_find_download_url_falls_back_to_download_like_url():
+    payload = {"result": {"fileUrl": "https://api.sam.gov/comp/extractfile/download/abc.zip"}}
+    assert _find_download_url(payload) == "https://api.sam.gov/comp/extractfile/download/abc.zip"
+
+
+def test_find_download_url_none_when_absent():
+    assert _find_download_url({"totalRecords": 0, "entityData": []}) is None
+
+
+# -- extract: defensive file parsing -----------------------------------------
 
 
 def _entity(uei: str) -> dict:
     return {"entityRegistration": {"ueiSAM": uei}}
+
+
+def _ueis(records) -> list[str]:
+    return [r["entityRegistration"]["ueiSAM"] for r in records]
+
+
+def test_parse_extract_envelope_json():
+    raw = json.dumps({"entityData": [_entity("A"), _entity("B")]}).encode()
+    assert _ueis(_parse_extract_bytes(raw)) == ["A", "B"]
+
+
+def test_parse_extract_bare_array():
+    raw = json.dumps([_entity("A"), _entity("C")]).encode()
+    assert _ueis(_parse_extract_bytes(raw)) == ["A", "C"]
+
+
+def test_parse_extract_ndjson():
+    raw = ("\n".join(json.dumps(_entity(u)) for u in ("A", "B", "C")) + "\n").encode()
+    assert _ueis(_parse_extract_bytes(raw)) == ["A", "B", "C"]
+
+
+def test_parse_extract_gzip_envelope():
+    raw = gzip.compress(json.dumps({"entityData": [_entity("Z")]}).encode())
+    assert _ueis(_parse_extract_bytes(raw)) == ["Z"]
+
+
+def test_parse_extract_zip_member():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("ENTITY.json", json.dumps([_entity("Q"), _entity("R")]))
+    assert _ueis(_parse_extract_bytes(buf.getvalue())) == ["Q", "R"]
+
+
+def test_parse_extract_empty_or_garbage():
+    assert list(_parse_extract_bytes(b"")) == []
+    assert list(_parse_extract_bytes(b"not json at all")) == []
+
+
+# -- extract: orchestration (year windows + max_records) ---------------------
+
+
+def test_extract_windows_over_years_and_dedups_disjoint(monkeypatch):
+    """Each registrationDate year triggers its own extract; results union across years."""
+    reader = SamEntitiesReader(api_key="k", since_year=2019, until_year=2021)
+    calls: list[str] = []
+
+    def fake_extract_window(year):
+        calls.append(str(year))
+        # one record per year, disjoint UEIs
+        yield from reader._emit(_entity(f"Y{year}"))
+
+    monkeypatch.setattr(reader, "_extract_window", fake_extract_window)
+    got = _ueis(reader._iter_extract())
+    assert got == ["Y2019", "Y2020", "Y2021"]
+    assert calls == ["2019", "2020", "2021"]
+
+
+def test_extract_single_window_when_year_windows_disabled(monkeypatch):
+    reader = SamEntitiesReader(api_key="k", year_windows=False)
+    seen_years: list[int | None] = []
+
+    def fake_extract_window(year):
+        seen_years.append(year)
+        yield from reader._emit(_entity("A"))
+
+    monkeypatch.setattr(reader, "_extract_window", fake_extract_window)
+    got = _ueis(reader._iter_extract())
+    assert got == ["A"]
+    assert seen_years == [None]  # a single unscoped extract, no year windowing
+
+
+def test_extract_stops_at_max_records_across_windows(monkeypatch):
+    """max_records bounds the run mid-window and prevents further extract requests."""
+    reader = SamEntitiesReader(api_key="k", since_year=2019, until_year=2021, max_records=2)
+    calls: list[int] = []
+
+    def fake_extract_window(year):
+        calls.append(year)
+        for i in range(5):
+            yield from reader._emit(_entity(f"{year}-{i}"))
+
+    monkeypatch.setattr(reader, "_extract_window", fake_extract_window)
+    got = _ueis(reader._iter_extract())
+    assert got == ["2019-0", "2019-1"]
+    # The 2020/2021 windows are never requested — the budget was already spent.
+    assert calls == [2019]
+
+
+def test_extract_window_triggers_then_downloads(monkeypatch):
+    """_extract_window: trigger call -> find URL -> download -> yield records."""
+    reader = SamEntitiesReader(api_key="k")
+    triggered: list[dict] = []
+
+    def fake_get(url, params):
+        triggered.append(params)
+        return {"download": "https://api.sam.gov/x/f.json?api_key=REPLACE_WITH_API_KEY"}
+
+    monkeypatch.setattr(reader, "_get", fake_get)
+    monkeypatch.setattr(reader, "_download_extract", lambda url: iter([_entity("A"), _entity("B")]))
+    got = _ueis(reader._extract_window(2022))
+    assert got == ["A", "B"]
+    # The trigger request asked for a JSON extract scoped to the year.
+    assert triggered[0]["format"] == "json"
+    assert triggered[0]["registrationDate"] == "[01/01/2022,12/31/2022]"
+
+
+def test_extract_window_skips_when_no_download_url(monkeypatch):
+    reader = SamEntitiesReader(api_key="k")
+    monkeypatch.setattr(reader, "_get", lambda url, params: {"totalRecords": 0})
+    called = {"downloaded": False}
+
+    def fake_download(url):
+        called["downloaded"] = True
+        yield from ()
+
+    monkeypatch.setattr(reader, "_download_extract", fake_download)
+    assert list(reader._extract_window(2022)) == []
+    assert called["downloaded"] is False
+
+
+def test_extract_window_falls_back_to_inline_data(monkeypatch):
+    """A small window returned inline (no extract URL) is still ingested."""
+    reader = SamEntitiesReader(api_key="k")
+    monkeypatch.setattr(
+        reader, "_get", lambda url, params: {"totalRecords": 2, "entityData": [_entity("A"), _entity("B")]}
+    )
+    # _download_extract must not be reached when there is no URL but inline data exists.
+    monkeypatch.setattr(reader, "_download_extract", lambda url: (_ for _ in ()).throw(AssertionError("unexpected")))
+    assert _ueis(reader._extract_window(2022)) == ["A", "B"]
+
+
+# -- extract: download polling ----------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, content: bytes = b""):
+        self.status_code = status_code
+        self.content = content
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise AssertionError(f"unexpected raise_for_status at {self.status_code}")
+
+
+class _FakeClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[str] = []
+
+    def get(self, url):
+        self.calls.append(url)
+        return self._responses.pop(0)
+
+
+def test_download_extract_polls_until_ready(monkeypatch):
+    monkeypatch.setattr(sam.time, "sleep", lambda *_: None)
+    reader = SamEntitiesReader(api_key="secret")
+    body = json.dumps({"entityData": [_entity("A"), _entity("B")]}).encode()
+    fake = _FakeClient([_FakeResp(202), _FakeResp(202), _FakeResp(200, body)])
+    monkeypatch.setattr(reader, "_client", fake)
+    got = _ueis(reader._download_extract("https://api.sam.gov/x/f.json?api_key=REPLACE_WITH_API_KEY"))
+    assert got == ["A", "B"]
+    # The masked placeholder was swapped for the real key on the download request.
+    assert "REPLACE_WITH_API_KEY" not in fake.calls[0]
+    assert "api_key=secret" in fake.calls[0]
+
+
+def test_download_extract_gives_up_after_poll_max(monkeypatch):
+    monkeypatch.setattr(sam.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(sam, "_EXTRACT_POLL_MAX", 3)
+    reader = SamEntitiesReader(api_key="secret")
+    fake = _FakeClient([_FakeResp(202), _FakeResp(202), _FakeResp(202)])
+    monkeypatch.setattr(reader, "_client", fake)
+    assert list(reader._download_extract("https://api.sam.gov/x/f.json")) == []
+
+
+# -- reinject key ------------------------------------------------------------
+
+
+def test_reinject_key_reinjects_query_param():
+    """SAM masks the api_key in nextLink; the reader swaps in the configured key."""
+    reader = SamEntitiesReader(api_key="real-secret")
+    masked = (
+        "https://api.sam.gov/entity-information/v4/entities"
+        "?api_key=REPLACE_WITH_API_KEY&page=5&size=10&registrationStatus=A"
+    )
+    out = reader._reinject_key(masked)
+    from urllib.parse import parse_qs, urlparse
+
+    q = parse_qs(urlparse(out).query)
+    assert q["api_key"] == ["real-secret"]
+    assert q["page"] == ["5"]
+    assert q["size"] == ["10"]
+    assert q["registrationStatus"] == ["A"]
+
+
+def test_reinject_key_swaps_placeholder_token_in_path():
+    reader = SamEntitiesReader(api_key="real-secret")
+    # Extract URLs can carry the placeholder anywhere, including outside the query.
+    masked = "https://api.sam.gov/comp/extractfile/REPLACE_WITH_API_KEY/ENTITY.json"
+    out = reader._reinject_key(masked)
+    assert "REPLACE_WITH_API_KEY" not in out
+    assert "api_key=real-secret" in out
+
+
+# -- partition walk: adaptive subdivision ------------------------------------
+
+
+def test_partition_subdivides_window_over_ceiling(monkeypatch):
+    """A window whose totalRecords exceeds the ceiling is halved until pageable."""
+    reader = SamEntitiesReader(mode="partition", api_key="k", since_year=2020, until_year=2020)
+
+    # Full year is over the ceiling; each half is under it.
+    def fake_total(gte, lte):
+        span_days = (lte - gte).days
+        return 8000 if span_days > 200 else 4000
+
+    paged: list[tuple[date, date]] = []
+
+    def fake_page(gte, lte):
+        paged.append((gte, lte))
+        yield from reader._emit(_entity(f"{gte.isoformat()}..{lte.isoformat()}"))
+
+    monkeypatch.setattr(reader, "_window_total", fake_total)
+    monkeypatch.setattr(reader, "_page_window", fake_page)
+    got = _ueis(reader._iter_partitioned())
+
+    # The year split into two disjoint, contiguous halves; each leaf was paged once.
+    assert len(paged) == 2
+    (g1, l1), (g2, l2) = paged
+    assert g1 == date(2020, 1, 1)
+    assert l2 == date(2020, 12, 31)
+    assert g2 == date.fromordinal(l1.toordinal() + 1)  # no gap, no overlap
+    assert got == [f"{g1}..{l1}", f"{g2}..{l2}"]
+
+
+def test_partition_pages_window_under_ceiling_without_split(monkeypatch):
+    reader = SamEntitiesReader(mode="partition", api_key="k", since_year=2020, until_year=2020)
+    monkeypatch.setattr(reader, "_window_total", lambda gte, lte: 12)
+    paged: list[tuple[date, date]] = []
+
+    def fake_page(gte, lte):
+        paged.append((gte, lte))
+        yield from reader._emit(_entity("solo"))
+
+    monkeypatch.setattr(reader, "_page_window", fake_page)
+    got = _ueis(reader._iter_partitioned())
+    assert paged == [(date(2020, 1, 1), date(2020, 12, 31))]  # single window, no split
+    assert got == ["solo"]
+
+
+def test_partition_single_day_over_ceiling_warns_but_pages(monkeypatch):
+    """A single day still over the ceiling is paged (best-effort), not infinitely split."""
+    reader = SamEntitiesReader(mode="partition", api_key="k", since_year=2020, until_year=2020)
+    monkeypatch.setattr(reader, "_window_total", lambda gte, lte: 9000)  # always over ceiling
+    paged: list[tuple[date, date]] = []
+
+    def fake_page(gte, lte):
+        paged.append((gte, lte))
+        yield from ()
+
+    monkeypatch.setattr(reader, "_page_window", fake_page)
+    list(reader._iter_partitioned())
+    # Recursion bottomed out at single days (365/366 of them), each paged once.
+    assert len(paged) >= 365
+    assert all(gte == lte for gte, lte in paged)
+
+
+# -- partition walk: paginated nextLink follow -------------------------------
 
 
 def _page(records: list[dict], *, next_link: str | None) -> dict:
@@ -179,9 +500,8 @@ def _by_page_get(pages: dict[int, dict]):
     return _get
 
 
-def test_paginate_follows_nextlink_until_absent(monkeypatch):
-    """The walk follows ``links.nextLink`` across pages and stops when it is gone."""
-    reader = SamEntitiesReader(api_key="test", per_page=2)
+def test_page_window_follows_nextlink_until_absent(monkeypatch):
+    reader = SamEntitiesReader(mode="partition", api_key="test", per_page=2)
     base = "https://api.sam.gov/entity-information/v4/entities"
     pages = {
         0: _page([_entity("A"), _entity("B")], next_link=f"{base}?api_key=MASKED&page=1&size=2"),
@@ -189,42 +509,89 @@ def test_paginate_follows_nextlink_until_absent(monkeypatch):
         2: _page([_entity("E")], next_link=f"{base}?api_key=MASKED&page=3&size=2"),  # short -> stop
     }
     monkeypatch.setattr(reader, "_get", _by_page_get(pages))
-    got = [r["entityRegistration"]["ueiSAM"] for r in reader._paginate()]
+    got = _ueis(reader._page_window(date(2020, 1, 1), date(2020, 12, 31)))
     assert got == ["A", "B", "C", "D", "E"]
 
 
-def test_paginate_stops_when_nextlink_missing(monkeypatch):
-    """A full final page with no ``nextLink`` ends the walk (no extra fetch)."""
-    reader = SamEntitiesReader(api_key="test", per_page=2)
+def test_page_window_stops_when_nextlink_missing(monkeypatch):
+    reader = SamEntitiesReader(mode="partition", api_key="test", per_page=2)
     base = "https://api.sam.gov/entity-information/v4/entities"
     pages = {
         0: _page([_entity("A"), _entity("B")], next_link=f"{base}?api_key=MASKED&page=1&size=2"),
         1: _page([_entity("C"), _entity("D")], next_link=None),  # full page, no nextLink -> stop
     }
     monkeypatch.setattr(reader, "_get", _by_page_get(pages))
-    got = [r["entityRegistration"]["ueiSAM"] for r in reader._paginate()]
+    got = _ueis(reader._page_window(date(2020, 1, 1), date(2020, 12, 31)))
     assert got == ["A", "B", "C", "D"]
 
 
-def test_paginate_stops_at_max_records(monkeypatch):
-    """``max_records`` bounds the walk mid-page (no full backfill)."""
-    reader = SamEntitiesReader(api_key="test", per_page=3, max_records=2)
+def test_page_window_stops_at_max_records(monkeypatch):
+    reader = SamEntitiesReader(mode="partition", api_key="test", per_page=3, max_records=2)
     base = "https://api.sam.gov/entity-information/v4/entities"
     pages = {0: _page([_entity("A"), _entity("B"), _entity("C")], next_link=f"{base}?api_key=MASKED&page=1&size=3")}
     monkeypatch.setattr(reader, "_get", _by_page_get(pages))
-    got = [r["entityRegistration"]["ueiSAM"] for r in reader._paginate()]
+    got = _ueis(reader._page_window(date(2020, 1, 1), date(2020, 12, 31)))
     assert got == ["A", "B"]
 
 
-def test_authorize_next_link_reinjects_real_key():
-    """SAM masks the api_key in nextLink; the reader swaps in the configured key."""
-    reader = SamEntitiesReader(api_key="real-secret")
-    masked = "https://api.sam.gov/entity-information/v4/entities?api_key=REPLACE_WITH_API_KEY&page=5&size=10&registrationStatus=A"
-    out = reader._authorize_next_link(masked)
-    from urllib.parse import parse_qs, urlparse
+# -- rollup: bounded rotation + env overrides --------------------------------
 
-    q = parse_qs(urlparse(out).query)
-    assert q["api_key"] == ["real-secret"]
-    assert q["page"] == ["5"]
-    assert q["size"] == ["10"]
-    assert q["registrationStatus"] == ["A"]
+
+def test_rotating_year_covers_full_range_over_a_cycle():
+    from spicy_regs.pipelines.rollups.sam_entities import _MIN_REGISTRATION_YEAR, _rotating_year
+
+    today = date(2026, 7, 18)
+    span = today.year - _MIN_REGISTRATION_YEAR + 1
+    seen = {_rotating_year(date.fromordinal(today.toordinal() + d)) for d in range(span)}
+    # A full rotation touches every year in [min, current] exactly once.
+    assert seen == set(range(_MIN_REGISTRATION_YEAR, today.year + 1))
+
+
+def test_int_env_parses_blank_and_bad_values(monkeypatch):
+    from spicy_regs.pipelines.rollups.sam_entities import _int_env
+
+    monkeypatch.delenv("SAM_MAX_RECORDS", raising=False)
+    assert _int_env("SAM_MAX_RECORDS") is None
+    monkeypatch.setenv("SAM_MAX_RECORDS", "  ")
+    assert _int_env("SAM_MAX_RECORDS") is None
+    monkeypatch.setenv("SAM_MAX_RECORDS", "not-a-number")
+    assert _int_env("SAM_MAX_RECORDS") is None
+    monkeypatch.setenv("SAM_MAX_RECORDS", "25000")
+    assert _int_env("SAM_MAX_RECORDS") == 25000
+
+
+def test_rollup_build_defaults_to_rotating_single_year(monkeypatch):
+    """With no env overrides the scheduled build fetches one rotating year window."""
+    from spicy_regs.pipelines.rollups import sam_entities as rollup
+
+    for var in ("SAM_INGEST_MODE", "SAM_SINCE_YEAR", "SAM_UNTIL_YEAR", "SAM_MAX_RECORDS"):
+        monkeypatch.delenv(var, raising=False)
+    captured: dict = {}
+
+    def fake_build(output_dir, **kwargs):
+        captured.update(kwargs)
+        return output_dir / "sam_entities.parquet"
+
+    monkeypatch.setattr(rollup, "build_sam_entities", fake_build)
+    rollup.SamEntitiesRollup().build(Path("/tmp/out"))
+    assert captured["mode"] == "extract"
+    assert captured["since_year"] == captured["until_year"]  # a single year window
+    assert captured["max_records"] is None
+
+
+def test_rollup_build_honours_explicit_range(monkeypatch, tmp_path):
+    from spicy_regs.pipelines.rollups import sam_entities as rollup
+
+    monkeypatch.setenv("SAM_SINCE_YEAR", "2000")
+    monkeypatch.setenv("SAM_UNTIL_YEAR", "2026")
+    monkeypatch.setenv("SAM_MAX_RECORDS", "0")  # blank/0 -> unbounded
+    monkeypatch.setenv("SAM_INGEST_MODE", "partition")
+    captured: dict = {}
+
+    def fake_build(output_dir, **kwargs):
+        captured.update(kwargs)
+        return output_dir / "sam_entities.parquet"
+
+    monkeypatch.setattr(rollup, "build_sam_entities", fake_build)
+    rollup.SamEntitiesRollup().build(tmp_path)
+    assert captured == {"mode": "partition", "since_year": 2000, "until_year": 2026, "max_records": None}


### PR DESCRIPTION
Makes `sam_entities` reach beyond the ~5K ceiling toward full coverage (~764,850 active entities). SAM's `/entities` API caps a single filtered query's pagination at ~5K and page `size` at 10, so the reader now **partitions the query space** (each partition stays under the cap), unioning + deduping on `uei`; bounded/resumable per run so the daily cron accretes and the merge stays shrink-guard-safe.

Validated hermetically: ruff + `ty check` clean, 75 tests pass (18 tables).

⚠️ **Live validation + the full backfill are pending a SAM API daily-quota reset** — the agent exhausted the quota while probing. Once it resets I'll run a bounded live check (prove it exceeds 5K distinct UEIs) and the full backfill. Note SAM appears to be **daily-quota-gated**, so full 764K coverage will accrete over several days of cron runs rather than one shot.