### PR TITLE
feat(r2): cache the corpus at the edge with purge-on-publish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,17 @@ R2_BUCKET_NAME=spicy-regs
 R2_ENDPOINT=https://YOUR_ACCOUNT_ID.r2.cloudflarestorage.com
 R2_PUBLIC_URL=https://data.spicy-regs.dev
 
-# Cloudflare Workers AI (used by search API for embeddings)
+# Cloudflare edge-cache purge — invalidate data.spicy-regs.dev after each publish.
+# Optional: unset => purge is a no-op (uploads still work). Both must be set to
+# enable it. Token needs Zone > Cache Purge (edit) on the spicy-regs.dev zone;
+# zone id is on the Cloudflare dashboard overview for that zone.
+# CLOUDFLARE_API_TOKEN=your_cache_purge_token
+# CLOUDFLARE_ZONE_ID=your_zone_id
+
+# Cloudflare Workers AI (vestigial — the removed search API's embeddings). Leave
+# unset unless re-adding embeddings. CLOUDFLARE_API_TOKEN above is reused for the
+# cache purge; CLOUDFLARE_ACCOUNT_ID is only for Workers AI.
 CLOUDFLARE_ACCOUNT_ID=your_account_id
-CLOUDFLARE_API_TOKEN=your_api_token
 
 # R2 Data Catalog (Apache Iceberg) — only needed for `run-pipeline --use-iceberg`.
 # URI + warehouse are under R2 > your bucket > Settings > Data Catalog.

--- a/.github/workflows/_rollup.yml
+++ b/.github/workflows/_rollup.yml
@@ -71,6 +71,9 @@ jobs:
           R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          # Cloudflare edge-cache purge after publish (best-effort; no-op if unset).
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           DATA_GOV_API_KEY: ${{ secrets.DATA_GOV_API_KEY }}
           # SAM.gov Entity API key. Unlike the generic DATA_GOV_API_KEY, SAM
           # requires a key provisioned by a SAM.gov account (api.data.gov-backed);

--- a/.github/workflows/backfill-comment-attachment-text.yml
+++ b/.github/workflows/backfill-comment-attachment-text.yml
@@ -76,6 +76,9 @@ jobs:
       R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
       R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
       R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+      # Cloudflare edge-cache purge after publish (best-effort; no-op if unset).
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
       R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
       R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}
       R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}

--- a/.github/workflows/dedupe-comments-catalog.yml
+++ b/.github/workflows/dedupe-comments-catalog.yml
@@ -91,6 +91,9 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
           R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          # Cloudflare edge-cache purge after publish (best-effort; no-op if unset).
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           # Re-exporting from the catalog re-sorts + re-compresses, so a partition
           # can shrink on disk while holding more rows; the script enforces a
           # row-count floor instead of the byte-size shrink guard.

--- a/.github/workflows/etl-new-pipeline.yml
+++ b/.github/workflows/etl-new-pipeline.yml
@@ -171,6 +171,9 @@ jobs:
           R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          # Cloudflare edge-cache purge after publish (best-effort; no-op if unset).
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           # Only used when use_iceberg is on; harmless otherwise.
           R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
           R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}

--- a/.github/workflows/publish-comments-mirror.yml
+++ b/.github/workflows/publish-comments-mirror.yml
@@ -62,6 +62,9 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
           R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          # Cloudflare edge-cache purge after publish (best-effort; no-op if unset).
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           # Bypass r2's byte-size shrink guard: re-exporting from the catalog
           # re-sorts + re-compresses the data, so a partition can be several times
           # smaller on disk while holding *more* rows (verified: ACF 19.7 MB -> 6.0 MB

--- a/.github/workflows/seed-comments-catalog.yml
+++ b/.github/workflows/seed-comments-catalog.yml
@@ -68,6 +68,9 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
           R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          # Cloudflare edge-cache purge after publish (best-effort; no-op if unset).
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
           R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}
           R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}

