### PR TITLE
fix(tests): isolate the environment so unit tests stop hitting production R2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,12 @@ the maintainers publish.
 - Follow existing code style and conventions (ruff handles most of this).
 - Add or update tests for any behavior change.
 - Run `uv run pytest` and `uv run ruff check .` before pushing.
+- The default suite is hermetic. An autouse `isolate_env` fixture in
+  `tests/conftest.py` strips `R2_*`, `SPICY_REGS_*`, `CLOUDFLARE_*`, `AWS_*`,
+  `AGENCIES`, and the API keys, so a local `.env` can't leak into a unit test and
+  send it at production R2. If a test genuinely needs real credentials or the
+  network, mark it `@pytest.mark.integration` — the fixture exempts those, and
+  they're deselected by default.
 
 ## Glossary
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,22 @@
 """Shared fixtures for pipeline tests."""
 
+import os
 from pathlib import Path
 
 import polars as pl
 import pytest
+
+_ISOLATED_PREFIXES = ("R2_", "SPICY_REGS_", "CLOUDFLARE_", "AWS_")
+_ISOLATED_NAMES = frozenset({"AGENCIES", "DATA_GOV_API_KEY", "SAM_API_KEY", "LDA_API_KEY", "COURTLISTENER_API_TOKEN"})
+
+
+@pytest.fixture(autouse=True)
+def isolate_env(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    if "integration" in request.keywords:
+        return
+    for name in list(os.environ):
+        if name.startswith(_ISOLATED_PREFIXES) or name in _ISOLATED_NAMES:
+            monkeypatch.delenv(name, raising=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
Triage of the 3 `tests/test_regulations_pipeline.py` failures. They aren't assertion bugs — the "hermetic" unit tests were **downloading the real production corpus**.

## What's actually happening

```
Downloaded manifest.parquet from R2
Loaded manifest: 28,327,698 keys (~125 MB)
Downloaded dockets.parquet from R2
Downloaded documents.parquet from R2
AssertionError: assert not True
  where True = (tmp_output / 'dockets.parquet').exists()
```

`test_run_with_no_records_is_noop` asserts the output dir is empty. It isn't — because `RegulationsPipeline.run()` primed itself from production R2 first.

`load_dotenv()` runs at module **import** time in `sources/r2.py:26`, `pipelines/regulations.py:51`, and `pipelines/rollups/base.py:34`. By the time pytest collects, a local `.env` is already in `os.environ`, so the pipeline finds real credentials and downloads.

## Why CI stayed green

CI has no `.env`, so the isolation happened by accident:

| | Runtime | Result |
|---|---|---|
| CI (no `.env`) | **31s** | green |
| Local (with `.env`) | **838s** | 3 failed |

That 800-second gap was entirely production download. A green CI was *hiding* the defect rather than catching it.

## Why a fixture and not three `delenv` calls

The suite already knew about this: **42 `monkeypatch.delenv` calls across 12 test files** patch the same leak one test at a time. The 3 failures are precisely the spots where someone forgot — and the failing tests are exactly the ones in that file lacking `delenv("R2_PUBLIC_URL")`, while every passing one has it.

Adding a fourth `delenv` fixes today's symptom and leaves the trap armed for the next test author. This makes hermeticity the default: an autouse `isolate_env` fixture strips `R2_*`, `SPICY_REGS_*`, `CLOUDFLARE_*`, `AWS_*`, `AGENCIES`, and the API keys. Tests marked `integration` are exempt, since they legitimately need credentials and the network.

## Result

```
before:  409 passed, 3 failed   in 838s
after:   412 passed, 0 failed   in  70s
```

`tests/test_regulations_pipeline.py` alone goes from **596s to 0.63s**.

## Verification

- Full suite: **412 passed, 0 failed**. No test relied on the leaked environment.
- `ruff check` and `ty check` clean; my added block is `ruff format`-stable.
- `pytest -m integration --collect-only` still collects all 3 integration tests, confirming the marker exemption works.
- Diff is 13 added lines in `conftest.py`, 0 deletions — I deliberately did **not** run `ruff format` across the whole file, since it would have reformatted ~200 lines of unrelated fixture data (`ruff format` isn't in CI, only pre-commit).

## Follow-ups, not in this PR

- The 42 `delenv` calls are now redundant no-ops. Removing them is a safe cleanup but a large mechanical diff, so I left them.
- Worth considering whether `load_dotenv()` at import time is right at all. Calling it inside the CLI entry points instead of at module scope would make the library importable without side effects, and this whole class of leak would go away. That's a larger refactor.