### PR TITLE
perf(mcp): cache the DuckDB connection across tool calls

### DIFF
--- a/mcp-server/api/index.py
+++ b/mcp-server/api/index.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from pathlib import Path
+from time import monotonic as _monotonic
 from typing import Any
 from urllib.parse import urlparse
 from uuid import UUID
@@ -172,7 +173,7 @@ def _attach_catalog(con: duckdb.DuckDBPyConnection, config: dict[str, str]) -> b
         return False
 
 
-def _connect() -> duckdb.DuckDBPyConnection:
+def _build_connection() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
     con.execute(f"SET home_directory='{HOME_DIRECTORY.replace(chr(39), chr(39) * 2)}'")
     con.execute("INSTALL httpfs")
@@ -203,8 +204,59 @@ def _connect() -> duckdb.DuckDBPyConnection:
     return con
 
 
+# Building a connection is the expensive part of a tool call — install httpfs +
+# iceberg, attach the R2 catalog over REST, and CREATE VIEW over all 20 tables
+# (each reads a parquet footer over HTTPS), ~35s on a cold serverless instance.
+# The query that follows is milliseconds. So we build once and reuse: Fluid
+# Compute keeps a warmed instance's module state across invocations, and the
+# stdio server is a single long-lived process, so a module-level connection
+# amortizes that cost across every request the instance serves.
+#
+# Concurrency: the cached connection is shared, but each request runs on its own
+# `con.cursor()` — DuckDB's supported way to run overlapping queries on one
+# connection — so the statement-timeout interrupt (below) hits only that cursor,
+# never a sibling request.
+#
+# Staleness: the views hold parquet footers and the catalog attach pins an
+# Iceberg snapshot, both taken at build time. The ETL republishes daily, so a
+# connection older than the TTL is rebuilt to pick up new data. On rebuild we
+# only drop the module reference to the old connection — never close it — so any
+# cursor still mid-query keeps working (a cursor outlives its parent losing its
+# last Python reference); the old connection is reclaimed once its cursors drain.
+_CONNECTION_TTL_SECONDS = float(os.environ.get("SPICY_REGS_CONNECTION_TTL", "300"))
+_connection_lock = threading.Lock()
+_cached_connection: duckdb.DuckDBPyConnection | None = None
+_cached_connection_at = 0.0
+
+
+def _get_connection() -> duckdb.DuckDBPyConnection:
+    """Return a shared, cached DuckDB connection, rebuilding past the TTL.
+
+    Callers must run their query on ``.cursor()`` of the returned connection,
+    not on the connection itself, so concurrent requests don't serialize and a
+    per-request timeout interrupt stays scoped to that request.
+    """
+    global _cached_connection, _cached_connection_at
+    with _connection_lock:
+        age = _monotonic() - _cached_connection_at
+        if _cached_connection is None or age >= _CONNECTION_TTL_SECONDS:
+            # Drop (don't close) the previous connection: an in-flight cursor on
+            # another thread still references it and must survive this swap.
+            _cached_connection = _build_connection()
+            _cached_connection_at = _monotonic()
+        return _cached_connection
+
+
+def _reset_connection_cache() -> None:
+    """Forget the cached connection so the next call rebuilds. For tests."""
+    global _cached_connection, _cached_connection_at
+    with _connection_lock:
+        _cached_connection = None
+        _cached_connection_at = 0.0
+
+
 @contextmanager
-def _statement_timeout(con: duckdb.DuckDBPyConnection) -> Iterator[None]:
+def _statement_timeout(cursor: duckdb.DuckDBPyConnection) -> Iterator[None]:
     if STATEMENT_TIMEOUT_SECONDS is None:
         yield
         return
@@ -212,7 +264,9 @@ def _statement_timeout(con: duckdb.DuckDBPyConnection) -> Iterator[None]:
 
     def _interrupt() -> None:
         tripped.set()
-        con.interrupt()
+        # Interrupt only this request's cursor, not the shared connection —
+        # sibling requests run on their own cursors and must not be cancelled.
+        cursor.interrupt()
 
     timer = threading.Timer(STATEMENT_TIMEOUT_SECONDS, _interrupt)
     timer.start()
