### PR TITLE
fix(mcp): pin mcp<2 so the Vercel MCP server stops 500ing on every request

### DIFF
--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -43,3 +43,40 @@ jobs:
         run: >
           npx vercel@latest deploy --prod --yes
           --token "${{ secrets.VERCEL_TOKEN }}"
+
+      # A Python import error in api/index.py is a *runtime* failure, so the
+      # build goes READY and the deploy step exits 0 while every request 500s.
+      # That is exactly how mcp 2.0 took the server down unnoticed. Drive one
+      # real MCP handshake through the public alias so the job fails instead.
+      - name: Smoke test the deployed endpoint
+        run: |
+          set -euo pipefail
+          payload='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+            "protocolVersion":"2025-06-18","capabilities":{},
+            "clientInfo":{"name":"deploy-smoke-test","version":"1"}}}'
+
+          for attempt in 1 2 3 4 5; do
+            code=$(curl -sS -o /tmp/smoke.out -w '%{http_code}' -m 60 \
+              -X POST https://mcp.spicy-regs.dev/mcp \
+              -H 'Content-Type: application/json' \
+              -H 'Accept: application/json, text/event-stream' \
+              -d "$payload") || code=000
+            [ "$code" = "200" ] && break
+            echo "attempt $attempt: HTTP $code, retrying for alias propagation..."
+            sleep 15
+          done
+
+          if [ "$code" != "200" ]; then
+            echo "::error::MCP initialize returned HTTP $code (expected 200)"
+            cat /tmp/smoke.out
+            exit 1
+          fi
+
+          # 200 alone isn't proof the tools registered — require the server's
+          # own identity back out of the handshake.
+          grep -q '"serverInfo"' /tmp/smoke.out || {
+            echo "::error::initialize returned 200 without serverInfo"
+            cat /tmp/smoke.out
+            exit 1
+          }
+          echo "Smoke test passed."

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,2 +1,7 @@
-mcp>=1.10.0
-duckdb>=1.2.0
+# Upper bounds are load-bearing, not caution. This file has no lockfile — pip
+# resolves it fresh on every Vercel rebuild — so an unbounded spec turns any
+# deploy into an unreviewed dependency upgrade. mcp 2.0 (2026-07-28) deleted
+# mcp.server.fastmcp outright and took down mcp.spicy-regs.dev that way.
+# Porting to the 2.x mcp.server.mcpserver API is what lifts the <2 bound.
+mcp>=1.27.1,<2
+duckdb>=1.2.0,<2


### PR DESCRIPTION
## The outage

`https://mcp.spicy-regs.dev/mcp` has returned `500 FUNCTION_INVOCATION_FAILED` on **every request** since the 2026-07-31 production deploy. The function dies at import, before any MCP logic runs:

```
File "/var/task/api/index.py", line 26, in <module>
  from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

## Root cause: an unpinned dependency, not a code change

| | |
|---|---|
| `mcp-server/requirements.txt` | `mcp>=1.10.0` — unbounded, and this directory has **no lockfile** |
| `mcp` 2.0.0 released to PyPI | 2026-07-28 13:45 UTC |
| Last production deploy (`dpl_CTFiQ…`, `f1fcb8c`) | 2026-07-31 16:57 UTC |

Unpacking the 2.0.0 wheel confirms `mcp/server/fastmcp/` **does not exist** in 2.x — FastMCP became `mcp.server.mcpserver`, and `mcp.types.Icon` went with it.

The triggering commit was a README/hostname change that touched no server code. With an unbounded spec and no lockfile, *any* rebuild for *any* reason is an unreviewed dependency upgrade.

## Why nothing caught it

- **The build stayed green.** A Python import error is a runtime failure, not a build failure — Vercel reported `READY` and the deploy step exited 0 while every request 500'd.
- **CI was unaffected.** The two MCP copies resolve dependencies differently: `uv.lock` pins `mcp==1.27.1` for `src/spicy_regs/mcp_server.py`, so the stdio server and the whole test suite kept passing. `test_vercel_copy_in_sync` guards *source* drift between the copies but says nothing about *dependency* drift — the axis that actually broke.

## Changes

1. **`mcp-server/requirements.txt`** — `mcp>=1.27.1,<2` and `duckdb>=1.2.0,<2`, with a comment explaining that the upper bounds are load-bearing rather than cautious, and what lifts the `<2`.
2. **`.github/workflows/deploy-mcp.yml`** — a post-deploy smoke test driving one real MCP `initialize` handshake through the public alias, failing the job on anything but a `200` carrying `serverInfo`. Retries for alias propagation. Interpolates no `${{ }}` expressions.

## Verification

- Clean venv against the new pins resolves **mcp 1.29.0 / duckdb 1.5.5**; `api/index.py` imports cleanly with all 20 tables and the ASGI app constructed.
- The smoke script was run against the **currently-broken** production endpoint and correctly exits 1 (`::error::MCP initialize returned HTTP 500`) — so it detects this exact class of failure rather than merely being present.
- Workflow YAML parses; the smoke step passes `bash -n`.

## Follow-up, not in this PR

`pyproject.toml:17` carries the same unbounded `mcp>=1.10.0`. It's shielded by `uv.lock` pinning 1.27.1 today, but `uv lock --upgrade` would walk into the identical wall. Porting both copies to the 2.x `mcp.server.mcpserver` API is the real path off the `<2` bound.