### PR TITLE
feat(mcp): raise maxDuration to the 800s Pro ceiling (was 300s)

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -142,12 +142,24 @@ Then point a client at `http://localhost:8000/mcp`.
 
 ## Limitations
 
-- Vercel functions here cap at 300s (`maxDuration` in `vercel.json`, the Pro
-  plan ceiling). A DuckDB statement-timeout watchdog trips at `290s` (override
-  with `SPICY_REGS_STATEMENT_TIMEOUT`) so runaway queries return a clean
-  `TimeoutError` just before the platform kill. The first query in a cold
-  container pays a few seconds to install the DuckDB `httpfs` extension and
-  fetch parquet metadata; subsequent queries within the same container are fast.
+- Vercel functions here cap at 800s (`maxDuration` in `vercel.json`) — the
+  generally-available ceiling on Pro, not the 300s that is merely the default on
+  every plan. Pro/Enterprise can go to 1800s via the extended-max-duration beta,
+  which we deliberately don't use: a blocking DuckDB query streams nothing while
+  it runs, and Vercel warns that idle HTTP/1.1 connections may be closed by
+  intermediaries regardless of the server-side budget. A DuckDB
+  statement-timeout watchdog trips at `790s` (override with
+  `SPICY_REGS_STATEMENT_TIMEOUT`) so runaway queries return a clean
+  `TimeoutError` just before the platform kill — a platform kill surfaces as an
+  opaque 500 instead. Raise the two together or not at all.
+- **In practice your MCP client, not the function, is the binding limit.** Most
+  clients abandon a tool call in 60–120s, well under 800s, so the extra headroom
+  only helps callers that raise their own timeout too. Note also that Fluid
+  Compute bills active CPU: a query that genuinely runs for minutes of DuckDB
+  compute now costs minutes of CPU rather than being cut off at five.
+- The first query in a cold container pays a few seconds to install the DuckDB
+  `httpfs` extension and fetch parquet metadata; subsequent queries within the
+  same container are fast.
 - The `find_duplicate_regulations.py` helper isn't exposed over MCP — its
   pairwise scan can exceed the function timeout. For that workload, use the
   local script via `uv run --script` (see the skill's SKILL.md).

--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -60,10 +60,12 @@ TABLES = (
     "fcc_proceedings",
     "fcc_filings",
 )
-# Kept just under the Vercel ``maxDuration`` (300s) so a runaway query trips
-# this watchdog and returns a clean ``TimeoutError`` before the platform hard
-# kills the function. Override with ``SPICY_REGS_STATEMENT_TIMEOUT``.
-STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "290s")
+# Kept just under the Vercel ``maxDuration`` (800s, the generally-available Pro
+# ceiling) so a runaway query trips this watchdog and returns a clean
+# ``TimeoutError`` before the platform hard kills the function -- a platform kill
+# gives the caller an opaque 500 instead. Raise both together or not at all.
+# Override with ``SPICY_REGS_STATEMENT_TIMEOUT``.
+STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "790s")
 
 logger = logging.getLogger(__name__)
 

--- a/mcp-server/vercel.json
+++ b/mcp-server/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "functions": {
     "api/index.py": {
-      "maxDuration": 300
+      "maxDuration": 800
     }
   },
   "rewrites": [

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -60,9 +60,11 @@ TABLES = (
     "fcc_proceedings",
     "fcc_filings",
 )
-# Matches the Vercel copy's default (kept just under that deploy's 300s
-# ``maxDuration``). Override with ``SPICY_REGS_STATEMENT_TIMEOUT``.
-STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "290s")
+# Matches the Vercel copy's default (kept just under that deploy's 800s
+# ``maxDuration``). stdio has no platform duration limit, so here this is purely
+# a runaway-query guard; it stays in lockstep with the Vercel copy so the two
+# behave identically. Override with ``SPICY_REGS_STATEMENT_TIMEOUT``.
+STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "790s")
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
`mcp-server/README.md` claimed 300s was "the Pro plan ceiling". It isn't — **300s is the *default* on every plan, including Hobby.** Per [Vercel's duration limits](https://vercel.com/docs/functions/configuring-functions/duration) with fluid compute (on by default):

| | Default | Maximum | Extended maximum |
|---|---|---|---|
| Hobby | 300s | 300s | — |
| **Pro** | 300s | **800s** | 1800s (beta) |
| Enterprise | 300s | 800s | 1800s (beta) |

The deploy has been leaving **500s of generally-available headroom** unused.

## Changes

- `mcp-server/vercel.json` — `maxDuration` 300 → **800**
- `mcp-server/api/index.py` + `src/spicy_regs/mcp_server.py` — statement-timeout watchdog default `290s` → **`790s`**, preserving the 10s margin so a runaway query returns a clean `TimeoutError` rather than an opaque platform-killed 500
- `mcp-server/README.md` — corrects the wrong ceiling claim and documents the two caveats below

Both copies move together. `src/spicy_regs/mcp_server.py` is stdio-only and has no platform duration limit, but the two are hand-mirrored and divergent defaults would be a trap for the next reader.

## Why not the 1800s extended tier

It's still beta, and it's a poor fit for this specific workload: a blocking DuckDB query streams nothing while it runs, so Vercel's warning that intermediaries may close idle HTTP/1.1 connections applies squarely here. 800s is GA with no runtime or Secure Compute caveats.

## Two caveats worth knowing before expecting much from this

1. **The binding limit is usually the client, not the function.** Most MCP clients abandon a tool call in 60–120s — far under 800s. This headroom only helps callers that raise their own timeout too.
2. **Fluid Compute bills active CPU.** A query that genuinely runs minutes of DuckDB compute now costs minutes of CPU instead of being cut off at five. The ceiling is a cap, not a floor — ordinary fast queries are unaffected — but runaway queries now have 13 minutes of rope.

Both are now in the README rather than left to be discovered from a bill or a confusing client-side timeout.

## Verification

- Both copies parse to `790.0s`; asserted `STATEMENT_TIMEOUT_SECONDS < maxDuration` so the watchdog always fires first (10s margin).
- `uv run ruff check .` and `uv run ty check` — both clean.
- `tests/test_mcp_server.py` — 24 passed, including `test_vercel_copy_in_sync`.

> Independent of #151, which fixes the current production outage (unpinned `mcp` resolving to 2.0). No file overlap; the two merge in either order. **#151 should go first** — this PR is an enhancement to a server that is currently returning 500 on every request.