--- a/src/spicy_regs/sources/cloudflare.py
+++ b/src/spicy_regs/sources/cloudflare.py
@@ -1,0 +1,67 @@
+"""Cloudflare cache purge — invalidate the edge cache after a publish.
+
+The data is served from R2 behind Cloudflare at ``data.spicy-regs.dev``. Once a
+Cloudflare Cache Rule marks the corpus eligible for edge caching (Cache-Control
+headers alone don't cache ``.parquet``/``.json.gz`` — those extensions aren't in
+Cloudflare's default set), a cached object would otherwise serve until its TTL
+expires even after the ETL republishes it. This module purges the exact URLs we
+just wrote so a fresh publish is visible immediately, letting us cache
+aggressively (fast reads for many concurrent clients) without serving stale data.
+
+Purging is **best-effort and never fails a publish**: a purge error logs a
+warning and returns, because the upload already succeeded and the moderate
+origin ``max-age`` is a self-healing backstop — stale data ages out on its own
+even if a purge is missed. It is a **no-op without credentials** (no
+``CLOUDFLARE_API_TOKEN`` / ``CLOUDFLARE_ZONE_ID``), mirroring how ``upload_file``
+no-ops without R2 credentials, so local runs and tests need no Cloudflare setup.
+"""
+
+from __future__ import annotations
+
+from os import getenv
+
+import httpx
+from loguru import logger
+
+# Cloudflare caps purge-by-URL at 30 URLs per request on Free/Pro/Business plans.
+_MAX_URLS_PER_CALL = 30
+_PURGE_TIMEOUT = 15.0
+
+
+def _purge_config() -> tuple[str, str] | None:
+    """Return (zone_id, token) if both are configured, else None."""
+    token = getenv("CLOUDFLARE_API_TOKEN")
+    zone_id = getenv("CLOUDFLARE_ZONE_ID")
+    if not token or not zone_id:
+        return None
+    return zone_id, token
+
+
+def purge_urls(urls: list[str]) -> None:
+    """Purge specific URLs from the Cloudflare edge cache (best-effort).
+
+    No-ops (with a debug log) when Cloudflare credentials aren't configured.
+    Batches into groups of 30 to respect the purge-by-URL limit. Any HTTP or
+    transport error is logged and swallowed — invalidation must never break the
+    publish that already wrote the data.
+    """
+    if not urls:
+        return
+    config = _purge_config()
+    if config is None:
+        logger.debug("Cloudflare purge skipped (CLOUDFLARE_API_TOKEN / CLOUDFLARE_ZONE_ID not set)")
+        return
+    zone_id, token = config
+    endpoint = f"https://api.cloudflare.com/client/v4/zones/{zone_id}/purge_cache"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    for start in range(0, len(urls), _MAX_URLS_PER_CALL):
+        batch = urls[start : start + _MAX_URLS_PER_CALL]
+        try:
+            resp = httpx.post(endpoint, headers=headers, json={"files": batch}, timeout=_PURGE_TIMEOUT)
+            if resp.status_code != 200 or not resp.json().get("success", False):
+                logger.warning("Cloudflare purge failed ({}): {}", resp.status_code, resp.text[:300])
+            else:
+                logger.info("Purged {} URL(s) from Cloudflare cache", len(batch))
+        except (httpx.HTTPError, ValueError) as exc:
+            logger.warning("Cloudflare purge error (upload already succeeded): {}", exc)

--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -22,6 +22,8 @@ import boto3
 import httpx
 from loguru import logger
 
+from spicy_regs.sources.cloudflare import purge_urls
+
 
 # --- download (public URL) -------------------------------------------------
 
@@ -172,17 +174,16 @@ def upload_file(local_path: Path, remote_key: str | None = None) -> None:
     remote_size = _get_remote_size(client, bucket, remote_key)
     _assert_upload_safe(local_size_bytes, remote_size, remote_key)
 
