### PR TITLE
fix(comments): dedup the catalog comments view on read

### DIFF
--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -287,7 +287,20 @@ def _connect() -> duckdb.DuckDBPyConnection:
         if name == "comments" and catalog_attached:
             namespace = catalog["namespace"]  # type: ignore[index]
             try:
-                con.execute(f'CREATE VIEW comments AS SELECT * FROM {CATALOG_ALIAS}."{namespace}"."comments"')
+                # Dedup on read: keep one row per comment_id (latest modify_date).
+                # The catalog table can physically carry duplicate comment_id rows —
+                # DuckDB's Iceberg engine has no MERGE INTO, so the ETL upsert uses a
+                # plain DELETE, and DELETE does not reliably remove prior rows on the
+                # R2 Data Catalog, so a re-merged comment_id can leave its old row
+                # behind. This QUALIFY makes the read surface single-valued regardless;
+                # physical compaction reclaims the space out-of-band. Keep in sync with
+                # spicy_regs.mcp_server.
+                con.execute(
+                    f'CREATE VIEW comments AS '
+                    f'SELECT * FROM {CATALOG_ALIAS}."{namespace}"."comments" '
+                    f'QUALIFY ROW_NUMBER() OVER '
+                    f'(PARTITION BY comment_id ORDER BY modify_date DESC NULLS LAST) = 1'
+                )
                 continue
             except duckdb.Error as exc:
                 # Catalog reachable but the table isn't there yet — fall back to

--- a/scripts/dedupe_comments_catalog.py
+++ b/scripts/dedupe_comments_catalog.py
@@ -4,8 +4,15 @@
 The one-time seed that loaded the pre-existing R2 partition tree into the catalog
 duplicated rows for agencies that were loaded more than once — its per-agency
 ``DELETE`` did not remove prior rows on the R2 Data Catalog, so re-loads
-accumulated exact copies (e.g. OMB ~2.5x, NARA ~3.8x; FWS/EPA/DOT clean). Comments
-added later by the daily merge are unaffected — this is historical, not ongoing.
+accumulated exact copies (e.g. OMB ~2.5x, NARA ~3.8x; FWS/EPA/DOT clean).
+
+The daily merge is affected by the *same* unreliable ``DELETE`` (see
+``iceberg._merge``), just at a far smaller scale: only comment_ids that are
+re-merged — a comment whose ``modify_date`` advanced, or a key re-staged by the
+redundant sweep — can leave their old row behind, so a handful of near-1.00x
+duplicates trickle in per run. The read surface hides them (``mcp_server`` dedups
+the ``comments`` view on read); this job is how the physical rows are reclaimed,
+so it is worth re-running periodically, not only after the seed.
 
 Default mode is a **read-only audit**: it reports every agency whose row count
 exceeds its distinct ``comment_id`` count, plus totals. Nothing is written.

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -286,7 +286,26 @@ def _connect() -> duckdb.DuckDBPyConnection:
         if name == "comments" and catalog_attached:
             namespace = catalog["namespace"]  # type: ignore[index]
             try:
-                con.execute(f'CREATE VIEW comments AS SELECT * FROM {CATALOG_ALIAS}."{namespace}"."comments"')
+                # Dedup on read: keep one row per comment_id (latest modify_date).
+                # The catalog table can physically carry duplicate comment_id rows
+                # because DuckDB's Iceberg engine has no MERGE INTO, so the ETL
+                # upsert (iceberg._merge) removes superseded rows with a plain
+                # DELETE — and DELETE does not reliably remove prior rows on the R2
+                # Data Catalog (the same limitation dedupe_table works around by
+                # never deleting). Any comment_id that is re-merged (a comment whose
+                # modify_date advanced, or a key re-staged by the redundant sweep)
+                # can therefore leave its old row behind next to the new one. This
+                # QUALIFY makes the read surface single-valued regardless, so counts
+                # aren't inflated and comments aren't repeated; physical compaction
+                # (scripts/dedupe_comments_catalog.py) reclaims the space out-of-band.
+                # A filter on agency_code/docket_id pushes down ahead of the window,
+                # so the common point-lookup queries only dedup the rows they touch.
+                con.execute(
+                    f'CREATE VIEW comments AS '
+                    f'SELECT * FROM {CATALOG_ALIAS}."{namespace}"."comments" '
+                    f'QUALIFY ROW_NUMBER() OVER '
+                    f'(PARTITION BY comment_id ORDER BY modify_date DESC NULLS LAST) = 1'
+                )
                 continue
             except duckdb.Error as exc:
                 # Catalog reachable but the table isn't there yet — fall back to

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -147,6 +147,18 @@ def _merge(con, staging_files: list[Path], record_type: RecordType) -> None:
     since-year-filtered run stages only a slice, so an agency-wide delete would
     drop the rows it isn't re-inserting. ``modify_date`` is an ISO-8601 string,
     so the lexical ``>`` comparison orders chronologically.
