### PR TITLE
fix: harden external-source rollups

### DIFF
--- a/.github/workflows/_rollup.yml
+++ b/.github/workflows/_rollup.yml
@@ -18,6 +18,21 @@ on:
         required: false
         default: false
         type: boolean
+      lda_since:
+        description: 'Optional LDA catch-up start date (YYYY-MM-DD)'
+        required: false
+        default: ''
+        type: string
+      lda_until:
+        description: 'Optional LDA catch-up end date (YYYY-MM-DD; still capped to a 30-day run)'
+        required: false
+        default: ''
+        type: string
+      congress_since:
+        description: 'Optional Congress.gov backfill start date (YYYY-MM-DD)'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   rollup:
@@ -54,6 +69,9 @@ jobs:
           # Optional: raises the Senate LDA API rate limit. The lobbying-filings
           # rollup is fully functional keyless, so an unset secret is fine.
           LDA_API_KEY: ${{ secrets.LDA_API_KEY }}
+          LDA_SINCE: ${{ inputs.lda_since }}
+          LDA_UNTIL: ${{ inputs.lda_until }}
+          CONGRESS_SINCE: ${{ inputs.congress_since }}
           # Optional: raises the CourtListener API rate limit. The court_dockets
           # rollup is fully functional keyless, so an unset secret is fine.
           COURTLISTENER_API_TOKEN: ${{ secrets.COURTLISTENER_API_TOKEN }}

--- a/.github/workflows/check-rollup-freshness.yml
+++ b/.github/workflows/check-rollup-freshness.yml
@@ -1,0 +1,38 @@
+name: Check external rollup freshness
+
+on:
+  schedule:
+    - cron: '50 23 * * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astral-sh/setup-uv@v4
+
+      - run: uv sync
+
+      - name: Restore row-count history
+        uses: actions/cache/restore@v4
+        with:
+          path: .rollup-freshness-state.json
+          key: rollup-freshness-${{ github.run_id }}
+          restore-keys: rollup-freshness-
+
+      - name: Check published rollups
+        run: uv run python scripts/check_rollup_freshness.py
+
+      - name: Save row-count history
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: .rollup-freshness-state.json
+          key: rollup-freshness-${{ github.run_id }}

--- a/.github/workflows/rollup-congress-bills.yml
+++ b/.github/workflows/rollup-congress-bills.yml
@@ -10,6 +10,11 @@ on:
         required: false
         default: false
         type: boolean
+      since:
+        description: 'Backfill bills updated since this date (YYYY-MM-DD); blank uses the stored watermark'
+        required: false
+        default: ''
+        type: string
 jobs:
   run:
     uses: ./.github/workflows/_rollup.yml
@@ -17,3 +22,4 @@ jobs:
     with:
       command: run-rollup-congress-bills
       skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}
+      congress_since: ${{ inputs.since || '' }}

--- a/.github/workflows/rollup-lobbying-filings.yml
+++ b/.github/workflows/rollup-lobbying-filings.yml
@@ -10,6 +10,16 @@ on:
         required: false
         default: false
         type: boolean
+      since:
+        description: 'Catch-up start date (YYYY-MM-DD); blank uses the stored watermark'
+        required: false
+        default: ''
+        type: string
+      until:
+        description: 'Catch-up end date (YYYY-MM-DD); each run remains capped at 30 days'
+        required: false
+        default: ''
+        type: string
 jobs:
   run:
     uses: ./.github/workflows/_rollup.yml
@@ -17,3 +27,5 @@ jobs:
     with:
       command: run-rollup-lobbying-filings
       skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}
+      lda_since: ${{ inputs.since || '' }}
+      lda_until: ${{ inputs.until || '' }}