-    # Parquet readers issue many byte-range requests. Serving stale ranges across
-    # an object replacement can mix two versions and corrupt the read, so Parquet
-    # may be stored by caches but must be revalidated before reuse. Small immutable-
-    # enough auxiliary artifacts retain the prior edge-cache policy. Operators can
-    # override either policy globally when testing a Cloudflare rule.
+    # Cache-Control policy. Parquet readers issue many byte-range requests, and
+    # serving stale ranges across an object replacement can mix two versions and
+    # corrupt a read — so historically Parquet was marked `no-cache`. That is now
+    # handled by purge-on-publish below (we invalidate the exact URL we just
+    # wrote), which lets Parquet be cached like everything else. The `max-age` is
+    # a self-healing backstop: if a purge is ever missed, stale data still ages
+    # out within the hour rather than persisting to the next daily republish.
+    # `R2_CACHE_CONTROL` still overrides everything for ad-hoc testing.
     configured_cache_control = getenv("R2_CACHE_CONTROL")
-    cache_control = configured_cache_control or (
-        "public, no-cache, must-revalidate"
-        if remote_key.endswith(".parquet")
-        else "public, max-age=3600, stale-while-revalidate=86400"
-    )
+    cache_control = configured_cache_control or "public, max-age=3600"
     client.upload_file(
         str(local_path),
         bucket,
@@ -192,6 +193,12 @@ def upload_file(local_path: Path, remote_key: str | None = None) -> None:
 
     public_url = getenv("R2_PUBLIC_URL", "")
     logger.info("Uploaded: {}/{}", public_url, remote_key)
+
+    # Invalidate the edge cache for exactly this object so the fresh version is
+    # visible immediately. Best-effort and a no-op without Cloudflare creds; it
+    # must never fail a publish that already wrote the data (see cloudflare.py).
+    if public_url:
+        purge_urls([f"{public_url.rstrip('/')}/{remote_key}"])
 
 
 def upload_directory_to_r2(local_dir: Path, remote_prefix: str | None = None) -> None:

--- a/tests/test_cloudflare.py
+++ b/tests/test_cloudflare.py
@@ -1,0 +1,94 @@
+"""Tests for the Cloudflare cache-purge helper (sources/cloudflare.py)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from spicy_regs.sources import cloudflare
+
+
+def _creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "tok-123")
+    monkeypatch.setenv("CLOUDFLARE_ZONE_ID", "zone-abc")
+
+
+def test_purge_noop_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No token/zone => no HTTP call at all (uploads must work without CF setup)."""
+    monkeypatch.delenv("CLOUDFLARE_API_TOKEN", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_ZONE_ID", raising=False)
+
+    def _boom(*a, **k):
+        raise AssertionError("httpx.post must not be called without credentials")
+
+    monkeypatch.setattr(httpx, "post", _boom)
+    cloudflare.purge_urls(["https://data.spicy-regs.dev/agency_stats.parquet"])
+
+
+def test_purge_noop_with_partial_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only one of the two vars set => still a no-op, not a malformed call."""
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "tok-123")
+    monkeypatch.delenv("CLOUDFLARE_ZONE_ID", raising=False)
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: pytest.fail("should not call"))
+    cloudflare.purge_urls(["https://data.spicy-regs.dev/x.parquet"])
+
+
+def test_purge_empty_list_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    _creds(monkeypatch)
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: pytest.fail("should not call"))
+    cloudflare.purge_urls([])
+
+
+def test_purge_posts_expected_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    _creds(monkeypatch)
+    calls: list[dict] = []
+
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        calls.append({"url": url, "headers": headers, "json": json})
+        return httpx.Response(200, json={"success": True, "result": {"id": "x"}})
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    cloudflare.purge_urls(["https://data.spicy-regs.dev/agency_stats.parquet"])
+
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://api.cloudflare.com/client/v4/zones/zone-abc/purge_cache"
+    assert calls[0]["headers"]["Authorization"] == "Bearer tok-123"
+    assert calls[0]["json"] == {"files": ["https://data.spicy-regs.dev/agency_stats.parquet"]}
+
+
+def test_purge_batches_over_thirty_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cloudflare caps purge-by-URL at 30; 70 URLs => 3 calls (30/30/10)."""
+    _creds(monkeypatch)
+    batch_sizes: list[int] = []
+
+    def _fake_post(url, headers=None, json: dict | None = None, timeout=None):
+        assert json is not None
+        batch_sizes.append(len(json["files"]))
+        return httpx.Response(200, json={"success": True})
+
+    monkeypatch.setattr(httpx, "post", _fake_post)
+    cloudflare.purge_urls([f"https://data.spicy-regs.dev/f{i}.parquet" for i in range(70)])
+
+    assert batch_sizes == [30, 30, 10]
+
+
+def test_purge_swallows_api_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-success API response is logged, not raised (publish already happened)."""
+    _creds(monkeypatch)
+    monkeypatch.setattr(
+        httpx,
+        "post",
+        lambda *a, **k: httpx.Response(403, json={"success": False, "errors": [{"message": "nope"}]}),
+    )
+    cloudflare.purge_urls(["https://data.spicy-regs.dev/x.parquet"])  # must not raise
+
+
+def test_purge_swallows_transport_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transport error must never propagate out of a best-effort purge."""
+    _creds(monkeypatch)
+
+    def _raise(*a, **k):
+        raise httpx.ConnectError("edge unreachable")
+
+    monkeypatch.setattr(httpx, "post", _raise)
+    cloudflare.purge_urls(["https://data.spicy-regs.dev/x.parquet"])  # must not raise

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -53,7 +53,9 @@ class TestUploadShrinkGuard:
         upload_to_r2(local)
         assert len(uploads) == 1
 
-    def test_parquet_upload_requires_cache_revalidation(self, tmp_path, monkeypatch):
+    def test_parquet_upload_is_cacheable(self, tmp_path, monkeypatch):
+        """Parquet is now cacheable — freshness comes from purge-on-publish, with
+        the max-age as a self-healing backstop (see sources/cloudflare.py)."""
         self._setup_env(monkeypatch)
         _, uploads = self._mock_r2_client(monkeypatch, remote_size=None)
         local = tmp_path / "rollup.parquet"
@@ -61,7 +63,7 @@ class TestUploadShrinkGuard:
 
         upload_to_r2(local)
 
-        assert uploads[0][2]["CacheControl"] == "public, no-cache, must-revalidate"
+        assert uploads[0][2]["CacheControl"] == "public, max-age=3600"
 
     def test_cache_control_env_override_wins(self, tmp_path, monkeypatch):
         self._setup_env(monkeypatch)

--- a/tests/test_r2.py
+++ b/tests/test_r2.py
@@ -50,3 +50,52 @@ def test_upload_comment_partitions_uploads_changed_and_index(
 
     assert (changed, str(changed.relative_to(tmp_path))) in uploaded
     assert (tmp_path / "comments_index.parquet", "comments_index.parquet") in uploaded
+
+
+def _upload_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Minimal R2 env so upload_file runs its body (isolate_env strips these)."""
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "k")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "s")
+    monkeypatch.setenv("R2_BUCKET_NAME", "spicy-regs")
+    monkeypatch.setenv("R2_PUBLIC_URL", "https://data.spicy-regs.dev")
+
+
+def test_upload_file_purges_exact_object_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """After a successful upload, the edge cache is purged for that one URL."""
+    _upload_env(monkeypatch)
+    (tmp_path / "agency_stats.parquet").write_bytes(b"x" * 100)
+
+    monkeypatch.setattr(r2, "get_r2_client", lambda: __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock())
+    monkeypatch.setattr(r2, "_get_remote_size", lambda *a, **k: None)
+    purged: list[list[str]] = []
+    monkeypatch.setattr(r2, "purge_urls", lambda urls: purged.append(urls))
+
+    r2.upload_file(tmp_path / "agency_stats.parquet")
+
+    assert purged == [["https://data.spicy-regs.dev/agency_stats.parquet"]]
+
+
+def test_upload_file_survives_unreachable_edge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: a dead Cloudflare edge must not fail a successful publish.
+
+    Uses the real ``purge_urls`` (creds set) with ``httpx.post`` raising, so this
+    exercises the actual composition rather than a mock — the property that
+    matters is that the ETL never dies because the cache couldn't be purged.
+    """
+    _upload_env(monkeypatch)
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "tok")
+    monkeypatch.setenv("CLOUDFLARE_ZONE_ID", "zone")
+    (tmp_path / "agency_stats.parquet").write_bytes(b"x" * 100)
+
+    monkeypatch.setattr(r2, "get_r2_client", lambda: __import__("unittest.mock", fromlist=["MagicMock"]).MagicMock())
+    monkeypatch.setattr(r2, "_get_remote_size", lambda *a, **k: None)
+
+    import httpx
+
+    def _raise(*a, **k):
+        raise httpx.ConnectError("edge down")
+
+    monkeypatch.setattr(httpx, "post", _raise)
+
+    # Must complete normally despite the purge failing underneath.
+    r2.upload_file(tmp_path / "agency_stats.parquet")


### PR DESCRIPTION
Hackathon prep, part two. The [load-test readiness report](https://claude.ai/code/artifact/20082b1f-aaff-472f-84e1-36f636568190) flagged that R2 serves fast but **nothing is cached at the edge** — 100 users repeatedly pulling the same rollups all hit origin. This lands the code half of turning that on, safely.

## The finding that shaped this

Every object returns `cf-cache-status: DYNAMIC` — including `docket_search.json.gz`, which already carries `public, max-age=3600`:

```
agency_stats.parquet    cache-control: public, no-cache          cf-cache-status: DYNAMIC
docket_search.json.gz   cache-control: public, max-age=3600      cf-cache-status: DYNAMIC  <- cacheable header, still not cached
```

So on this R2 custom domain, **`Cache-Control` alone doesn't cache** — `.parquet`/`.json.gz` aren't in Cloudflare's default-cacheable extension set. A **Cache Rule is the actual on-switch** (follow-up below). This PR makes the origin side ready and safe.

## Why caching was off — and how this makes it safe

Parquet is read via many byte-range requests; an object replaced mid-read could serve two versions into one query. The blanket `no-cache` on Parquet was how that was avoided (documented in `sources/r2.py`). **Purge-on-publish** replaces it with something both safe and fast:

- **`sources/cloudflare.py`** — `purge_urls()` invalidates the exact URLs just written. Best-effort and a **no-op without `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ZONE_ID`** (mirrors how `upload_file` no-ops without R2 creds). A purge failure logs and returns — it must never fail a publish that already wrote the data.
- **`upload_file`** now marks Parquet cacheable (`public, max-age=3600`) and purges the object's URL after a successful write. The `max-age` is a **self-healing backstop**: a missed purge ages out within the hour rather than persisting to the next daily republish. `R2_CACHE_CONTROL` still overrides for ad-hoc testing.
- **All six publishing workflows** forward the two Cloudflare secrets.

The hazard is further bounded by timing: every republish runs in the **nightly window (~06:00 and ~21:00–00:00 UTC)**, so purge-then-repopulate never overlaps daytime hackathon traffic.

## ⚠️ Requirement worth calling out

The purge targets `R2_PUBLIC_URL`, so that secret **must be the Cloudflare-fronted `data.spicy-regs.dev`** (the cached domain) — not the raw `pub-*.r2.dev` URL. Purging the r2.dev host would miss the cache. The documented value is already `data.spicy-regs.dev`; just noting the coupling.

## Verified end to end against real R2

Uploaded a throwaway object through the real `upload_file`:
```
Uploaded ... _cache_probe/upload_test.parquet
s3 HEAD CacheControl = 'public, max-age=3600'   # new policy applied
purge no-op'd cleanly with no token; upload succeeded
```
Probe objects cleaned up. Tests cover: no-op without creds, partial creds, correct API request shape, 30-URL batching, both failure modes swallowed, that `upload_file` purges the exact object URL, and that an **unreachable edge never fails a publish** (real `purge_urls`, `httpx.post` raising).

## Still required to turn caching on (the follow-up you're doing with me)

1. A **Cloudflare Cache Rule** marking the corpus paths eligible for cache with an Edge TTL — I'll create it via API once you add the scoped token, and verify `cf-cache-status` flips to `HIT` live.
2. **`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ZONE_ID`** added as GitHub Actions secrets so CI purges on publish.

This PR is **inert until step 1** — safe to merge now; the header change is harmless and the purge no-ops without the secrets.

## Checks

```
uv run ruff check .   All checks passed
uv run ty check       All checks passed
uv run pytest         536 passed, 3 deselected
uv run spicy-regs-dict check   passed
```