### PR TITLE
refactor: load .env in CLI entry points, not at import time

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,12 +92,16 @@ the maintainers publish.
 - Follow existing code style and conventions (ruff handles most of this).
 - Add or update tests for any behavior change.
 - Run `uv run pytest` and `uv run ruff check .` before pushing.
+- Never call `load_dotenv()` at module scope. Importing the package must not
+  mutate `os.environ` — that leaks a developer's `.env` into unit tests and
+  points them at production R2. Call it in the CLI entry point instead (the
+  `@app.default` command, or `main()`). `tests/test_env_loading.py` enforces
+  this.
 - The default suite is hermetic. An autouse `isolate_env` fixture in
-  `tests/conftest.py` strips `R2_*`, `SPICY_REGS_*`, `CLOUDFLARE_*`, `AWS_*`,
-  `AGENCIES`, and the API keys, so a local `.env` can't leak into a unit test and
-  send it at production R2. If a test genuinely needs real credentials or the
-  network, mark it `@pytest.mark.integration` — the fixture exempts those, and
-  they're deselected by default.
+  `tests/conftest.py` also strips `R2_*`, `SPICY_REGS_*`, `CLOUDFLARE_*`,
+  `AWS_*`, `AGENCIES`, and the API keys as defence in depth. If a test genuinely
+  needs real credentials or the network, mark it `@pytest.mark.integration` — the
+  fixture exempts those, and they're deselected by default.
 
 ## Glossary
 

--- a/scripts/seed_comments_catalog.py
+++ b/scripts/seed_comments_catalog.py
@@ -39,8 +39,6 @@ from loguru import logger
 from spicy_regs.schemas import COMMENT
 from spicy_regs.sources import iceberg, r2
 