--- a/scripts/check_rollup_freshness.py
+++ b/scripts/check_rollup_freshness.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Check public external-source rollups for stale watermarks and stalled growth.
+
+Date-backed sources are checked against source-appropriate age budgets. Sources
+without a meaningful update date are either tracked by row-count change
+(``usaspending_recipients``) or explicitly skipped with a reason. The state file
+lets the daily workflow remember when a row count last changed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+import duckdb
+
+DEFAULT_BASE_URL = "https://r2.spicy-regs.dev"
+
+
+@dataclass(frozen=True)
+class DateCheck:
+    table: str
+    column: str
+    budget_days: int
+    label: str | None = None
+
+
+DATE_CHECKS = (
+    DateCheck("federal_register", "publication_date", 3),
+    DateCheck("lobbying_filings", "dt_posted", 3),
+    # Both metrics matter: update_date alone can stay green while recent
+    # legislative actions are missing from an incompletely seeded congress.
+    DateCheck("congress_bills", "update_date", 7, "update watermark"),
+    DateCheck("congress_bills", "latest_action_date", 7, "latest action"),
+    DateCheck("cfr_sections", "last_modified", 45),
+    DateCheck("fec_committees", "last_file_date", 14),
+    DateCheck("court_dockets", "date_filed", 14),
+    DateCheck("gao_reports", "published_date", 14),
+    DateCheck("crs_reports", "published_date", 14),
+)
+
+ROW_CHANGE_BUDGETS = {"usaspending_recipients": 14}
+SKIPPED = {
+    "unified_agenda": "semiannual edition, not a daily date watermark",
+    "sam_entities": "registration_date does not change when an existing entity is refreshed",
+}
+
+
+def _query(base_url: str) -> str:
+    branches = []
+    for check in DATE_CHECKS:
+        label = check.label or check.column
+        branches.append(
+            f"""SELECT '{check.table}' AS table_name, '{label}' AS metric,
+                       CAST(MAX(TRY_CAST({check.column} AS TIMESTAMP)) AS VARCHAR) AS latest,
+                       COUNT(*)::BIGINT AS row_count
+                FROM read_parquet('{base_url}/{check.table}.parquet')"""
+        )
+    for table in ROW_CHANGE_BUDGETS:
+        branches.append(
+            f"""SELECT '{table}' AS table_name, 'row count' AS metric,
+                       NULL::VARCHAR AS latest, COUNT(*)::BIGINT AS row_count
+                FROM read_parquet('{base_url}/{table}.parquet')"""
+        )
+    return "\nUNION ALL\n".join(branches)
+
+
+def _parse_latest(raw: str | None) -> date | None:
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).date()
+    except ValueError:
+        try:
+            return date.fromisoformat(raw[:10])
+        except ValueError:
+            return None
+
+
+def evaluate_date_rows(rows: list[tuple[str, str, str | None, int]], today: date) -> list[str]:
+    """Return human-readable failures for the date-backed result rows."""
+    budgets = {(c.table, c.label or c.column): c.budget_days for c in DATE_CHECKS}
+    failures: list[str] = []
+    for table, metric, raw_latest, row_count in rows:
+        budget = budgets.get((table, metric))
+        if budget is None:
+            continue
+        latest = _parse_latest(raw_latest)
+        if latest is None:
+            failures.append(f"{table} ({metric}): no parseable watermark across {row_count:,} rows")
+            continue
+        age = (today - latest).days
+        status = "OK" if age <= budget else "STALE"
+        print(f"{status}: {table} ({metric}) latest={latest} age={age}d budget={budget}d rows={row_count:,}")
+        if age > budget:
+            failures.append(f"{table} ({metric}) is {age}d old (budget {budget}d)")
+    return failures
+
+
+def evaluate_row_changes(
+    rows: list[tuple[str, str, str | None, int]],
+    state: dict[str, dict[str, object]],
+    today: date,
+) -> list[str]:
+    """Update row-count state and flag tables unchanged beyond their budget."""
+    failures: list[str] = []
+    for table, metric, _latest, row_count in rows:
+        if metric != "row count" or table not in ROW_CHANGE_BUDGETS:
+            continue
+        previous = state.get(table, {})
+        previous_count = previous.get("count")
+        if previous_count != row_count:
+            state[table] = {"count": row_count, "last_changed": today.isoformat()}
+            print(f"OK: {table} row count changed {previous_count!r} -> {row_count:,}")
+            continue
+        raw_changed = str(previous.get("last_changed", today.isoformat()))
+        try:
+            last_changed = date.fromisoformat(raw_changed)
+        except ValueError:
+            last_changed = today
+        age = (today - last_changed).days
+        budget = ROW_CHANGE_BUDGETS[table]
+        status = "OK" if age <= budget else "STALE"
+        print(f"{status}: {table} rows={row_count:,} unchanged={age}d budget={budget}d")
+        if age > budget:
+            failures.append(f"{table} row count has not changed for {age}d (budget {budget}d)")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default=os.environ.get("SPICY_REGS_R2_URL", DEFAULT_BASE_URL))
+    parser.add_argument("--state-file", type=Path, default=Path(".rollup-freshness-state.json"))
+    parser.add_argument("--today", type=date.fromisoformat, default=date.today(), help="Testing override (YYYY-MM-DD)")
+    args = parser.parse_args()
+
+    try:
+        state = json.loads(args.state_file.read_text()) if args.state_file.exists() else {}
+    except (OSError, json.JSONDecodeError):
+        state = {}
+
+    con = duckdb.connect()
+    try:
+        rows = con.execute(_query(args.base_url)).fetchall()
+    finally:
+        con.close()
+
+    failures = evaluate_date_rows(rows, args.today)
+    failures.extend(evaluate_row_changes(rows, state, args.today))
+    args.state_file.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+
+    for table, reason in SKIPPED.items():
+        print(f"SKIP: {table} — {reason}")
+    if failures:
+        print("\nFreshness failures:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("\nAll monitored external-source rollups are within budget.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_rollup_freshness.py
+++ b/scripts/check_rollup_freshness.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date, datetime
 from pathlib import Path
@@ -20,6 +21,8 @@ from pathlib import Path
 import duckdb
 
 DEFAULT_BASE_URL = "https://r2.spicy-regs.dev"
+FreshnessRow = tuple[str, str, str | None, int]
+FreshnessState = dict[str, dict[str, int | str]]
 
 
 @dataclass(frozen=True)
@@ -82,7 +85,7 @@ def _parse_latest(raw: str | None) -> date | None:
             return None
 
 
-def evaluate_date_rows(rows: list[tuple[str, str, str | None, int]], today: date) -> list[str]:
+def evaluate_date_rows(rows: Sequence[FreshnessRow], today: date) -> list[str]:
     """Return human-readable failures for the date-backed result rows."""
     budgets = {(c.table, c.label or c.column): c.budget_days for c in DATE_CHECKS}
     failures: list[str] = []
@@ -103,8 +106,8 @@ def evaluate_date_rows(rows: list[tuple[str, str, str | None, int]], today: date
 
 
 def evaluate_row_changes(
-    rows: list[tuple[str, str, str | None, int]],
-    state: dict[str, dict[str, object]],
+    rows: Sequence[FreshnessRow],
+    state: FreshnessState,
     today: date,
 ) -> list[str]:
     """Update row-count state and flag tables unchanged beyond their budget."""

--- a/src/spicy_regs/pipelines/rollups/congress_bills.py
+++ b/src/spicy_regs/pipelines/rollups/congress_bills.py
@@ -6,11 +6,23 @@ merge with the prior published table happens inside ``build_congress_bills``.
 The base class still handles the shrink-guarded R2 upload of the single output.
 """
 
+import os
+from datetime import date
 from pathlib import Path
 from typing import ClassVar
 
 from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
 from spicy_regs.transforms import build_congress_bills
+
+
+def _date_env(name: str) -> date | None:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be YYYY-MM-DD, got {raw!r}") from exc
 
 
 class CongressBillsRollup(RollupPipeline):
@@ -21,7 +33,7 @@ class CongressBillsRollup(RollupPipeline):
     output: ClassVar[str] = "congress_bills.parquet"
 
     def build(self, output_dir: Path) -> Path:
-        return build_congress_bills(output_dir)
+        return build_congress_bills(output_dir, since=_date_env("CONGRESS_SINCE"))
 
 
 app = make_rollup_app(CongressBillsRollup)

--- a/src/spicy_regs/pipelines/rollups/lobbying_filings.py
+++ b/src/spicy_regs/pipelines/rollups/lobbying_filings.py
@@ -6,6 +6,8 @@ merge with the prior published table happens inside ``build_lobbying_filings``.
 The base class still handles the shrink-guarded R2 upload of the single output.
 """
 
+import os
+from datetime import date
 from pathlib import Path
 from typing import ClassVar
 
@@ -13,15 +15,29 @@ from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
 from spicy_regs.transforms import build_lobbying_filings
 
 
+def _date_env(name: str) -> date | None:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be YYYY-MM-DD, got {raw!r}") from exc
+
+
 class LobbyingFilingsRollup(RollupPipeline):
-    """Senate Lobbying Disclosure Act filings ingested from lda.senate.gov (key optional)."""
+    """Senate Lobbying Disclosure Act filings ingested from lda.gov (key optional)."""
 
     name: ClassVar[str] = "lobbying-filings"
     inputs: ClassVar[tuple[str, ...]] = ()
     output: ClassVar[str] = "lobbying_filings.parquet"
 
     def build(self, output_dir: Path) -> Path:
-        return build_lobbying_filings(output_dir)
+        return build_lobbying_filings(
+            output_dir,
+            since=_date_env("LDA_SINCE"),
+            until=_date_env("LDA_UNTIL"),
+        )
 
 
 app = make_rollup_app(LobbyingFilingsRollup)

--- a/src/spicy_regs/sources/lobbying_filings.py
+++ b/src/spicy_regs/sources/lobbying_filings.py
@@ -33,7 +33,9 @@ from loguru import logger
 
 from spicy_regs.sources.base import Reader
 
-API_BASE = "https://lda.senate.gov/api/v1"
+# The Senate-hosted API sunsets on 2026-07-31. lda.gov is its official,
+# API-compatible successor and is already live.
+API_BASE = "https://lda.gov/api/v1"
 
 # Max the API accepts per page.
 PER_PAGE = 25
@@ -59,16 +61,16 @@ def _resolve_api_key() -> str | None:
 class LobbyingFilingsReader(Reader):
     """Yields raw LDA filing dicts from the ``/filings/`` list endpoint.
 
-    ``since`` scopes the fetch to filings posted on/after a date (server-side via
-    ``filing_dt_posted_after``); incremental runs pass the max ``dt_posted``
-    already stored. ``filing_year`` and ``max_records`` bound the fetch for
-    validation. With no key configured the reader still fetches, just slower.
+    ``since``/``until`` scope the fetch by posting date (server-side via the
+    API's before/after filters). Bounded windows let a stale incremental ingest
+    catch up monotonically without exceeding its scheduled-run timeout.
     """
 
     def __init__(
         self,
         *,
         since: date | None = None,
+        until: date | None = None,
         filing_year: int | None = None,
         max_records: int | None = None,
         page_size: int = PER_PAGE,
@@ -76,6 +78,7 @@ class LobbyingFilingsReader(Reader):
         verbose: bool = False,
     ) -> None:
         self.since = since
+        self.until = until
         self.filing_year = filing_year
         self.max_records = max_records
         self.page_size = min(page_size, PER_PAGE)
@@ -87,9 +90,10 @@ class LobbyingFilingsReader(Reader):
     def iter_records(self) -> Iterator[dict]:
         keyed = "with API key" if self.api_key else "keyless (lower rate limit)"
         logger.info(
-            "LDA filings: fetching {} (since={}, filing_year={}, max_records={})",
+            "LDA filings: fetching {} (since={}, until={}, filing_year={}, max_records={})",
             keyed,
             self.since or "the beginning",
+            self.until or "today",
             self.filing_year or "any",
             self.max_records or "unbounded",
         )
@@ -110,6 +114,11 @@ class LobbyingFilingsReader(Reader):
             params["filing_year"] = self.filing_year
         if self.since is not None:
             params["filing_dt_posted_after"] = self.since.isoformat()
+        if self.until is not None:
+            params["filing_dt_posted_before"] = self.until.isoformat()
+        # Oldest-first makes a partial/retried catch-up run move its watermark
+        # forward instead of repeatedly spending its budget on the newest page.
+        params["ordering"] = "dt_posted"
         url = f"{API_BASE}/filings/"
         first = True
         while url:

--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -62,10 +62,7 @@ def download_from_r2(remote_key: str, local_path: Path) -> bool:
                 logger.info("{} not found on R2 (404)", remote_key)
                 return False
             if response.status_code != 200:
-                raise RuntimeError(
-                    f"Failed to download {remote_key} from R2: HTTP "
-                    f"{response.status_code}"
-                )
+                raise RuntimeError(f"Failed to download {remote_key} from R2: HTTP {response.status_code}")
             with open(temp_path, "wb") as f:
                 for chunk in response.iter_bytes():
                     f.write(chunk)
@@ -132,18 +129,14 @@ def _assert_upload_safe(
     if remote_size is None or remote_size == 0:
         return
     if getenv("R2_ALLOW_SHRINK") == "1":
-        logger.warning(
-            "R2_ALLOW_SHRINK=1: bypassing shrink guard for {}", remote_key
-        )
+        logger.warning("R2_ALLOW_SHRINK=1: bypassing shrink guard for {}", remote_key)
         return
 
     ratio_env = getenv("R2_MIN_SIZE_RATIO", "0.5")
     try:
         min_ratio = float(ratio_env)
     except ValueError:
-        raise RuntimeError(
-            f"Invalid R2_MIN_SIZE_RATIO={ratio_env!r}; expected a float"
-        )
+        raise RuntimeError(f"Invalid R2_MIN_SIZE_RATIO={ratio_env!r}; expected a float")
 
     ratio = local_size / remote_size
     if ratio < min_ratio:
@@ -182,12 +175,17 @@ def upload_file(local_path: Path, remote_key: str | None = None) -> None:
     remote_size = _get_remote_size(client, bucket, remote_key)
     _assert_upload_safe(local_size_bytes, remote_size, remote_key)
 
-    # Cache-Control makes the objects eligible for Cloudflare edge caching on
-    # the public custom domain (without it every browser range request pays a
-    # full edge->R2 origin round-trip, measured at ~130-180ms each). The corpus
-    # refreshes roughly daily; max-age bounds staleness after a republish and
-    # stale-while-revalidate keeps the edge fast across the refresh boundary.
-    cache_control = getenv("R2_CACHE_CONTROL", "public, max-age=3600, stale-while-revalidate=86400")
+    # Parquet readers issue many byte-range requests. Serving stale ranges across
+    # an object replacement can mix two versions and corrupt the read, so Parquet
+    # may be stored by caches but must be revalidated before reuse. Small immutable-
+    # enough auxiliary artifacts retain the prior edge-cache policy. Operators can
+    # override either policy globally when testing a Cloudflare rule.
+    configured_cache_control = getenv("R2_CACHE_CONTROL")
+    cache_control = configured_cache_control or (
+        "public, no-cache, must-revalidate"
+        if remote_key.endswith(".parquet")
+        else "public, max-age=3600, stale-while-revalidate=86400"
+    )
     client.upload_file(
         str(local_path),
         bucket,

--- a/src/spicy_regs/transforms/build_fr_docket_links.py
+++ b/src/spicy_regs/transforms/build_fr_docket_links.py
@@ -58,6 +58,7 @@ def build_fr_docket_links(output_dir: Path) -> Path:
             fr.signing_date,
             fr.agency_slugs,
             fr.docket_ids_json,
+            fr.regulation_id_numbers_json,
             fr.html_url,
             fr.pdf_url,
             fr.executive_order_number

--- a/src/spicy_regs/transforms/build_lobbying_filings.py
+++ b/src/spicy_regs/transforms/build_lobbying_filings.py
@@ -35,6 +35,17 @@ OUTPUT = "lobbying_filings.parquet"
 # Re-scan this many days before the last stored dt_posted on each run, so
 # filings posted/amended after the watermark are picked up.
 OVERLAP_DAYS = 7
+MAX_WINDOW_DAYS = 30
+
+
+def _bounded_until(since: date | None, until: date | None, *, today: date | None = None) -> date | None:
+    """Return a deterministic end date no more than one catch-up window ahead."""
+    if since is None:
+        return until
+    if until is not None and until < since:
+        raise ValueError(f"LDA until date {until} precedes since date {since}")
+    return min(until or today or date.today(), since + timedelta(days=MAX_WINDOW_DAYS))
+
 
 # The published schema: all VARCHAR, keyed by filing_uuid. Array/nested fields
 # are JSON strings.
@@ -144,6 +155,7 @@ def build_lobbying_filings(
     output_dir: Path,
     *,
     since: date | None = None,
+    until: date | None = None,
     filing_year: int | None = None,
     max_records: int | None = None,
 ) -> Path:
@@ -164,10 +176,19 @@ def build_lobbying_filings(
     if since is None:
         prior_max = _prior_max_dt_posted(prior_file) if have_prior else None
         since = (prior_max - timedelta(days=OVERLAP_DAYS)) if prior_max else None
-    logger.info("LDA: fetching filings posted since {}", since or "the beginning")
+    # A stale watermark must not create an ever-growing request that repeatedly
+    # hits the 30-minute CI timeout. Walk toward today in bounded windows; the
+    # overlap makes each successive merge resilient to late/amended filings.
+    until = _bounded_until(since, until)
+    logger.info("LDA: fetching filings posted {} through {}", since or "the beginning", until or "today")
 
     # 3. Fetch + shape into a "new rows" parquet.
-    reader = LobbyingFilingsReader(since=since, filing_year=filing_year, max_records=max_records)
+    reader = LobbyingFilingsReader(
+        since=since,
+        until=until,
+        filing_year=filing_year,
+        max_records=max_records,
+    )
     rows = [_shape(f) for f in reader.iter_records()]
     new_file = output_dir / "_lda_new.parquet"
     table = pa.Table.from_pylist(rows, schema=_SCHEMA) if rows else _SCHEMA.empty_table()

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -21,18 +21,16 @@ class TestUploadShrinkGuard:
         any HEAD and records upload_file calls on ``uploads``."""
         from botocore.exceptions import ClientError
 
-        uploads: list[tuple[str, str]] = []
+        uploads: list[tuple[str, str, dict | None]] = []
         fake = MagicMock()
 
         if remote_size is None:
-            fake.head_object.side_effect = ClientError(
-                {"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject"
-            )
+            fake.head_object.side_effect = ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
         else:
             fake.head_object.return_value = {"ContentLength": remote_size}
 
         def fake_upload_file(local, bucket, key, ExtraArgs=None):
-            uploads.append((local, key))
+            uploads.append((local, key, ExtraArgs))
 
         fake.upload_file.side_effect = fake_upload_file
 
@@ -54,6 +52,27 @@ class TestUploadShrinkGuard:
 
         upload_to_r2(local)
         assert len(uploads) == 1
+
+    def test_parquet_upload_requires_cache_revalidation(self, tmp_path, monkeypatch):
+        self._setup_env(monkeypatch)
+        _, uploads = self._mock_r2_client(monkeypatch, remote_size=None)
+        local = tmp_path / "rollup.parquet"
+        local.write_bytes(b"parquet")
+
+        upload_to_r2(local)
+
+        assert uploads[0][2]["CacheControl"] == "public, no-cache, must-revalidate"
+
+    def test_cache_control_env_override_wins(self, tmp_path, monkeypatch):
+        self._setup_env(monkeypatch)
+        monkeypatch.setenv("R2_CACHE_CONTROL", "no-store")
+        _, uploads = self._mock_r2_client(monkeypatch, remote_size=None)
+        local = tmp_path / "rollup.parquet"
+        local.write_bytes(b"parquet")
+
+        upload_to_r2(local)
+
+        assert uploads[0][2]["CacheControl"] == "no-store"
 
     def test_allows_upload_when_new_file_is_larger(self, tmp_path, monkeypatch):
         """Normal incremental growth should succeed."""

--- a/tests/test_lobbying_filings.py
+++ b/tests/test_lobbying_filings.py
@@ -8,9 +8,10 @@ reader's DRF ``next``-following pagination + ``max_records`` bound.
 from __future__ import annotations
 
 import json
+from datetime import date
 
-from spicy_regs.sources.lobbying_filings import LobbyingFilingsReader
-from spicy_regs.transforms.build_lobbying_filings import COLUMNS, _shape
+from spicy_regs.sources.lobbying_filings import API_BASE, LobbyingFilingsReader
+from spicy_regs.transforms.build_lobbying_filings import COLUMNS, _bounded_until, _shape
 
 _RAW_FILING = {
     "filing_uuid": "7866327b-c892-4430-b9f0-1f0f679c58c6",
@@ -42,6 +43,10 @@ _RAW_FILING = {
         },
     ],
 }
+
+
+def test_uses_post_sunset_lda_api_host():
+    assert API_BASE == "https://lda.gov/api/v1"
 
 
 def test_shape_produces_exact_schema():
@@ -120,3 +125,32 @@ def test_pagination_respects_max_records(monkeypatch):
     monkeypatch.setattr(reader, "_get", fake_get)
     got = [f["filing_uuid"] for f in reader._paginate()]
     assert got == ["a", "b", "c"]
+
+
+def test_pagination_sends_bounded_date_window(monkeypatch):
+    reader = LobbyingFilingsReader(since=date(2026, 4, 1), until=date(2026, 5, 1))
+    seen_params: dict[str, object] = {}
+
+    def fake_get(url: str, params: dict | None) -> dict | None:
+        assert params is not None
+        seen_params.update(params)
+        return _page([], None)
+
+    monkeypatch.setattr(reader, "_get", fake_get)
+    assert list(reader._paginate()) == []
+    assert seen_params["filing_dt_posted_after"] == "2026-04-01"
+    assert seen_params["filing_dt_posted_before"] == "2026-05-01"
+    assert seen_params["ordering"] == "dt_posted"
+
+
+def test_lagging_window_is_capped_to_thirty_days():
+    assert _bounded_until(
+        date(2026, 4, 1),
+        None,
+        today=date(2026, 7, 20),
+    ) == date(2026, 5, 1)
+    assert _bounded_until(
+        date(2026, 7, 1),
+        None,
+        today=date(2026, 7, 20),
+    ) == date(2026, 7, 20)

--- a/tests/test_rollup_freshness.py
+++ b/tests/test_rollup_freshness.py
@@ -1,0 +1,27 @@
+from datetime import date
+
+from scripts.check_rollup_freshness import evaluate_date_rows, evaluate_row_changes
+
+
+def test_date_freshness_checks_both_congress_watermarks():
+    rows = [
+        ("congress_bills", "update watermark", "2026-07-19", 100),
+        ("congress_bills", "latest action", "2025-04-02", 100),
+    ]
+    failures = evaluate_date_rows(rows, date(2026, 7, 20))
+    assert len(failures) == 1
+    assert "latest action" in failures[0]
+
+
+def test_row_count_state_flags_a_stalled_source():
+    state = {"usaspending_recipients": {"count": 100_000, "last_changed": "2026-07-01"}}
+    rows = [("usaspending_recipients", "row count", None, 100_000)]
+    failures = evaluate_row_changes(rows, state, date(2026, 7, 20))
+    assert failures
+
+
+def test_row_count_change_resets_the_clock():
+    state = {"usaspending_recipients": {"count": 99_000, "last_changed": "2026-07-01"}}
+    rows = [("usaspending_recipients", "row count", None, 100_000)]
+    assert evaluate_row_changes(rows, state, date(2026, 7, 20)) == []
+    assert state["usaspending_recipients"] == {"count": 100_000, "last_changed": "2026-07-20"}


### PR DESCRIPTION
## What changed

- add Federal Register RIN arrays to `fr_docket_links` so browser consumers can avoid scanning the full Federal Register table
- bound LDA catch-up runs to deterministic 30-day windows, add manual date controls, and move to the official `lda.gov` API host
- add a Congress backfill start-date control
- add daily external-source freshness monitoring, including both Congress watermarks and row-count state for USASpending
- require cache revalidation for Parquet uploads to prevent stale or mixed-version range reads

## Why

The LDA rollup was trapped in a timeout loop, the Congress table had a historical coverage hole that its update watermark could not heal, and long-lived HTTP caching could serve stale or torn Parquet reads after object replacement.

## Validation

- `uv run ruff check .`
- 64 focused Python tests passed, including data dictionary and MCP consistency
- workflow YAML parsed successfully
- dry-run FR link rollup built 714,755 rows
- sample docket `EPA-HQ-OAR-2025-0078` resolved RIN `2060-AS32` and the expected Unified Agenda entry
- live freshness probe correctly flagged stale LDA and Congress tables

## Post-merge operations

1. Republish `fr_docket_links` before merging the companion UI PR.
2. Run bounded LDA catch-up publishes until current.
3. Dispatch the Congress rollup with an explicit historical `since` date to fill the 119th Congress gap.
4. Confirm two consecutive green rollup and freshness runs.