+
+    CAVEAT — the ``DELETE`` does not reliably remove prior rows on the R2 Data
+    Catalog (the same limitation that made the one-time seed duplicate rows and
+    that :func:`dedupe_table` works around by never deleting). So a key that is
+    *re-merged* — an existing comment whose ``modify_date`` advanced, or a key the
+    redundant daily sweep re-stages — can be left behind next to its replacement,
+    growing physical duplicate ``comment_id`` rows over time. Brand-new keys are
+    unaffected (nothing to delete). This is why the read surface dedups on read
+    (``mcp_server`` wraps the ``comments`` view in a per-``comment_id`` QUALIFY)
+    and physical duplicates are reclaimed out-of-band by ``dedupe_table``; a
+    delete-free incremental upsert is not possible here because the only reliable
+    removal primitive on this catalog is a whole-table ``DROP`` + rebuild.
     """
     cols = list(record_type.schema)
     key = record_type.dedup_key

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -241,6 +241,46 @@ def test_sandbox_locks_configuration():
         con.execute("SET allow_unsigned_extensions=true")
 
 
+def test_comments_catalog_view_dedups_on_read():
+    """The catalog-backed ``comments`` view keeps one row per comment_id.
+
+    The R2 Data Catalog can physically carry duplicate comment_id rows: the ETL
+    upsert removes superseded rows with a plain ``DELETE``, which does not reliably
+    take on the catalog, so a re-merged comment_id can leave its old row behind.
+    ``_connect`` wraps the catalog table in a per-comment_id QUALIFY so the read
+    surface stays single-valued regardless. This locks in that dedup expression:
+    the newest ``modify_date`` wins, exactly one row survives per id, and
+    non-duplicated ids are untouched — which is also the ``count(*) ==
+    count(DISTINCT comment_id)`` invariant the freshness check relies on.
+    """
+    con = duckdb.connect()
+    con.execute(
+        """
+        CREATE TABLE raw (comment_id VARCHAR, modify_date VARCHAR, comment VARCHAR);
+        INSERT INTO raw VALUES
+            ('c1', '2024-01-01', 'old'),
+            ('c1', '2024-03-01', 'new'),
+            ('c1', '2024-02-01', 'mid'),
+            ('c2', NULL, 'only-null'),
+            ('c3', '2024-05-01', 'unique');
+        """
+    )
+    # The exact dedup wrapper used by the catalog `comments` view in `_connect`.
+    con.execute(
+        "CREATE VIEW comments AS SELECT * FROM raw "
+        "QUALIFY ROW_NUMBER() OVER "
+        "(PARTITION BY comment_id ORDER BY modify_date DESC NULLS LAST) = 1"
+    )
+    rows = con.execute("SELECT comment_id, comment FROM comments ORDER BY comment_id").fetchall()
+    assert rows == [("c1", "new"), ("c2", "only-null"), ("c3", "unique")]
+    counts = con.execute(
+        "SELECT count(*), count(DISTINCT comment_id) FROM comments"
+    ).fetchone()
+    assert counts is not None
+    total, distinct = counts
+    assert total == distinct == 3
+
+
 @pytest.mark.integration
 def test_connect_queries_r2_end_to_end():
     """Live: the real ``_connect`` (httpfs + R2 views) serves the MCP tools.


### PR DESCRIPTION
## Summary

The nightly **Check comments freshness** job has been red since **2026-07-08**, failing on its *uniqueness* check: the Iceberg `comments` catalog table carries duplicate `comment_id` rows (745 across EBSA/APHIS/CDC/USCIS/BIS on the 07-18 run).

These are **not** the one-time seed residue the code comments claim ("historical, not ongoing"). The catalog was verified clean twice on 2026-07-17 — a `dedupe --apply` at 16:33 (*"No duplication…"*) and a full freshness check at 18:09 (*"OK (uniqueness)…"*) — then had 745 duplicate rows by the 00:52 scheduled run. So the pipeline is actively reintroducing them.

**Root cause.** DuckDB's Iceberg engine has no `MERGE INTO`, so the daily upsert (`iceberg._merge`) removes superseded rows with a plain `DELETE` — and `DELETE` does not reliably remove prior rows on the R2 Data Catalog. This is the *exact* limitation `dedupe_table` already documents and works around ("Never `DELETE` … the historical duplication came from loads whose `DELETE` didn't remove prior rows"). Any `comment_id` that gets **re-merged** (a comment whose `modify_date` advanced, or a key re-staged by the redundant daily sweep) can leave its old row beside the new one, so a handful of near-1.00x duplicates accumulate each run (EBSA had more re-merged keys → 740). Brand-new keys are unaffected (nothing to delete). The same broken `DELETE` is in `upsert_comment_text`, which is why the streak began right after the 07-07/08 text-backfill runs.

A delete-free *incremental* upsert isn't possible here: the only reliable removal primitive on this catalog is a whole-table `DROP` + rebuild (what `dedupe_table` does out-of-band). The correct pattern under this constraint is **merge-on-read**: dedup the read surface, compact physically out-of-band.

**Fix.** Wrap the catalog `comments` view in a per-`comment_id` `QUALIFY ROW_NUMBER() … ORDER BY modify_date DESC` (latest wins) in both the canonical `spicy_regs.mcp_server` and the Vercel copy. The read surface is now single-valued regardless of physical duplicates, so counts aren't inflated, comments don't repeat, and the freshness uniqueness check goes green (it validates that same surface). A point-lookup filter on `agency_code`/`docket_id` pushes down ahead of the window, so common queries only dedup the rows they touch. Also corrects the now-false docstrings in `_merge` and the dedupe script.

**Not in this PR (needs catalog credentials / your approval):**
- Run the **Dedupe comments catalog** workflow with `apply=true`, then **Publish comments mirror**, to reclaim the ~745 existing physical duplicates.
- Consider periodic (scheduled) compaction so physical growth stays bounded.

## Test plan

- [x] `uv run pytest` (hermetic: `test_mcp_server.py`, `test_iceberg.py`, `test_data_dictionary.py` → 55 passed)
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run ty check` → All checks passed
- [x] Added a hermetic regression test (`test_comments_catalog_view_dedups_on_read`) asserting the dedup expression keeps one row per id (latest `modify_date`), leaves unique ids untouched, and yields `count(*) == count(DISTINCT comment_id)`.

## Checklist

- [x] My change is scoped to one concern
- [x] I added or updated tests for new behavior
- [x] I updated docs (corrected the misleading docstrings)
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yoXC3UkyWJ33bxbkYjfQF)_