### PR TITLE
refactor(mcp): move all code comments out of the two MCP server modules

### DIFF
--- a/mcp-server/INTERNALS.md
+++ b/mcp-server/INTERNALS.md
@@ -1,0 +1,129 @@
+# MCP server internals
+
+> Engineering notes for contributors. Not user-facing — for how to *use* the
+> server see [`README.md`](README.md), and for table schemas see
+> <https://docs.spicy-regs.dev>.
+
+This is the rationale behind the MCP server implementation. Both source files are
+comment-free by project policy (documentation lives in markdown), so this
+document is the explanation for what the code does and why.
+
+It covers **both copies**, which are hand-mirrored and must stay in sync:
+
+| File | Role |
+|---|---|
+| `src/spicy_regs/mcp_server.py` | Canonical. Stdio via the `spicy-regs-mcp` console script, plus `build_app()` for ASGI. |
+| `mcp-server/api/index.py` | Vercel function. A parallel copy so the deploy avoids the parent package's ETL dependencies (boto3, polars). |
+
+`tests/test_mcp_server.py::test_vercel_copy_in_sync` enforces that the tool
+surface, `TABLES`, `INSTRUCTIONS`, `DEFAULT_R2_BASE_URL`, `CATALOG_ALIAS`, and
+`DEFAULT_CATALOG_NAMESPACE` match. It does **not** check dependency drift — the
+Vercel copy has no lockfile, which is how an unpinned `mcp>=1.10.0` resolving to
+2.0 took production down in July 2026. Pins in `mcp-server/requirements.txt`
+carry upper bounds for that reason.
+
+Everything below applies to both copies unless stated.
+
+## What must never be deleted
+
+**The three `@mcp.tool()` docstrings are not documentation — do not delete them.**
+FastMCP reflects over `fn.__doc__` to build the tool descriptions sent to every
+client during `list_tools`. `describe_table`'s docstring is how a client learns
+which tables are valid; `query_sql`'s is how it learns the available views.
+Strip them and the server still runs, but every client goes blind. Verify with
+`asyncio.run(build_server().list_tools())`.
+
+**Inline `# type: ignore` / `# noqa` are directives, not comments.** `ty` and
+`ruff` gate merges and both read them. `_connect` needs `# type: ignore[index]`
+on `catalog["namespace"]`; the Vercel copy needs `# noqa: E402` on its `_icon`
+import, which must follow the `sys.path` insert.
+
+## Connection setup (`_connect`, `_apply_security_settings`)
+
+- `SET home_directory` **must precede** `INSTALL`/`LOAD`. DuckDB writes
+  extensions under `<home_directory>/.duckdb`, and the default home is read-only
+  or undefined on serverless hosts — hence `_resolve_home_directory` defaulting
+  to the temp dir (`SPICY_REGS_HOME_DIR` overrides).
+- **Do NOT disable `LocalFileSystem`.** It looks like an obvious guard against
+  user SQL reading local files, but httpfs reads the system CA bundle off the
+  local filesystem on every TLS handshake. Disabling it breaks the only thing
+  this server does: the moment a view binds you get `File system LocalFileSystem
+  has been disabled by configuration`.
+- `SET temp_directory=''` is the sandbox that replaces it. `temp_directory`
+  defaults to a local `.tmp` that is read-only on serverless hosts, so a spilling
+  query (big GROUP BY/ORDER BY) fails there regardless. Empty disables spilling —
+  queries run in memory or fail with a clear OOM.
+- `_apply_security_settings` is deliberately separate from `_connect` so the
+  sandbox is testable without network. Run it after httpfs loads and before any
+  user SQL; `SET lock_configuration=true` is last because it freezes everything.
+
+## The statement timeout
+
+**DuckDB has no `statement_timeout` parameter.** `SET statement_timeout=...`
+raises `Catalog Error: unrecognized configuration parameter` — this was a shipped
+runtime crash once, and `tests/test_mcp_server.py` guards the regression. The cap
+is a watchdog (`_statement_timeout`) that calls `con.interrupt()` and converts
+DuckDB's `InterruptException` into a `TimeoutError` so the cause is unambiguous.
+
+`SPICY_REGS_STATEMENT_TIMEOUT` defaults to `790s`, kept just under the Vercel
+`maxDuration` of **800s** so a runaway query returns a clean `TimeoutError`
+instead of an opaque platform-killed 500. **Raise the two together or not at
+all.** 800s is the generally-available Pro ceiling; 300s is only the all-plans
+default. The 1800s extended tier is beta and a poor fit — a blocking DuckDB query
+streams nothing, so Vercel's warning about intermediaries closing idle HTTP/1.1
+connections applies squarely. In practice the binding limit is usually the *MCP
+client*, which typically gives up at 60–120s. The canonical stdio copy has no
+platform limit at all; its default matches purely to keep the mirrors identical.
+
+## Iceberg catalog attach (`_attach_catalog`)
+
+Best-effort by design: a bad token, network failure, or missing table falls back
+to the monolithic `comments.parquet` rather than taking the server down. Must run
+**before** `_apply_security_settings` locks the configuration.
+
+`INSTALL avro` / `LOAD avro` explicitly, before iceberg, is load-bearing. DuckDB
+1.5's iceberg extension reads Avro manifests via a separate `avro` extension and
+tries to auto-install it lazily during `LOAD` — but that nested install doesn't
+inherit the session's `home_directory` in serverless sandboxes and dies with
+`Can't find the home directory at ''`, failing the whole attach so comments
+silently fall back to the frozen monolith. Installing it explicitly runs on the
+same top-level path that already installs httpfs/iceberg fine. Wrapped in its own
+try/except because on DuckDB <1.5 avro isn't separate and `INSTALL avro` errors.
+
+## Why the comments view has a QUALIFY
+
+The catalog table can physically hold duplicate `comment_id` rows. DuckDB's
+Iceberg engine has no `MERGE INTO`, so the ETL upsert (`iceberg._merge`) removes
+superseded rows with a plain `DELETE` — and `DELETE` does not reliably remove
+prior rows on the R2 Data Catalog (the same limitation `dedupe_table` works
+around by never deleting). Any re-merged `comment_id` can leave its old row
+beside the new one. The `QUALIFY ROW_NUMBER() OVER (PARTITION BY comment_id ORDER
+BY modify_date DESC NULLS LAST) = 1` makes the read surface single-valued
+regardless, so counts aren't inflated. Physical compaction happens out-of-band via
+`scripts/dedupe_comments_catalog.py`. A filter on `agency_code`/`docket_id` pushes
+down ahead of the window, so point lookups only dedup rows they touch.
+
+A table in `TABLES` whose parquet isn't published yet (a new source whose first
+upload hasn't run) is skipped with a warning rather than breaking every query —
+same degradation strategy as the catalog fallback.
+
+## DNS rebinding protection is off in `build_app`
+
+Deliberate. The deployment is reached via `mcp.spicy-regs.dev` and per-deploy
+`*.vercel.app` hosts; FastMCP's default localhost-only allowlist would reject all
+of them with **421**. The server is public, stateless, and read-only, so
+rebinding protection buys nothing.
+
+## Other invariants
+
+- `ICONS` uses a base64 `data:` URI, not an `https://` URL, so it works on both
+  the stdio and HTTP transports. Generated by `scripts/gen_icon.py`.
+- `_resolve_catalog_config` and `_resolve_r2_base_url` reject quotes,
+  backslashes, and control characters outright rather than escaping them, because
+  the values are inlined into `CREATE SECRET`/`ATTACH`/`read_parquet`, which take
+  no bind parameters.
+- `R2_CATALOG_NAMESPACE` uses `or DEFAULT` rather than `get`'s default argument so
+  an env var set to the empty string falls back to `default` instead of `""`.
+- The Vercel `app()` wrapper normalizes the ASGI path: `vercel.json` rewrites
+  `/mcp` onto `/api/index`, and depending on how the rewrite is forwarded the path
+  arrives as either one, so both are mapped onto the transport's `/mcp` mount.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -142,6 +142,11 @@ Then point a client at `http://localhost:8000/mcp`.
 
 ## Limitations
 
