### PR TITLE
ci: schedule weekly comments-catalog compaction + serialize catalog writers

### DIFF
--- a/.github/workflows/dedupe-comments-catalog.yml
+++ b/.github/workflows/dedupe-comments-catalog.yml
@@ -1,24 +1,31 @@
-name: Dedupe comments catalog (manual)
+name: Dedupe comments catalog
 
 # Audits and (optionally) removes duplicate rows from the Iceberg `comments`
-# catalog table. The one-time seed duplicated rows for agencies loaded more than
-# once (its per-agency DELETE didn't remove prior rows on the R2 Data Catalog);
-# the daily merge is unaffected. See scripts/dedupe_comments_catalog.py.
+# catalog table. Duplicates arise because DuckDB's Iceberg engine has no
+# MERGE INTO, so the daily upsert (iceberg._merge) removes superseded rows with a
+# plain DELETE — and DELETE does not reliably remove prior rows on the R2 Data
+# Catalog. The one-time seed hit this at large scale (agencies loaded more than
+# once kept exact copies); the daily merge hits it at small scale, so a handful
+# of re-merged comment_ids leak in per run. The read surface hides them
+# (mcp_server dedups the `comments` view on read); this job reclaims the physical
+# rows. See scripts/dedupe_comments_catalog.py.
 #
-# Manual dispatch only — the apply path WRITES to the production catalog, so it
-# never runs on a schedule. It defaults to a read-only audit; flip `apply` on to
-# rebuild the table deduplicated. The rebuild writes a fresh table per-agency and
-# swaps it in by RENAME (never DELETE, never a whole-table single write), ordered
-# so an unsupported RENAME fails with the live table still in place.
-#
-# Recommended sequence: run once with apply=false (audit), review the report in
-# the logs, run again with apply=true, then run apply=false once more to confirm
-# it's clean. After a successful apply, run the "Publish comments mirror" workflow
-# so the public files the UI reads are refreshed from the cleaned catalog.
+# Runs weekly (Sunday 09:00 UTC) as physical compaction — the read-side dedup
+# already keeps queries + the freshness check correct, so this is housekeeping to
+# keep storage bounded — plus manual dispatch. Scheduled runs always `--apply`;
+# manual dispatch defaults to a read-only audit (flip `apply` on to rebuild). The
+# rebuild writes a deduped sibling per agency and swaps it in by DROP + CREATE +
+# per-agency INSERT (never DELETE, never a whole-table single write); the sibling
+# is kept until the rebuilt row count is verified, so an interrupted swap is
+# resumable. After an apply this workflow republishes the public comments mirror
+# so the UI's files reflect the cleaned catalog.
 #
 # Requires: R2_CATALOG_URI, R2_CATALOG_WAREHOUSE, R2_CATALOG_TOKEN (+ optional
-# R2_CATALOG_NAMESPACE) — read and write the catalog table.
+# R2_CATALOG_NAMESPACE) to read/write the catalog; plus R2_ACCESS_KEY_ID,
+# R2_SECRET_ACCESS_KEY, R2_ENDPOINT, R2_BUCKET_NAME, R2_PUBLIC_URL for the mirror.
 on:
+  schedule:
+    - cron: '0 9 * * 0'  # weekly compaction, Sunday 09:00 UTC
   workflow_dispatch:
     inputs:
       apply:
@@ -28,7 +35,11 @@ on:
         type: boolean
 
 concurrency:
-  group: dedupe-comments-catalog
+  # Shared with the ETL and the text backfill so no two writers ever touch the
+  # catalog `comments` table at once — the dedupe does a whole-table swap, so an
+  # overlapping ETL merge could race or lose data. cancel-in-progress:false makes
+  # a writer queue behind the in-flight one instead of clobbering it.
+  group: comments-catalog-write
   cancel-in-progress: false
 
 jobs:
@@ -54,14 +65,40 @@ jobs:
 
       - name: Audit / dedupe the catalog
         env:
+          # Scheduled compaction always applies; manual dispatch honors the input.
+          EVENT: ${{ github.event_name }}
+          APPLY: ${{ inputs.apply }}
           R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
           R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}
           R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
           R2_CATALOG_NAMESPACE: ${{ secrets.R2_CATALOG_NAMESPACE }}
         run: |
           ARGS=""
-          if [ "${{ inputs.apply }}" = "true" ]; then
+          if [ "$EVENT" = "schedule" ] || [ "$APPLY" = "true" ]; then
             ARGS="$ARGS --apply"
           fi
           echo "Running: uv run python scripts/dedupe_comments_catalog.py $ARGS"
           uv run python scripts/dedupe_comments_catalog.py $ARGS