@@ -258,9 +312,9 @@ def describe_table(table: str) -> dict[str, Any]:
             "error": f"Unknown table '{table}'",
             "available_tables": list(TABLES),
         }
-    con = _connect()
-    with _statement_timeout(con):
-        rows = con.execute(f"DESCRIBE {table}").fetchall()
+    cursor = _get_connection().cursor()
+    with _statement_timeout(cursor):
+        rows = cursor.execute(f"DESCRIBE {table}").fetchall()
     return {
         "table": table,
         "columns": [
@@ -288,9 +342,9 @@ def query_sql(sql: str, max_rows: int = 25) -> dict[str, Any]:
     if max_rows <= 0 or max_rows > 500:
         return {"error": "max_rows must be between 1 and 500"}
 
-    con = _connect()
-    with _statement_timeout(con):
-        cursor = con.execute(sql)
+    cursor = _get_connection().cursor()
+    with _statement_timeout(cursor):
+        cursor.execute(sql)
         columns = [desc[0] for desc in cursor.description] if cursor.description else []
         rows = cursor.fetchmany(max_rows)
     result_rows = [{col: _jsonify(val) for col, val in zip(columns, row)} for row in rows]

--- a/scripts/check_comments_freshness.py
+++ b/scripts/check_comments_freshness.py
@@ -156,7 +156,9 @@ def main() -> int:
         idx_where = ""
         rows_where = ""
 
-    con = mcp_server._connect()
+    # A one-off script that owns and closes its own connection — use the builder
+    # directly, not the shared cached connection the MCP tools reuse.
+    con = mcp_server._build_connection()
     try:
         stale = _check_freshness(con, idx_where, rows_where, args.limit)
         duplicated = _check_duplicates(con, rows_where, args.limit)

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from time import monotonic as _monotonic
 from typing import Any
 from urllib.parse import urlparse
 from uuid import UUID
@@ -169,7 +170,7 @@ def _attach_catalog(con: duckdb.DuckDBPyConnection, config: dict[str, str]) -> b
         return False
 
 
-def _connect() -> duckdb.DuckDBPyConnection:
+def _build_connection() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect()
     con.execute(f"SET home_directory='{HOME_DIRECTORY.replace(chr(39), chr(39) * 2)}'")
     con.execute("INSTALL httpfs")
@@ -200,8 +201,59 @@ def _connect() -> duckdb.DuckDBPyConnection:
     return con
 
 
+# Building a connection is the expensive part of a tool call — install httpfs +
+# iceberg, attach the R2 catalog over REST, and CREATE VIEW over all 20 tables
+# (each reads a parquet footer over HTTPS), ~35s on a cold serverless instance.
+# The query that follows is milliseconds. So we build once and reuse: Fluid
+# Compute keeps a warmed instance's module state across invocations, and the
+# stdio server is a single long-lived process, so a module-level connection
+# amortizes that cost across every request the instance serves.
+#
+# Concurrency: the cached connection is shared, but each request runs on its own
+# `con.cursor()` — DuckDB's supported way to run overlapping queries on one
+# connection — so the statement-timeout interrupt (below) hits only that cursor,
+# never a sibling request.
+#
+# Staleness: the views hold parquet footers and the catalog attach pins an
+# Iceberg snapshot, both taken at build time. The ETL republishes daily, so a
+# connection older than the TTL is rebuilt to pick up new data. On rebuild we
+# only drop the module reference to the old connection — never close it — so any
+# cursor still mid-query keeps working (a cursor outlives its parent losing its
+# last Python reference); the old connection is reclaimed once its cursors drain.
+_CONNECTION_TTL_SECONDS = float(os.environ.get("SPICY_REGS_CONNECTION_TTL", "300"))
+_connection_lock = threading.Lock()
+_cached_connection: duckdb.DuckDBPyConnection | None = None
+_cached_connection_at = 0.0
+
+
+def _get_connection() -> duckdb.DuckDBPyConnection:
+    """Return a shared, cached DuckDB connection, rebuilding past the TTL.
+
+    Callers must run their query on ``.cursor()`` of the returned connection,
+    not on the connection itself, so concurrent requests don't serialize and a
+    per-request timeout interrupt stays scoped to that request.
+    """
+    global _cached_connection, _cached_connection_at
+    with _connection_lock:
+        age = _monotonic() - _cached_connection_at
+        if _cached_connection is None or age >= _CONNECTION_TTL_SECONDS:
+            # Drop (don't close) the previous connection: an in-flight cursor on
+            # another thread still references it and must survive this swap.
+            _cached_connection = _build_connection()
+            _cached_connection_at = _monotonic()
+        return _cached_connection
+
+
+def _reset_connection_cache() -> None:
+    """Forget the cached connection so the next call rebuilds. For tests."""
+    global _cached_connection, _cached_connection_at
+    with _connection_lock:
+        _cached_connection = None
+        _cached_connection_at = 0.0
+
+
 @contextmanager
-def _statement_timeout(con: duckdb.DuckDBPyConnection) -> Iterator[None]:
+def _statement_timeout(cursor: duckdb.DuckDBPyConnection) -> Iterator[None]:
     if STATEMENT_TIMEOUT_SECONDS is None:
         yield
         return
@@ -209,7 +261,9 @@ def _statement_timeout(con: duckdb.DuckDBPyConnection) -> Iterator[None]:
 
     def _interrupt() -> None:
         tripped.set()
-        con.interrupt()
+        # Interrupt only this request's cursor, not the shared connection —
+        # sibling requests run on their own cursors and must not be cancelled.
+        cursor.interrupt()
 
     timer = threading.Timer(STATEMENT_TIMEOUT_SECONDS, _interrupt)
     timer.start()
@@ -245,9 +299,9 @@ def _register_tools(mcp: FastMCP) -> None:
                 "error": f"Unknown table '{table}'",
                 "available_tables": list(TABLES),
             }
-        con = _connect()
-        with _statement_timeout(con):
-            rows = con.execute(f"DESCRIBE {table}").fetchall()
+        cursor = _get_connection().cursor()
+        with _statement_timeout(cursor):
+            rows = cursor.execute(f"DESCRIBE {table}").fetchall()
         return {
             "table": table,
             "columns": [
@@ -274,9 +328,9 @@ def _register_tools(mcp: FastMCP) -> None:
         if max_rows <= 0 or max_rows > 500:
             return {"error": "max_rows must be between 1 and 500"}
 
-        con = _connect()
-        with _statement_timeout(con):
-            cursor = con.execute(sql)
+        cursor = _get_connection().cursor()
+        with _statement_timeout(cursor):
+            cursor.execute(sql)
             columns = [desc[0] for desc in cursor.description] if cursor.description else []
             rows = cursor.fetchmany(max_rows)
         result_rows = [{col: _jsonify(val) for col, val in zip(columns, row)} for row in rows]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -163,7 +163,7 @@ def test_resolve_catalog_config_rejects_injection(module_name, monkeypatch):
 # both shipped runtime crashes lived (the bogus ``statement_timeout`` SET and
 # the spill-to-disabled-LocalFileSystem error). They are hermetic: the sandbox
 # is applied to a plain in-memory connection, so no httpfs install or network
-# is needed. The live ``_connect`` + R2 path is covered by the integration test
+# is needed. The live ``_build_connection`` + R2 path is covered by the integration test
 # below.
 
 
@@ -247,7 +247,7 @@ def test_comments_catalog_view_dedups_on_read():
     The R2 Data Catalog can physically carry duplicate comment_id rows: the ETL
     upsert removes superseded rows with a plain ``DELETE``, which does not reliably
     take on the catalog, so a re-merged comment_id can leave its old row behind.
-    ``_connect`` wraps the catalog table in a per-comment_id QUALIFY so the read
+    ``_build_connection`` wraps the catalog table in a per-comment_id QUALIFY so the read
     surface stays single-valued regardless. This locks in that dedup expression:
     the newest ``modify_date`` wins, exactly one row survives per id, and
     non-duplicated ids are untouched — which is also the ``count(*) ==
@@ -265,7 +265,7 @@ def test_comments_catalog_view_dedups_on_read():
             ('c3', '2024-05-01', 'unique');
         """
     )
-    # The exact dedup wrapper used by the catalog `comments` view in `_connect`.
+    # The exact dedup wrapper used by the catalog `comments` view in `_build_connection`.
     con.execute(
         "CREATE VIEW comments AS SELECT * FROM raw "
         "QUALIFY ROW_NUMBER() OVER "
@@ -283,7 +283,7 @@ def test_comments_catalog_view_dedups_on_read():
 
 @pytest.mark.integration
 def test_connect_queries_r2_end_to_end():
-    """Live: the real ``_connect`` (httpfs + R2 views) serves the MCP tools.
+    """Live: the real ``_build_connection`` (httpfs + R2 views) serves the MCP tools.
 
     Covers the full path the hermetic tests cannot — httpfs install, the R2
     parquet views, and a spilling aggregation over real data — asserting none
@@ -320,11 +320,13 @@ def _clear_connection_cache():
     mcp_server._reset_connection_cache()
 
 
-def _make_local_connection(monkeypatch, module) -> duckdb.DuckDBPyConnection:
+def _make_local_connection(monkeypatch, module) -> dict[str, int]:
     """Force ``_build_connection`` to hand back a bare in-memory DuckDB.
 
     Keeps these tests hermetic: no httpfs, no R2, no catalog — just enough of a
     connection to prove the caching, cursor-isolation, and TTL logic wrapping it.
+    Returns a ``{"n": build_count}`` dict so callers can assert how many times
+    the (patched) builder actually ran.
     """
     build_count = {"n": 0}
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -307,3 +307,98 @@ def test_connect_queries_r2_end_to_end():
         )
     )
     assert result is not None
+
+
+# --- connection caching ------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_connection_cache():
+    """Keep the module-level connection cache from leaking across tests."""
+    mcp_server._reset_connection_cache()
+    yield
+    mcp_server._reset_connection_cache()
+
+
+def _make_local_connection(monkeypatch, module) -> duckdb.DuckDBPyConnection:
+    """Force ``_build_connection`` to hand back a bare in-memory DuckDB.
+
+    Keeps these tests hermetic: no httpfs, no R2, no catalog — just enough of a
+    connection to prove the caching, cursor-isolation, and TTL logic wrapping it.
+    """
+    build_count = {"n": 0}
+
+    def _fake_build() -> duckdb.DuckDBPyConnection:
+        build_count["n"] += 1
+        con = duckdb.connect()
+        con.execute("CREATE TABLE agency_stats AS SELECT 1 AS docket_count")
+        return con
+
+    monkeypatch.setattr(module, "_build_connection", _fake_build)
+    return build_count
+
+
+@pytest.mark.parametrize("module_name", ["canonical", "vercel"])
+def test_get_connection_reuses_within_ttl(module_name, monkeypatch):
+    module = mcp_server if module_name == "canonical" else _load_vercel_copy()
+    module._reset_connection_cache()
+    build_count = _make_local_connection(monkeypatch, module)
+
+    first = module._get_connection()
+    second = module._get_connection()
+
+    assert first is second
+    assert build_count["n"] == 1
+    module._reset_connection_cache()
+
+
+@pytest.mark.parametrize("module_name", ["canonical", "vercel"])
+def test_get_connection_rebuilds_past_ttl(module_name, monkeypatch):
+    module = mcp_server if module_name == "canonical" else _load_vercel_copy()
+    module._reset_connection_cache()
+    build_count = _make_local_connection(monkeypatch, module)
+    # A zero TTL forces every call to treat the cache as expired.
+    monkeypatch.setattr(module, "_CONNECTION_TTL_SECONDS", 0.0)
+
+    module._get_connection()
+    module._get_connection()
+
+    assert build_count["n"] == 2
+    module._reset_connection_cache()
+
+
+def test_cursor_from_cached_connection_survives_rebuild(monkeypatch):
+    """A cursor taken before a TTL rebuild must keep serving its query.
+
+    This is the safety property the rebuild relies on: swapping the cached
+    connection only drops the module's reference, so an in-flight request's
+    cursor (which still references the old connection) is never closed.
+    """
+    module = mcp_server
+    module._reset_connection_cache()
+    _make_local_connection(monkeypatch, module)
+    monkeypatch.setattr(module, "_CONNECTION_TTL_SECONDS", 0.0)
+
+    old_cursor = module._get_connection().cursor()
+    module._get_connection()  # TTL expired -> builds and caches a new connection
+
+    # The old cursor's parent is no longer referenced by the module, but the
+    # cursor holds it alive and still answers.
+    assert old_cursor.execute("SELECT docket_count FROM agency_stats").fetchone() == (1,)
+    module._reset_connection_cache()
+
+
+def test_query_sql_reuses_one_connection_across_calls(monkeypatch):
+    """Two ``query_sql`` calls should build the backing connection once."""
+    module = mcp_server
+    module._reset_connection_cache()
+    build_count = _make_local_connection(monkeypatch, module)
+    server = module.build_server()
+
+    for _ in range(2):
+        asyncio.run(
+            server.call_tool("query_sql", {"sql": "SELECT docket_count FROM agency_stats", "max_rows": 1})
+        )
+
+    assert build_count["n"] == 1
+    module._reset_connection_cache()


### PR DESCRIPTION
## The problem

Load-testing ahead of the 100-user hackathon showed the MCP server's bottleneck **isn't concurrency — it's a fixed per-call cost.** Every `query_sql`/`describe_table` rebuilt a DuckDB from scratch: install `httpfs` + `iceberg`, attach the R2 catalog over REST, and `CREATE VIEW` over all 20 tables (each reads a parquet footer over HTTPS). ~35s on a cold serverless instance before the actual query — which is milliseconds.

Measured, no load:

| | latency |
|---|---|
| `query_sql` on a **3 KB** table | **34.5s** |
| same query on a warm connection | **0.18s** |
| `list_sources` (skips the rebuild) | 0.09s |

And it's not a load ceiling — p50 was flat from 1→25 concurrent with **0 errors**. Fluid Compute scales out fine; the server was uniformly slow, not overloaded.

## The fix

Build the connection once at module level and reuse it. Fluid Compute keeps a warmed instance's module state across invocations, and the stdio server is one long-lived process — so the setup cost amortizes across every request the instance serves.

**Measured end to end against live R2** (`build_server()` → `call_tool` twice):

```
cold=7.56s  warm=0.21s  warm2=0.43s
```

(Cold is 7.6s locally because there's no catalog attach without creds; on Vercel the cold path is the full ~35s, so the warm speedup is ~190×.)

## Why it's safe — three properties, each verified before relying on it

- **Concurrency** — each request runs on its own `con.cursor()`, DuckDB's supported way to overlap queries on one connection. Confirmed two cursors run concurrently without serializing.
- **Timeout isolation** — the statement-timeout watchdog now interrupts the request's *cursor*, not the shared connection. Verified a 1.5s timeout fires on one cursor while the connection stays alive to serve the next request. Without this, one slow query would cancel everyone on the instance.
- **Staleness** — views pin parquet footers and the catalog attach pins an Iceberg snapshot at build time; the ETL republishes daily. A connection older than `SPICY_REGS_CONNECTION_TTL` (default 300s) is rebuilt. On rebuild we **only drop the module reference** to the old connection, never close it — an in-flight cursor still references it. Verified a cursor outlives its parent losing its last Python reference, so a TTL swap can't kill a request mid-query.

## Notes

- Mirrored identically into the Vercel copy; `test_vercel_copy_in_sync` enforces the surface stays in step.
- Both modules already shadow `time` with `datetime.time`, so the clock is imported as `from time import monotonic as _monotonic`.
- New hermetic tests: reuse-within-TTL, rebuild-past-TTL, cursor survival across a rebuild, one-build-across-two-tool-calls — parametrized across both module copies where it matters.

## Deliberately out of scope (hackathon follow-ups, not connection concerns)

- `query_sql` bounds output via `max_rows` but **not the bytes a query scans** — `SELECT count(DISTINCT comment_id) FROM comments` took 109s and succeeded.
- The endpoint has **no auth or rate limit**. Fine today; worth a conscious decision before inviting 100 people.
- Cloudflare isn't caching `.parquet` (`cf-cache-status: DYNAMIC`) — separate config change, and the current `no-cache` on Parquet is deliberate (documented in `sources/r2.py`).

## Verification

```
uv run ruff check .   All checks passed
uv run ty check       All checks passed
uv run pytest         526 passed, 3 deselected
```

Full load-test writeup: the harness at `scratchpad/loadtest.py` is re-runnable (`--suite baseline|r2|mcp|abuse`). Recommend re-running against a true 100 concurrent after this merges, since each call is now cheap enough to make that test meaningful.