+> Working on the server itself? [`INTERNALS.md`](INTERNALS.md) has the
+> engineering rationale — why the connection is set up in that order, why
+> `LocalFileSystem` must stay enabled, why the comments view carries a `QUALIFY`,
+> and what must not be deleted from either copy.
+
 - Vercel functions here cap at 800s (`maxDuration` in `vercel.json`) — the
   generally-available ceiling on Pro, not the 300s that is merely the default on
   every plan. Pro/Enterprise can go to 1800s via the extended-max-duration beta,

--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -1,11 +1,3 @@
-"""Spicy Regs MCP server (Vercel ASGI handler).
-
-Parallel copy of ``src/spicy_regs/mcp_server.py`` so the Vercel deploy can ship
-without pulling in the parent package's ETL dependencies. The two must keep
-the same tool surface (names, parameters, behavior); the test at
-``tests/test_mcp_server.py::test_vercel_copy_in_sync`` asserts that.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -27,17 +19,10 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import Icon
 
-# This file is loaded as a standalone module — both as the Vercel function
-# entrypoint and, in tests, via importlib.spec_from_file_location — so its own
-# directory isn't on sys.path. Add it so the sibling generated _icon module
-# (produced by scripts/gen_icon.py) resolves in every context.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _icon import ICON_DATA_URI  # noqa: E402
 
 DEFAULT_R2_BASE_URL = "https://data.spicy-regs.dev"
-# The full published R2 surface. Must match the data dictionary's table list
-# (src/spicy_regs/data_dictionary.py::TABLES) — a test enforces it so the two
-# can't drift. Keep in sync with the canonical copy in src/spicy_regs/mcp_server.py.
 TABLES = (
     "dockets",
     "documents",
@@ -60,35 +45,15 @@ TABLES = (
     "fcc_proceedings",
     "fcc_filings",
 )
-# Kept just under the Vercel ``maxDuration`` (800s, the generally-available Pro
-# ceiling) so a runaway query trips this watchdog and returns a clean
-# ``TimeoutError`` before the platform hard kills the function -- a platform kill
-# gives the caller an opaque 500 instead. Raise both together or not at all.
-# Override with ``SPICY_REGS_STATEMENT_TIMEOUT``.
 STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "790s")
 
 logger = logging.getLogger(__name__)
 
-# DuckDB alias the R2 Data Catalog is attached under (mirrors
-# ``spicy_regs.sources.iceberg._CATALOG_ALIAS``). When the catalog is
-# configured, the ``comments`` view is served from it instead of the monolithic
-# ``comments.parquet`` — the comments table is too large to keep republishing as
-# a single file, so the catalog is its read surface. All other tables stay on
-# the public Parquet snapshots.
 CATALOG_ALIAS = "reg_catalog"
 DEFAULT_CATALOG_NAMESPACE = "default"
 
 
 def _parse_timeout_seconds(raw: str) -> float | None:
-    """Parse ``SPICY_REGS_STATEMENT_TIMEOUT`` into seconds (``None`` disables it).
-
-    DuckDB has no ``statement_timeout`` configuration parameter — ``SET
-    statement_timeout=...`` raises ``Catalog Error: unrecognized configuration
-    parameter``. The cap is instead enforced with a watchdog that interrupts the
-    connection (see :func:`_statement_timeout`). Accepts a bare number of
-    seconds or a value suffixed with ``ms``/``s``/``m``; non-positive values
-    disable the timeout.
-    """
     text = raw.strip().lower()
     if not text:
         return None
@@ -117,9 +82,6 @@ INSTRUCTIONS = (
     "IDs, comment IDs, agency codes, and dates from the rows you return."
 )
 
-# Server icon, advertised on the Implementation metadata sent during
-# ``initialize``. A base64 data: URI (not an https:// URL) so it works for both
-# the stdio and HTTP transports — see scripts/gen_icon.py.
 ICONS = [Icon(src=ICON_DATA_URI, mimeType="image/png", sizes=["512x512"])]
 
 
@@ -137,15 +99,6 @@ R2_BASE_URL = _resolve_r2_base_url()
 
 
 def _resolve_home_directory() -> str:
-    """Pick a writable directory for DuckDB's extension/home cache.
-
-    DuckDB resolves its extension cache under ``$HOME/.duckdb``. Serverless
-    hosts (Vercel/AWS Lambda) frequently have no writable home directory, or
-    none defined at all, so ``INSTALL httpfs`` fails with
-    ``Can't find the home directory at ''``. Defaulting to the platform temp
-    directory keeps the extension fetch working there while staying valid on
-    local stdio installs; ``SPICY_REGS_HOME_DIR`` overrides it.
-    """
     raw = os.environ.get("SPICY_REGS_HOME_DIR", tempfile.gettempdir())
     if any(c in raw for c in ("\x00", "\n", "\r")):
         raise RuntimeError(f"SPICY_REGS_HOME_DIR contains illegal characters: {raw!r}")
@@ -156,18 +109,6 @@ HOME_DIRECTORY = _resolve_home_directory()
 
 
 def _resolve_catalog_config() -> dict[str, str] | None:
-    """Return R2 Data Catalog connection settings, or ``None`` when unconfigured.
-
-    The catalog is optional: when ``R2_CATALOG_URI`` / ``R2_CATALOG_WAREHOUSE`` /
-    ``R2_CATALOG_TOKEN`` are all present the ``comments`` view is served from the
-    Iceberg catalog; otherwise the server falls back to the monolithic
-    ``comments.parquet`` (the dual model). The token used here should be a
-    read-scoped R2 API token — this is a public, read-only server.
-
-    Values are inlined into ``CREATE SECRET`` / ``ATTACH`` (which take no bind
-    parameters), so any value containing a quote, backslash, or control
-    character is rejected outright rather than escaped.
-    """
     uri = os.environ.get("R2_CATALOG_URI")
     warehouse = os.environ.get("R2_CATALOG_WAREHOUSE")
     token = os.environ.get("R2_CATALOG_TOKEN")
@@ -177,8 +118,6 @@ def _resolve_catalog_config() -> dict[str, str] | None:
         "uri": uri,
         "warehouse": warehouse,
         "token": token,
-        # `or DEFAULT` (not get's default arg) so an env var set to an empty
-        # string falls back to the default namespace rather than "".
         "namespace": os.environ.get("R2_CATALOG_NAMESPACE") or DEFAULT_CATALOG_NAMESPACE,
     }
     for key, value in config.items():
@@ -188,7 +127,6 @@ def _resolve_catalog_config() -> dict[str, str] | None:
 
 
 def _jsonify(value: Any) -> Any:
-    """Coerce DuckDB row values into JSON-serializable forms."""
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
     if isinstance(value, (datetime, date, time)):
@@ -209,54 +147,16 @@ def _jsonify(value: Any) -> Any:
 
 
 def _apply_security_settings(con: duckdb.DuckDBPyConnection) -> None:
-    """Lock a fresh connection down to read-only remote access.
-
-    Separated from :func:`_connect` (which also installs httpfs and creates the
-    R2 views) so the sandbox can be exercised in tests without network access.
-    Run after httpfs is loaded and before any user SQL.
-    """
     con.execute("SET preserve_insertion_order=false")
     con.execute("SET autoinstall_known_extensions=false")
     con.execute("SET autoload_known_extensions=false")
     con.execute("SET allow_unsigned_extensions=false")
-    # NB: do NOT disable LocalFileSystem here. It is tempting as a guard against
-    # user SQL reading local files, but httpfs reads the system CA bundle off
-    # the local filesystem for every TLS handshake, so disabling it breaks the
-    # only thing this server does — reading the R2 parquet over HTTPS fails with
-    # "File system LocalFileSystem has been disabled by configuration" the
-    # moment a view binds. See the query_sql docstring for the access model.
-    #
-    # Disable on-disk spilling instead: temp_directory defaults to a local
-    # ".tmp" that is read-only on serverless hosts, so a spilling query (a big
-    # GROUP BY/ORDER BY) would fail there anyway. Empty disables spilling —
-    # queries run in memory or fail with a clear out-of-memory error.
     con.execute("SET temp_directory=''")
-    # DuckDB has no statement_timeout parameter; the per-query cap is enforced
-    # by the _statement_timeout watchdog wrapping each tool's execution.
     con.execute("SET lock_configuration=true")
 
 
 def _attach_catalog(con: duckdb.DuckDBPyConnection, config: dict[str, str]) -> bool:
-    """Attach the R2 Data Catalog so the ``comments`` view can read from it.
-
-    Best-effort: if the iceberg extension or the attach fails (bad token,
-    network, catalog down) the server stays up by falling back to the monolithic
-    ``comments.parquet``. Must run before :func:`_apply_security_settings` locks
-    the configuration. Returns ``True`` only when the catalog is attached.
-    """
     try:
-        # DuckDB 1.5's iceberg extension reads Avro manifests via a separate
-        # `avro` extension. iceberg tries to auto-install it lazily during LOAD,
-        # but that nested install doesn't inherit the session's home_directory in
-        # serverless sandboxes (Vercel) and dies with "Can't find the home
-        # directory at ''" — so the whole attach fails and comments silently fall
-        # back to the frozen monolith. Installing avro explicitly first runs on
-        # the same top-level path that already installs httpfs/iceberg fine, so it
-        # sees the configured home_directory and the nested auto-install is skipped.
-        #
-        # Best-effort: on older DuckDB (<1.5) avro isn't a separate extension and
-        # `INSTALL avro` errors — swallow it and let iceberg use its bundled Avro
-        # path, so this never regresses environments where the attach already works.
         try:
             con.execute("INSTALL avro")
             con.execute("LOAD avro")
@@ -274,15 +174,10 @@ def _attach_catalog(con: duckdb.DuckDBPyConnection, config: dict[str, str]) -> b
 
 def _connect() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
-    # Must precede INSTALL/LOAD: that step writes the extension under
-    # <home_directory>/.duckdb, and the default home is read-only or undefined
-    # on serverless hosts.
     con.execute(f"SET home_directory='{HOME_DIRECTORY.replace(chr(39), chr(39) * 2)}'")
     con.execute("INSTALL httpfs")
     con.execute("LOAD httpfs")
 
-    # Optionally attach the Iceberg catalog (before the config lock) so the
-    # comments view can be served from it.
     catalog = _resolve_catalog_config()
     catalog_attached = catalog is not None and _attach_catalog(con, catalog)
 
@@ -291,46 +186,25 @@ def _connect() -> duckdb.DuckDBPyConnection:
         if name == "comments" and catalog_attached:
             namespace = catalog["namespace"]  # type: ignore[index]
             try:
-                # Dedup on read: keep one row per comment_id (latest modify_date).
-                # The catalog table can physically carry duplicate comment_id rows —
-                # DuckDB's Iceberg engine has no MERGE INTO, so the ETL upsert uses a
-                # plain DELETE, and DELETE does not reliably remove prior rows on the
-                # R2 Data Catalog, so a re-merged comment_id can leave its old row
-                # behind. This QUALIFY makes the read surface single-valued regardless;
-                # physical compaction reclaims the space out-of-band. Keep in sync with
-                # spicy_regs.mcp_server.
                 con.execute(
-                    f'CREATE VIEW comments AS '
+                    f"CREATE VIEW comments AS "
                     f'SELECT * FROM {CATALOG_ALIAS}."{namespace}"."comments" '
-                    f'QUALIFY ROW_NUMBER() OVER '
-                    f'(PARTITION BY comment_id ORDER BY modify_date DESC NULLS LAST) = 1'
+                    f"QUALIFY ROW_NUMBER() OVER "
+                    f"(PARTITION BY comment_id ORDER BY modify_date DESC NULLS LAST) = 1"
                 )
                 continue
             except duckdb.Error as exc:
-                # Catalog reachable but the table isn't there yet — fall back to
-                # the monolith rather than breaking every query on the server.
                 logger.warning("comments not available in catalog; falling back to monolith: %s", exc)
         url = f"{R2_BASE_URL}/{name}.parquet"
         try:
             con.execute(f"CREATE VIEW {name} AS SELECT * FROM read_parquet('{url}')")
         except duckdb.Error as exc:
-            # A table registered in TABLES whose parquet isn't published yet
-            # (e.g. a new source whose first upload hasn't run) shouldn't break
-            # every query on the server — skip its view and keep the rest, the
-            # same way the comments-catalog branch degrades above.
             logger.warning("table %s not available at %s; skipping view: %s", name, url, exc)
     return con
 
 
 @contextmanager
 def _statement_timeout(con: duckdb.DuckDBPyConnection) -> Iterator[None]:
-    """Cap the wrapped query's runtime, replacing the missing DuckDB setting.
-
-    Starts a watchdog timer that calls ``con.interrupt()`` once the configured
-    budget elapses; a tripped timer turns DuckDB's ``InterruptException`` into a
-    ``TimeoutError`` so the cause is unambiguous. A no-op when the timeout is
-    disabled.
-    """
     if STATEMENT_TIMEOUT_SECONDS is None:
         yield
         return
@@ -358,10 +232,6 @@ mcp = FastMCP(
     icons=ICONS,
     stateless_http=True,
     streamable_http_path="/mcp",
-    # The hosted deployment is reached via mcp.spicy-regs.dev and per-deploy
-    # *.vercel.app hosts; FastMCP's default localhost-only DNS-rebinding
-    # allowlist would reject all of them with 421. The server is public,
-    # stateless, and read-only, so rebinding protection buys nothing here.
     transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
 )
 
@@ -440,14 +310,6 @@ _FUNCTION_PATH = "/api/index"
 
 
 async def app(scope, receive, send):
-    """ASGI entry point for Vercel.
-
-    vercel.json rewrites /mcp to this function. Only the exact function path
-    (/api/index) is routable on the platform, and depending on how rewritten
-    requests are forwarded the ASGI path can arrive as the original (/mcp) or
-    as the function path; normalize the latter onto the transport's /mcp
-    mount so both work.
-    """
     if scope["type"] == "http" and scope.get("path", "").startswith(_FUNCTION_PATH):
         suffix = scope["path"][len(_FUNCTION_PATH) :]
         path = suffix if suffix.startswith("/mcp") else "/mcp"

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -1,18 +1,3 @@
-"""Spicy Regs MCP server (stdio + ASGI).
-
-Canonical FastMCP server implementation. Exposed two ways:
-
-- Stdio, via the ``spicy-regs-mcp`` console script declared in pyproject.toml.
-  Install with ``uvx --from "spicy-regs @ git+https://github.com/civictechdc/spicy-regs" spicy-regs-mcp``
-  or, once published, ``uvx spicy-regs-mcp``.
-- Streamable HTTP, via :func:`build_app` for ASGI deployment.
-
-The Vercel function at ``mcp-server/api/index.py`` keeps a parallel copy so it
-can deploy without pulling in the parent package's ETL dependencies. Keep the
-tool surface (names, parameters, behavior) in sync between the two files;
-``tests/test_mcp_server.py::test_vercel_copy_in_sync`` enforces this.
-"""
-
 from __future__ import annotations
 
 import logging
@@ -35,9 +20,6 @@ from mcp.types import Icon
 from spicy_regs._icon import ICON_DATA_URI
 
 DEFAULT_R2_BASE_URL = "https://data.spicy-regs.dev"
-# The full published R2 surface. Must match the data dictionary's table list
-# (src/spicy_regs/data_dictionary.py::TABLES) — a test enforces it so the two
-# can't drift. Keep in sync with the Vercel copy in mcp-server/api/index.py.
 TABLES = (
     "dockets",
     "documents",
@@ -60,34 +42,15 @@ TABLES = (
     "fcc_proceedings",
     "fcc_filings",
 )
-# Matches the Vercel copy's default (kept just under that deploy's 800s
-# ``maxDuration``). stdio has no platform duration limit, so here this is purely
-# a runaway-query guard; it stays in lockstep with the Vercel copy so the two
-# behave identically. Override with ``SPICY_REGS_STATEMENT_TIMEOUT``.
 STATEMENT_TIMEOUT = os.environ.get("SPICY_REGS_STATEMENT_TIMEOUT", "790s")
 
 logger = logging.getLogger(__name__)
 
-# DuckDB alias the R2 Data Catalog is attached under (mirrors
-# ``spicy_regs.sources.iceberg._CATALOG_ALIAS``). When the catalog is
-# configured, the ``comments`` view is served from it instead of the monolithic
-# ``comments.parquet`` — the comments table is too large to keep republishing as
-# a single file, so the catalog is its read surface. All other tables stay on
-# the public Parquet snapshots.
 CATALOG_ALIAS = "reg_catalog"
 DEFAULT_CATALOG_NAMESPACE = "default"
 
 
 def _parse_timeout_seconds(raw: str) -> float | None:
-    """Parse ``SPICY_REGS_STATEMENT_TIMEOUT`` into seconds (``None`` disables it).
-
-    DuckDB has no ``statement_timeout`` configuration parameter — ``SET
-    statement_timeout=...`` raises ``Catalog Error: unrecognized configuration
-    parameter``. The cap is instead enforced with a watchdog that interrupts the
-    connection (see :func:`_statement_timeout`). Accepts a bare number of
-    seconds or a value suffixed with ``ms``/``s``/``m``; non-positive values
-    disable the timeout.
-    """
     text = raw.strip().lower()
     if not text:
         return None
@@ -116,9 +79,6 @@ INSTRUCTIONS = (
     "IDs, comment IDs, agency codes, and dates from the rows you return."
 )
 
-# Server icon, advertised on the Implementation metadata sent during
-# ``initialize``. A base64 data: URI (not an https:// URL) so it works for both
-# the stdio and HTTP transports — see scripts/gen_icon.py.
 ICONS = [Icon(src=ICON_DATA_URI, mimeType="image/png", sizes=["512x512"])]
 
 
@@ -136,15 +96,6 @@ R2_BASE_URL = _resolve_r2_base_url()
 
 
 def _resolve_home_directory() -> str:
-    """Pick a writable directory for DuckDB's extension/home cache.
-
-    DuckDB resolves its extension cache under ``$HOME/.duckdb``. Serverless
-    hosts (Vercel/AWS Lambda) frequently have no writable home directory, or
-    none defined at all, so ``INSTALL httpfs`` fails with
-    ``Can't find the home directory at ''``. Defaulting to the platform temp
-    directory keeps the extension fetch working there while staying valid on
-    local stdio installs; ``SPICY_REGS_HOME_DIR`` overrides it.
-    """
     raw = os.environ.get("SPICY_REGS_HOME_DIR", tempfile.gettempdir())
     if any(c in raw for c in ("\x00", "\n", "\r")):
         raise RuntimeError(f"SPICY_REGS_HOME_DIR contains illegal characters: {raw!r}")
@@ -155,18 +106,6 @@ HOME_DIRECTORY = _resolve_home_directory()
 
 
 def _resolve_catalog_config() -> dict[str, str] | None:
-    """Return R2 Data Catalog connection settings, or ``None`` when unconfigured.
-
-    The catalog is optional: when ``R2_CATALOG_URI`` / ``R2_CATALOG_WAREHOUSE`` /
-    ``R2_CATALOG_TOKEN`` are all present the ``comments`` view is served from the
-    Iceberg catalog; otherwise the server falls back to the monolithic
-    ``comments.parquet`` (the dual model). The token used here should be a
-    read-scoped R2 API token — this is a public, read-only server.
-
-    Values are inlined into ``CREATE SECRET`` / ``ATTACH`` (which take no bind
-    parameters), so any value containing a quote, backslash, or control
-    character is rejected outright rather than escaped.
-    """
     uri = os.environ.get("R2_CATALOG_URI")
     warehouse = os.environ.get("R2_CATALOG_WAREHOUSE")
     token = os.environ.get("R2_CATALOG_TOKEN")
@@ -176,8 +115,6 @@ def _resolve_catalog_config() -> dict[str, str] | None:
         "uri": uri,
         "warehouse": warehouse,
         "token": token,
-        # `or DEFAULT` (not get's default arg) so an env var set to an empty
-        # string falls back to the default namespace rather than "".
         "namespace": os.environ.get("R2_CATALOG_NAMESPACE") or DEFAULT_CATALOG_NAMESPACE,
     }
     for key, value in config.items():
@@ -187,7 +124,6 @@ def _resolve_catalog_config() -> dict[str, str] | None:
 
 
 def _jsonify(value: Any) -> Any:
-    """Coerce DuckDB row values into JSON-serializable forms."""
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
     if isinstance(value, (datetime, date, time)):
@@ -208,54 +144,16 @@ def _jsonify(value: Any) -> Any:
 
 
 def _apply_security_settings(con: duckdb.DuckDBPyConnection) -> None:
-    """Lock a fresh connection down to read-only remote access.
-
-    Separated from :func:`_connect` (which also installs httpfs and creates the
-    R2 views) so the sandbox can be exercised in tests without network access.
-    Run after httpfs is loaded and before any user SQL.
-    """
     con.execute("SET preserve_insertion_order=false")
     con.execute("SET autoinstall_known_extensions=false")
     con.execute("SET autoload_known_extensions=false")
     con.execute("SET allow_unsigned_extensions=false")
-    # NB: do NOT disable LocalFileSystem here. It is tempting as a guard against
-    # user SQL reading local files, but httpfs reads the system CA bundle off
-    # the local filesystem for every TLS handshake, so disabling it breaks the
-    # only thing this server does — reading the R2 parquet over HTTPS fails with
-    # "File system LocalFileSystem has been disabled by configuration" the
-    # moment a view binds. See the query_sql docstring for the access model.
-    #
-    # Disable on-disk spilling instead: temp_directory defaults to a local
-    # ".tmp" that is read-only on serverless hosts, so a spilling query (a big
-    # GROUP BY/ORDER BY) would fail there anyway. Empty disables spilling —
-    # queries run in memory or fail with a clear out-of-memory error.
     con.execute("SET temp_directory=''")
-    # DuckDB has no statement_timeout parameter; the per-query cap is enforced
-    # by the _statement_timeout watchdog wrapping each tool's execution.
     con.execute("SET lock_configuration=true")
 
 
 def _attach_catalog(con: duckdb.DuckDBPyConnection, config: dict[str, str]) -> bool:
-    """Attach the R2 Data Catalog so the ``comments`` view can read from it.
-
-    Best-effort: if the iceberg extension or the attach fails (bad token,
-    network, catalog down) the server stays up by falling back to the monolithic
-    ``comments.parquet``. Must run before :func:`_apply_security_settings` locks
-    the configuration. Returns ``True`` only when the catalog is attached.
-    """
     try:
-        # DuckDB 1.5's iceberg extension reads Avro manifests via a separate
-        # `avro` extension. iceberg tries to auto-install it lazily during LOAD,
-        # but that nested install doesn't inherit the session's home_directory in
-        # serverless sandboxes (Vercel) and dies with "Can't find the home
-        # directory at ''" — so the whole attach fails and comments silently fall
-        # back to the frozen monolith. Installing avro explicitly first runs on
-        # the same top-level path that already installs httpfs/iceberg fine, so it
-        # sees the configured home_directory and the nested auto-install is skipped.
-        #
-        # Best-effort: on older DuckDB (<1.5) avro isn't a separate extension and
-        # `INSTALL avro` errors — swallow it and let iceberg use its bundled Avro
-        # path, so this never regresses environments where the attach already works.
         try:
             con.execute("INSTALL avro")
             con.execute("LOAD avro")
@@ -273,15 +171,10 @@ def _attach_catalog(con: duckdb.DuckDBPyConnection, config: dict[str, str]) -> b
 
 def _connect() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
-    # Must precede INSTALL/LOAD: that step writes the extension under
-    # <home_directory>/.duckdb, and the default home is read-only or undefined
-    # on serverless hosts.
     con.execute(f"SET home_directory='{HOME_DIRECTORY.replace(chr(39), chr(39) * 2)}'")
     con.execute("INSTALL httpfs")
     con.execute("LOAD httpfs")
 
-    # Optionally attach the Iceberg catalog (before the config lock) so the
-    # comments view can be served from it.
     catalog = _resolve_catalog_config()
     catalog_attached = catalog is not None and _attach_catalog(con, catalog)
 
@@ -290,52 +183,25 @@ def _connect() -> duckdb.DuckDBPyConnection:
         if name == "comments" and catalog_attached:
             namespace = catalog["namespace"]  # type: ignore[index]
             try:
-                # Dedup on read: keep one row per comment_id (latest modify_date).
-                # The catalog table can physically carry duplicate comment_id rows
-                # because DuckDB's Iceberg engine has no MERGE INTO, so the ETL
-                # upsert (iceberg._merge) removes superseded rows with a plain
-                # DELETE — and DELETE does not reliably remove prior rows on the R2
-                # Data Catalog (the same limitation dedupe_table works around by
-                # never deleting). Any comment_id that is re-merged (a comment whose
-                # modify_date advanced, or a key re-staged by the redundant sweep)
-                # can therefore leave its old row behind next to the new one. This
-                # QUALIFY makes the read surface single-valued regardless, so counts
-                # aren't inflated and comments aren't repeated; physical compaction
-                # (scripts/dedupe_comments_catalog.py) reclaims the space out-of-band.
-                # A filter on agency_code/docket_id pushes down ahead of the window,
-                # so the common point-lookup queries only dedup the rows they touch.
                 con.execute(
-                    f'CREATE VIEW comments AS '
+                    f"CREATE VIEW comments AS "
                     f'SELECT * FROM {CATALOG_ALIAS}."{namespace}"."comments" '
-                    f'QUALIFY ROW_NUMBER() OVER '
-                    f'(PARTITION BY comment_id ORDER BY modify_date DESC NULLS LAST) = 1'
+                    f"QUALIFY ROW_NUMBER() OVER "
+                    f"(PARTITION BY comment_id ORDER BY modify_date DESC NULLS LAST) = 1"
                 )
                 continue
             except duckdb.Error as exc:
-                # Catalog reachable but the table isn't there yet — fall back to
-                # the monolith rather than breaking every query on the server.
                 logger.warning("comments not available in catalog; falling back to monolith: %s", exc)
         url = f"{R2_BASE_URL}/{name}.parquet"
         try:
             con.execute(f"CREATE VIEW {name} AS SELECT * FROM read_parquet('{url}')")
         except duckdb.Error as exc:
-            # A table registered in TABLES whose parquet isn't published yet
-            # (e.g. a new source whose first upload hasn't run) shouldn't break
-            # every query on the server — skip its view and keep the rest, the
-            # same way the comments-catalog branch degrades above.
             logger.warning("table %s not available at %s; skipping view: %s", name, url, exc)
     return con
 
 
 @contextmanager
 def _statement_timeout(con: duckdb.DuckDBPyConnection) -> Iterator[None]:
-    """Cap the wrapped query's runtime, replacing the missing DuckDB setting.
-
-    Starts a watchdog timer that calls ``con.interrupt()`` once the configured
-    budget elapses; a tripped timer turns DuckDB's ``InterruptException`` into a
-    ``TimeoutError`` so the cause is unambiguous. A no-op when the timeout is
-    disabled.
-    """
     if STATEMENT_TIMEOUT_SECONDS is None:
         yield
         return
@@ -425,25 +291,18 @@ def _register_tools(mcp: FastMCP) -> None:
 
 
 def build_server() -> FastMCP:
-    """Construct a FastMCP server with the Spicy Regs tools registered."""
     mcp = FastMCP("spicy-regs", instructions=INSTRUCTIONS, icons=ICONS)
     _register_tools(mcp)
     return mcp
 
 
 def build_app():
-    """ASGI app for Streamable HTTP transport (used by the Vercel function)."""
     mcp = FastMCP(
         "spicy-regs",
         instructions=INSTRUCTIONS,
         icons=ICONS,
         stateless_http=True,
         streamable_http_path="/mcp",
-        # The hosted deployment is reached via mcp.spicy-regs.dev and
-        # per-deploy *.vercel.app hosts; FastMCP's default localhost-only
-        # DNS-rebinding allowlist would reject all of them with 421. The
-        # server is public, stateless, and read-only, so rebinding
-        # protection buys nothing here.
         transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
     )
     _register_tools(mcp)
@@ -451,7 +310,6 @@ def build_app():
 
 
 def main() -> None:
-    """Stdio entry point used by the ``spicy-regs-mcp`` console script."""
     build_server().run()
 
 


### PR DESCRIPTION
> **Stacked on #152** — base is `feat/mcp-raise-max-duration`, not `main`, because this deletes the very comments that PR adds. Merge #152 first and this retargets to `main` cleanly.

Applies the project policy — no comments in code files; documentation lives in markdown — to `src/spicy_regs/mcp_server.py` and its mirror `mcp-server/api/index.py`.

**286 lines removed** from the two modules. The rationale is preserved in full in a new **`mcp-server/INTERNALS.md`**.

## Why INTERNALS.md and not CLAUDE.md

CLAUDE.md was the intended destination, but it can't be one: `.git/info/exclude` carries a bare `CLAUDE.md` pattern, and gitignore syntax matches that **at every directory level**. Verified — `CLAUDE.md`, `mcp-server/CLAUDE.md`, `docs/CLAUDE.md`, and `src/spicy_regs/CLAUDE.md` are all excluded. Moving the rationale there would have deleted it from a shared repo and left it on one laptop; the next person to touch `_attach_catalog` would drop the `INSTALL avro` line without knowing why it exists.

`docs/` is also wrong — that's the public data-dictionary site (docs.spicy-regs.dev), built with `mkdocs build --strict` and an explicit nav, aimed at data consumers. Contributor notes would be off-topic there, and an unlisted file fails the strict build.

So: `mcp-server/INTERNALS.md`, following the existing `src/spicy_regs/transforms/README.md` precedent of docs beside code, but named INTERNALS because policy reserves READMEs for what the general public needs. `mcp-server/README.md` gets a pointer; the local CLAUDE.md keeps a stub.

## Two things deliberately kept

Neither is documentation, and both would be silent breakage:

1. **The three `@mcp.tool()` docstrings.** FastMCP reflects over `fn.__doc__` to build the tool descriptions sent to every client during `list_tools`. `describe_table`'s docstring is how a client learns which tables are valid; `query_sql`'s is how it learns the available views. Deleting them ships a server whose tools have no descriptions — and no markdown file can substitute, because the client never reads this repo.
2. **Inline `# type: ignore[index]` and `# noqa: E402`.** Both `ty` and `ruff` gate merges and read these.

Both rules are now written down in `INTERNALS.md` so the next cleanup doesn't rediscover them the hard way.

## How

Stripping used Python's `tokenize`, not regex, so a `#` inside a string literal was never at risk of being treated as a comment. Docstring removal was AST-driven. `ruff format` was applied afterward.

## Verification

- `ruff check`, `ruff format --check`, `ty check` — all clean.
- `tests/test_mcp_server.py` — 24 passed, including `test_vercel_copy_in_sync`.
- Asserted both copies still return **non-empty descriptions for all three tools**, and that `describe_table`'s description still enumerates the tables.
- Vercel ASGI app still constructs; both copies still parse the timeout to `790.0s`.

## Unrelated, but worth flagging

`main` is currently red: `tests/test_regulations_pipeline.py` has 3 failures (`test_run_extracts_stages_and_merges`, `test_run_dedups_on_merge_keeping_latest_modify_date`, `test_run_with_no_records_is_noop`) that reproduce on a clean checkout with zero changes. Not caused by this PR or #151/#152, but CI here will be red until they're fixed.