+
+      # After an apply the catalog is clean but the public mirror the UI reads is
+      # still the pre-dedupe export, so refresh it. Skipped on an audit-only
+      # dispatch (apply=false), where nothing changed.
+      - name: Republish the public comments mirror
+        if: ${{ github.event_name == 'schedule' || inputs.apply == true }}
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          # Re-exporting from the catalog re-sorts + re-compresses, so a partition
+          # can shrink on disk while holding more rows; the script enforces a
+          # row-count floor instead of the byte-size shrink guard.
+          R2_ALLOW_SHRINK: '1'
+          R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
+          R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}
+          R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
+          R2_CATALOG_NAMESPACE: ${{ secrets.R2_CATALOG_NAMESPACE }}
+        run: |
+          echo "Running: uv run python scripts/publish_comments_mirror.py"
+          uv run python scripts/publish_comments_mirror.py

--- a/.github/workflows/etl-new-pipeline.yml
+++ b/.github/workflows/etl-new-pipeline.yml
@@ -76,6 +76,18 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  # Serialize every writer to the Iceberg `comments` table. The upsert is a
+  # DELETE + INSERT (DuckDB's Iceberg engine has no MERGE INTO), which is not
+  # safe under concurrent writers, so two overlapping runs can duplicate rows.
+  # `max-parallel: 1` only serializes batches within one run; this group also
+  # keeps two ETL runs (the redundant 06:25/18:25 sweeps, or a dispatch over a
+  # scheduled run) — and the dedupe/backfill workflows, which share this group —
+  # from ever writing the catalog at the same time. cancel-in-progress:false so a
+  # queued run waits for the in-flight one instead of cancelling it mid-write.
+  group: comments-catalog-write
+  cancel-in-progress: false
+
 jobs:
   # Resolve the batch matrix and the upload/iceberg flags once, so the etl job's
   # matrix can be event-dependent (schedule => all batches; dispatch => the one


### PR DESCRIPTION
## Summary

Follow-up to #143. That PR deduped the `comments` read surface, which keeps queries and the freshness check correct — but physical duplicate `comment_id` rows still accumulate in the Iceberg catalog, and the concurrency hole that lets duplicates form was never closed. This PR does both: schedules physical compaction to bound the growth, and serializes every catalog writer so new duplicates stop forming.

### 1. Weekly compaction (`dedupe-comments-catalog.yml`)
- Adds a `schedule` trigger — **Sunday 09:00 UTC**. Cadence is weekly on purpose: it's a full-table `DROP`+rebuild of tens of millions of rows, dupes only trickle in, and the read-side dedup already keeps everything correct, so this is pure housekeeping.
- Scheduled runs always `--apply`. Dispatch inputs don't exist on a `schedule` event, so without this a scheduled run would only audit and never clean. Manual dispatch still defaults to a read-only audit.
- After an apply, **republishes the public comments mirror** so the UI's Parquet reflects the cleaned catalog (mirrors the backfill workflow's republish step, including the `R2_ALLOW_SHRINK` row-count-floor guard).
- Refreshes the now-stale header (dropped "(manual)" and the false "daily merge is unaffected" note).

### 2. Serialize catalog writers (`comments-catalog-write` group)
`etl-new-pipeline.yml` had **no** top-level `concurrency`, so its two daily sweeps — or a dispatch over a running sweep — could overlap and run the `DELETE`+`INSERT` upsert against the single `comments` table concurrently. DuckDB's Iceberg engine has no `MERGE INTO`, so concurrent writers can duplicate rows (`max-parallel: 1` only serializes batches *within* one run). The dedupe does a whole-table swap, so it must not overlap an ETL merge either. The backfill already used `comments-catalog-write`; **ETL and dedupe now join it**, with `cancel-in-progress: false` so a queued writer waits for the in-flight one instead of clobbering it.

## Test plan

- [x] `uv run pytest` (no Python changed; #143's suite still green)
- [x] `uv run ruff check .`
- [x] All three workflows parse and share `concurrency.group: comments-catalog-write`; `dedupe` + `etl` triggers are `[schedule, workflow_dispatch]`.
- [ ] Manually exercised — workflow-only change; verified by YAML parse + reasoning. First scheduled compaction fires Sunday 09:00 UTC (or dispatch it with `apply=true` to run now).

## Checklist

- [x] My change is scoped to one concern
- [ ] I added or updated tests for new behavior (workflow-only; no unit-testable surface)
- [x] I updated docs (workflow header comments)
- [ ] CI is green

## Note
Independent of this PR, the ~745 duplicate rows already in the catalog get reclaimed the first time the dedupe applies — either the first scheduled run, or a manual dispatch with `apply=true` now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011yoXC3UkyWJ33bxbkYjfQF)_