-load_dotenv()
-
 _REQUIRED_S3_ENV = ("R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "R2_ENDPOINT")
 
 
@@ -101,6 +99,7 @@ def _expected_counts(con, bucket: str) -> dict[str, int]:
 
 
 def main() -> int:
+    load_dotenv()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--agency", help="Load only this agency_code (default: all)")
     parser.add_argument("--output-dir", type=Path, default=Path("output"))

--- a/src/spicy_regs/backfill_derived_text.py
+++ b/src/spicy_regs/backfill_derived_text.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Any
 
 import polars as pl
+from dotenv import load_dotenv
 from loguru import logger
 
 from spicy_regs.schemas import RecordType
@@ -410,6 +411,7 @@ def backfill_comments_catalog(
 
 
 def main() -> None:
+    load_dotenv()
     parser = argparse.ArgumentParser(
         description="Backfill comment text_content from Mirrulations derived-data extracted text."
     )

--- a/src/spicy_regs/cli.py
+++ b/src/spicy_regs/cli.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from urllib.request import urlretrieve
 from urllib.error import URLError
 
+from dotenv import load_dotenv
+
 # Public URL for the R2 bucket
 PUBLIC_URL = "https://data.spicy-regs.dev"
 DATA_TYPES = ["dockets", "documents", "comments", "manifest"]
@@ -201,6 +203,7 @@ def cmd_agencies(args):
 
 
 def main():
+    load_dotenv()
     parser = argparse.ArgumentParser(
         prog="spicy-regs",
         description="Download and explore federal regulations data from Spicy Regs",

--- a/src/spicy_regs/data_dictionary.py
+++ b/src/spicy_regs/data_dictionary.py
@@ -29,6 +29,7 @@ import tempfile
 from pathlib import Path
 
 import polars as pl
+from dotenv import load_dotenv
 
 from spicy_regs.schemas.regulations import RECORD_TYPES
 
@@ -668,6 +669,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> None:
+    load_dotenv()
     parser = build_parser()
     args = parser.parse_args(argv)
     sys.exit(args.func(args))

--- a/src/spicy_regs/enrich_pdf.py
+++ b/src/spicy_regs/enrich_pdf.py
@@ -30,6 +30,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import polars as pl
+from dotenv import load_dotenv
 from loguru import logger
 
 from spicy_regs.schemas import RecordType
@@ -507,6 +508,7 @@ def enrich_comments_catalog(
 
 
 def main() -> None:
+    load_dotenv()
     parser = argparse.ArgumentParser(description="Backfill documents/comments text_content from PDF attachments.")
     parser.add_argument("--output-dir", type=Path, default=Path("output"))
     parser.add_argument(

--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -48,8 +48,6 @@ from spicy_regs.transforms import (
     write_staging,
 )
 
-load_dotenv()
-
 
 class RegulationsPipeline(Pipeline):
     """Mirrulations S3 → Parquet ETL, composed from Readers, Writers, and transforms."""
@@ -412,6 +410,7 @@ def main(
     verbose: Annotated[bool, Parameter(name=["--verbose", "-v"], help="Verbose logging")] = False,
 ) -> None:
     """Run the regulations.gov ETL pipeline."""
+    load_dotenv()
     RegulationsPipeline(
         agency=agency,
         output_dir=output_dir,

--- a/src/spicy_regs/pipelines/rollups/base.py
+++ b/src/spicy_regs/pipelines/rollups/base.py
@@ -31,8 +31,6 @@ from loguru import logger
 from spicy_regs.pipelines.base import Pipeline
 from spicy_regs.sources import r2
 
-load_dotenv()
-
 
 class RollupPipeline(Pipeline):
     """A single materialized rollup, run standalone from the base tables on R2."""
@@ -111,6 +109,7 @@ def make_rollup_app(pipeline_cls: type[RollupPipeline]) -> App:
         output_dir: Annotated[Path | None, Parameter(help="Output directory")] = None,
         skip_upload: Annotated[bool, Parameter(help="Skip R2 upload (recommended while vetting)")] = True,
     ) -> None:
+        load_dotenv()
         pipeline_cls(output_dir=output_dir, skip_upload=skip_upload).run()
 
     return app

--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -20,10 +20,7 @@ from pathlib import Path
 
 import boto3
 import httpx
-from dotenv import load_dotenv
 from loguru import logger
-
-load_dotenv()
 
 
 # --- download (public URL) -------------------------------------------------

--- a/src/spicy_regs/vectordb/embed.py
+++ b/src/spicy_regs/vectordb/embed.py
@@ -23,6 +23,7 @@ import argparse
 from pathlib import Path
 
 import polars as pl
+from dotenv import load_dotenv
 from tqdm import tqdm
 
 try:
@@ -163,6 +164,7 @@ def embed_parquet(
 
 
 def main():
+    load_dotenv()
     # Build preset help text
     preset_help = "Model presets:\n"
     for key, val in MODEL_PRESETS.items():

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,0 +1,48 @@
+"""Guards that ``.env`` is loaded by CLI entry points, never at import time."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SEARCH_ROOTS = (REPO_ROOT / "src", REPO_ROOT / "scripts")
+
+
+_DEFINITIONS = (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+
+
+def _module_scope_dotenv_calls(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text())
+    lines = []
+    for node in tree.body:
+        if isinstance(node, _DEFINITIONS):
+            continue
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Call) and isinstance(sub.func, ast.Name) and sub.func.id == "load_dotenv":
+                lines.append(sub.lineno)
+    return lines
+
+
+def _python_files() -> list[Path]:
+    return [p for root in SEARCH_ROOTS if root.is_dir() for p in sorted(root.rglob("*.py"))]
+
+
+@pytest.mark.parametrize("path", _python_files(), ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_no_module_scope_load_dotenv(path: Path) -> None:
+    offenders = _module_scope_dotenv_calls(path)
+    assert not offenders, (
+        f"{path.relative_to(REPO_ROOT)} calls load_dotenv() at module scope "
+        f"(line {offenders[0]}). Importing the package must not mutate os.environ — "
+        f"it leaks a developer's .env into unit tests and sends them at production R2. "
+        f"Call load_dotenv() inside the CLI entry point instead."
+    )
+
+
+def test_entry_points_load_dotenv() -> None:
+    from spicy_regs.pipelines import regulations
+    from spicy_regs.pipelines.rollups import base
+
+    for module in (regulations, base):
+        source = Path(module.__file__).read_text()
+        assert "load_dotenv()" in source, f"{module.__name__} never calls load_dotenv()"

--- a/tests/test_regulations_pipeline.py
+++ b/tests/test_regulations_pipeline.py
@@ -188,7 +188,6 @@ def test_chunked_comments_commit_per_chunk(tmp_output: Path, monkeypatch: pytest
     """With chunk_size set, comments ingest in bounded key-chunks and the catalog
     MERGE runs once per chunk (so a huge agency commits in pieces, never buffering
     everything in memory)."""
-    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     # 5 comment files, chunk_size 2 -> chunks [2,2,1] -> 3 merges.
     store = {
         _comment_key(f"c{i}", "EPA-2026-0001"): dumps(
@@ -237,7 +236,6 @@ def _run(tmp_output: Path, **overrides: Any) -> None:
 
 
 def test_second_run_skips_keys_already_in_manifest(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     store = {
         _docket_key("EPA-2024-0001"): dumps(_docket_payload("EPA-2024-0001", "2024-01-01")).encode(),
         _docket_key("EPA-2025-0002"): dumps(_docket_payload("EPA-2025-0002", "2025-01-01")).encode(),
@@ -259,7 +257,6 @@ def test_second_run_skips_keys_already_in_manifest(tmp_output: Path, monkeypatch
 
 
 def test_full_refresh_reprocesses_despite_manifest(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     store = {_docket_key("EPA-2024-0001"): dumps(_docket_payload("EPA-2024-0001", "2024-01-01")).encode()}
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
 
@@ -284,7 +281,6 @@ def test_failed_download_is_not_committed_to_manifest_and_retries_next_run(
 ) -> None:
     """A transient download failure must not be marked processed, so the next
     incremental run re-lists and re-downloads it."""
-    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     good = _docket_key("EPA-2024-0001")
     flaky = _docket_key("EPA-2025-0002")
     store = {
@@ -312,7 +308,6 @@ def test_failed_download_is_not_committed_to_manifest_and_retries_next_run(
 def test_parse_failure_is_committed_to_manifest(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A deterministically corrupt file is marked processed (so it doesn't retry
     forever) and recorded in failed_keys.parquet with kind=parse."""
-    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     good = _docket_key("EPA-2024-0001")
     corrupt = _docket_key("EPA-2025-0002")
     store = {
@@ -335,7 +330,6 @@ def test_parse_failure_is_committed_to_manifest(tmp_output: Path, monkeypatch: p
 
 def test_chunked_comments_exclude_failed_keys_from_manifest(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The chunked ingest path excludes transient failures from the manifest too."""
-    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     keys = {f"c{i}": _comment_key(f"c{i}", "EPA-2026-0001") for i in range(3)}
     store = {
         keys[f"c{i}"]: dumps(_comment_payload(f"c{i}", "EPA-2026-0001", "2026-01-01T00:00:00Z")).encode()
@@ -373,7 +367,6 @@ def test_chunked_comments_exclude_failed_keys_from_manifest(tmp_output: Path, mo
 
 
 def test_processes_multiple_agencies_in_parallel(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     monkeypatch.setenv("AGENCIES", "EPA,FDA")
     store = {
         _docket_key("EPA-2024-0001", agency="EPA"): dumps(
@@ -402,7 +395,6 @@ def test_processes_multiple_agencies_in_parallel(tmp_output: Path, monkeypatch: 
 def test_run_uploads_changed_comment_partitions(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A run that stages comments must publish the changed partitions + index,
     not just the monolithic dataset."""
-    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)  # keep merge's R2 fetch offline
     store = {
         _comment_key("c1", "EPA-2024-0001"): dumps(
             _comment_payload("c1", "EPA-2024-0001", "2024-01-01T00:00:00Z")
@@ -440,7 +432,6 @@ def test_run_uploads_changed_comment_partitions(tmp_output: Path, monkeypatch: p
 
 def test_run_skips_partition_upload_when_no_comments(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A dockets-only run must not call the comment-partition upload."""
-    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)
     store = {
         _docket_key("EPA-2024-0001"): dumps(_docket_payload("EPA-2024-0001", "2024-01-01")).encode(),
     }
@@ -475,7 +466,6 @@ def test_run_primes_comments_index_from_r2_before_merge(tmp_output: Path, monkey
     regression by asserting the index is requested during the prime step and
     that pre-existing rows survive the rebuild.
     """
-    monkeypatch.delenv("R2_PUBLIC_URL", raising=False)  # keep merge's partition fetch offline
     store = {
         _comment_key("c1", "EPA-2024-0001"): dumps(
             _comment_payload("c1", "EPA-2024-0001", "2024-01-01T00:00:00Z")


### PR DESCRIPTION
Removes the cause of #154. That PR contained the blast radius with an autouse `isolate_env` fixture; this removes the import-time side effect itself.

`load_dotenv()` ran at **module scope** in `sources/r2.py`, `pipelines/regulations.py`, and `pipelines/rollups/base.py`, so merely importing the package mutated `os.environ`. That is what let a developer's `.env` reach unit tests and point them at production R2.

## Where it moved

| Entry point | Now loads `.env` |
|---|---|
| `pipelines/regulations.py` | inside the `@app.default` command |
| `pipelines/rollups/base.py` | inside `make_rollup_app`'s command — **covers all 20 `run-rollup-*` scripts** via the one shared factory |
| `cli.py`, `backfill_derived_text.py`, `enrich_pdf.py`, `data_dictionary.py`, `vectordb/embed.py`, `scripts/seed_comments_catalog.py` | first line of `main()` |
| `sources/r2.py` | call dropped entirely — it's a library, and every entry point reaching it now loads `.env` itself |

`mcp_server.py` is deliberately untouched. It never called `load_dotenv`, reads its config at import from the real environment the deployment supplies, and adding a call to `main()` would be a **no-op** anyway since those constants are already computed by then.

## Verified both directions

Not assumed — actually measured:

- **Import purity.** Importing `spicy_regs.sources.r2`, `.pipelines.regulations`, `.pipelines.rollups.base`, and a concrete rollup in a fresh process leaves `R2_PUBLIC_URL`, `R2_ACCESS_KEY_ID`, and `R2_SECRET_ACCESS_KEY` absent from `os.environ`. (Confirmed my shell doesn't export them and `.env` does define them, so the check is meaningful.)
- **Entry points still work.** Invoking the `run-pipeline` and `run-rollup-*` cyclopts apps with the pipeline stubbed shows `.env` loaded by the time the command body runs.

`tests/test_env_loading.py` locks this in with an AST scan asserting no module-scope `load_dotenv()` anywhere in `src/` or `scripts/`. I confirmed it **fails when the call is reintroduced** rather than merely passing today.

## On the `delenv` calls

Removed the 10 `monkeypatch.delenv("R2_PUBLIC_URL")` calls in `test_regulations_pipeline.py` — pure leak guards, now redundant twice over.

**The remaining 34 are deliberately kept**, because they're test *arrangement*, not defence. Removing them would weaken or silently break real coverage:

- `test_mcp_server`'s partial-catalog-config tests delete one var while setting the others, to prove partial config returns `None`.
- `test_sam_entities` cycles `SAM_MAX_RECORDS` through blank and invalid values — and `SAM_MAX_RECORDS` isn't covered by `isolate_env` at all, so removing it would be an outright bug.
- `test_download_r2::test_returns_false_when_r2_url_not_set` and `test_manifest::test_load_no_manifest_is_empty` assert behaviour when R2 is unconfigured; the `delenv` is the precondition their names describe.
- The `_clear_key_env` helpers cycle API-key precedence.

I read all 42 before deciding, rather than pattern-matching the call name.

## Result

```
513 passed, 3 deselected in 68s
```

`ruff check`, `ruff format --check`, and `ty check` all clean.

`isolate_env` stays as defence in depth — for a genuinely exported shell var, or a future import-time reader. Belt and braces is right here; the braces just weren't load-bearing anymore.