### PR TITLE
docs: add changelog (root + docs site) and /two-week-changelog command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,79 @@
+# Changelog
+
+All notable changes to the Spicy Regs data pipeline are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Entries link to the pull request that introduced the change.
+
+## [2026.07.22]
+
+The headline of this cycle: the pipeline went from mirroring regulations.gov and
+the Federal Register to ingesting **ten complementary federal data sources**, so
+the full rulemaking lifecycle — the organizations that engage in it and its
+downstream context — can be queried from one place. Alongside the new sources,
+this cycle hardened the rollups and made the published corpus edge-cacheable.
+
+### Added
+
+- **Federal Register** ingestion brought fully in-repo ([#125]).
+- **Unified Agenda** (RegInfo) ingestion — `unified_agenda` ([#126]).
+- **Congress.gov** bill ingestion — `congress_bills` ([#127]).
+- **GovInfo CFR** section ingestion — `cfr_sections` ([#128]).
+- **OpenFEC** committees ingestion — `fec_committees` ([#132]).
+- **Senate Lobbying Disclosure (LDA)** filings ingestion — `lobbying_filings` ([#133]).
+- **SAM.gov** entity registry ingestion — `sam_entities` ([#134]).
+- **USASpending** recipients ingestion — `usaspending_recipients` ([#135]).
+- **CourtListener** litigation ingestion — `court_dockets` ([#137]).
+- **GAO + CRS** reports ingestion — `gao_reports`, `crs_reports` ([#138]).
+- Docs: a Python query walkthrough ([#142]) and a refreshed table catalog for
+  the eleven new data sources ([#139]).
+
+### Changed
+
+- **Performance:** made the R2 parquet corpus edge-cacheable and pruned docket
+  scans ([#124]).
+- **SAM.gov:** upgraded to full-coverage ingestion via a partitioned walk ([#141]).
+- **OpenFEC:** switched to keyset pagination to walk all committees ([#136]).
+- **Unified Agenda:** now fetches and parses the real `REGINFO_RIN_DATA` XML
+  export ([#131]).
+- **CFR:** use the GovInfo `/published` endpoint and derive section fields from
+  IDs ([#130]).
+- **Congress.gov:** drop the always-null `policy_area` (the list endpoint omits
+  it) ([#129]).
+- **CI:** schedule weekly comments-catalog compaction and serialize catalog
+  writers ([#145]); forward `SAM_API_KEY` to rollup jobs ([#140]).
+
+### Fixed
+
+- Harden the external-source rollups ([#147]).
+- Dedup the catalog comments view on read ([#143]).
+- Sub-batch catalog dedup by key hash to avoid runner OOM ([#123]).
+- Matrix sweep + full agency coverage to stop batch starvation ([#121]).
+- Stop marking failed downloads as processed in the ETL manifest ([#120]).
+
+[2026.07.22]: https://github.com/civictechdc/spicy-regs/releases/tag/v2026.07.22
+[#120]: https://github.com/civictechdc/spicy-regs/pull/120
+[#121]: https://github.com/civictechdc/spicy-regs/pull/121
+[#123]: https://github.com/civictechdc/spicy-regs/pull/123
+[#124]: https://github.com/civictechdc/spicy-regs/pull/124
+[#125]: https://github.com/civictechdc/spicy-regs/pull/125
+[#126]: https://github.com/civictechdc/spicy-regs/pull/126
+[#127]: https://github.com/civictechdc/spicy-regs/pull/127
+[#128]: https://github.com/civictechdc/spicy-regs/pull/128
+[#129]: https://github.com/civictechdc/spicy-regs/pull/129
+[#130]: https://github.com/civictechdc/spicy-regs/pull/130
+[#131]: https://github.com/civictechdc/spicy-regs/pull/131
+[#132]: https://github.com/civictechdc/spicy-regs/pull/132
+[#133]: https://github.com/civictechdc/spicy-regs/pull/133
+[#134]: https://github.com/civictechdc/spicy-regs/pull/134
+[#135]: https://github.com/civictechdc/spicy-regs/pull/135
+[#136]: https://github.com/civictechdc/spicy-regs/pull/136
+[#137]: https://github.com/civictechdc/spicy-regs/pull/137
+[#138]: https://github.com/civictechdc/spicy-regs/pull/138
+[#139]: https://github.com/civictechdc/spicy-regs/pull/139
+[#140]: https://github.com/civictechdc/spicy-regs/pull/140
+[#141]: https://github.com/civictechdc/spicy-regs/pull/141
+[#142]: https://github.com/civictechdc/spicy-regs/pull/142
+[#143]: https://github.com/civictechdc/spicy-regs/pull/143
+[#145]: https://github.com/civictechdc/spicy-regs/pull/145
+[#147]: https://github.com/civictechdc/spicy-regs/pull/147

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,52 @@
+# Changelog
+
+Notable changes to the Spicy Regs data pipeline and the tables it publishes.
+Entries link to the pull request that introduced the change. The canonical
+per-release copy lives in [`CHANGELOG.md`](https://github.com/civictechdc/spicy-regs/blob/main/CHANGELOG.md)
+at the repository root and on the
+[GitHub Releases](https://github.com/civictechdc/spicy-regs/releases) page.
+
+## 2026-07-22
+
+This cycle expanded the dataset from a regulations.gov + Federal Register mirror
+into a broader federal-data corpus: **ten new complementary sources** now ship
+as their own tables, covering the rulemaking lifecycle, the organizations that
+engage in it, and its downstream context.
+
+!!! note "New tables"
+    Every table below is published as `https://r2.spicy-regs.dev/<name>.parquet`
+    and documented under **Tables** in the nav.
+
+### New data sources
+
+| Table | Source | PR |
+| --- | --- | --- |
+| `federal_register` | Federal Register (now ingested in-repo) | [#125](https://github.com/civictechdc/spicy-regs/pull/125) |
+| `unified_agenda` | Unified Agenda (RegInfo) | [#126](https://github.com/civictechdc/spicy-regs/pull/126) |
+| `congress_bills` | Congress.gov | [#127](https://github.com/civictechdc/spicy-regs/pull/127) |
+| `cfr_sections` | GovInfo CFR | [#128](https://github.com/civictechdc/spicy-regs/pull/128) |
+| `fec_committees` | OpenFEC | [#132](https://github.com/civictechdc/spicy-regs/pull/132) |
+| `lobbying_filings` | Senate Lobbying Disclosure (LDA) | [#133](https://github.com/civictechdc/spicy-regs/pull/133) |
+| `sam_entities` | SAM.gov entity registry | [#134](https://github.com/civictechdc/spicy-regs/pull/134) |
+| `usaspending_recipients` | USASpending | [#135](https://github.com/civictechdc/spicy-regs/pull/135) |
+| `court_dockets` | CourtListener litigation | [#137](https://github.com/civictechdc/spicy-regs/pull/137) |
+| `gao_reports`, `crs_reports` | GAO + CRS reports | [#138](https://github.com/civictechdc/spicy-regs/pull/138) |
+
+### Changed
+
+- Made the R2 parquet corpus **edge-cacheable** and pruned docket scans ([#124](https://github.com/civictechdc/spicy-regs/pull/124)).
+- **SAM.gov:** full-coverage ingestion via a partitioned walk ([#141](https://github.com/civictechdc/spicy-regs/pull/141)).
+- **OpenFEC:** keyset pagination to walk all committees ([#136](https://github.com/civictechdc/spicy-regs/pull/136)).
+- **Unified Agenda:** fetch and parse the real `REGINFO_RIN_DATA` XML export ([#131](https://github.com/civictechdc/spicy-regs/pull/131)).
+- **CFR:** use the GovInfo `/published` endpoint and derive section fields from IDs ([#130](https://github.com/civictechdc/spicy-regs/pull/130)).
+- **Congress.gov:** drop the always-null `policy_area` ([#129](https://github.com/civictechdc/spicy-regs/pull/129)).
+- **CI:** weekly comments-catalog compaction with serialized writers ([#145](https://github.com/civictechdc/spicy-regs/pull/145)); forward `SAM_API_KEY` to rollup jobs ([#140](https://github.com/civictechdc/spicy-regs/pull/140)).
+- **Docs:** Python query walkthrough ([#142](https://github.com/civictechdc/spicy-regs/pull/142)) and refreshed table catalog ([#139](https://github.com/civictechdc/spicy-regs/pull/139)).
+
+### Fixed
+
+- Hardened the external-source rollups ([#147](https://github.com/civictechdc/spicy-regs/pull/147)).
+- Dedup the catalog comments view on read ([#143](https://github.com/civictechdc/spicy-regs/pull/143)).
+- Sub-batch catalog dedup by key hash to avoid runner OOM ([#123](https://github.com/civictechdc/spicy-regs/pull/123)).
+- Matrix sweep + full agency coverage to stop batch starvation ([#121](https://github.com/civictechdc/spicy-regs/pull/121)).
+- Stop marking failed downloads as processed in the ETL manifest ([#120](https://github.com/civictechdc/spicy-regs/pull/120)).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ markdown_extensions:
 
 nav:
   - Overview: index.md
+  - Changelog: changelog.md
   - Querying with Python: querying-python.md
   - Tables:
       - dockets: tables/dockets.md


### PR DESCRIPTION
## Summary

Adds a changelog for the data pipeline and a reusable command to regenerate it.

- **`CHANGELOG.md`** at the repo root ([Keep a Changelog](https://keepachangelog.com/) format), covering the last two weeks: the ten new external data-source ingestions (Federal Register, Unified Agenda, Congress.gov, CFR, FEC, LDA lobbying, SAM.gov, USASpending, CourtListener, GAO/CRS) plus the rollup-hardening and edge-cache/perf work. Each entry links to its PR.
- **`docs/changelog.md`** — a Changelog page for the mkdocs docs site (`docs.spicy-regs.dev`), wired into the nav in `mkdocs.yml`.
- **`.claude/commands/two-week-changelog.md`** — a slash command (`/two-week-changelog`) that regenerates this changelog and a subscriber-facing summary from merged PRs across both Spicy Regs repos.

This is a companion to the changelog work in `ekim1394/spicy-regs-ui`.

## Test plan

Docs + tooling only — no pipeline code changed.

- [ ] `uv run pytest` — n/a (no code changes)
- [ ] `uv run ruff check .` — n/a (no Python changes)
- [x] Manually exercised the change — verified the new nav entry is valid YAML and the changelog links resolve to the correct PR numbers.

## Checklist

- [x] My change is scoped to one concern
- [ ] I added or updated tests for new behavior — n/a (docs only)
- [x] I updated docs (this PR is the docs update)
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGv5AZ9zMmXNTuWwecF4NV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGv5AZ9zMmXNTuWwecF4NV)_