### PR TITLE
feat(deploy): opt-in Terraform management of the CI cache-purge token

### DIFF
--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -54,3 +54,42 @@ to re-create/overwrite live config.
 - Validated with `terraform validate` against the Cloudflare v5 provider. `plan`
   and `apply` need a token and are intentionally left to a human — this repo has
   never had credentials, by design.
+
+## Managing tokens (opt-in, off by default)
+
+`tokens.tf` can create the **CI cache-purge token** (the one the ETL's
+purge-on-publish uses, stored as the GitHub Actions secret
+`CLOUDFLARE_API_TOKEN`). It is **disabled by default** — `manage_ci_purge_token`
+defaults to `false`, so nothing is created unless you opt in. Read these
+tradeoffs first; token creation is not like the other resources:
+
+- **Bootstrap.** Terraform cannot create the token it authenticates with, so
+  this only manages *other* service tokens — never the R2/Cache-Rules token you
+  run `plan`/`apply` with (that stays hand-made).
+- **Privilege escalation.** To create tokens, the token Terraform runs with must
+  gain **Account · Account API Tokens · Edit** — the power to mint arbitrary
+  tokens. Add that permission deliberately; it's a big step up from the scoped
+  R2 + Cache Rules token.
+- **Secret in state.** The new token's value is a sensitive computed attribute
+  written to `terraform.tfstate`. With **local state that's a live credential in
+  a plaintext file on disk** — treat state as a secret, or move to an encrypted
+  remote backend before enabling this.
+- **No import / rotation = new secret.** Cloudflare reveals a token's secret only
+  at creation, so an existing token can't be imported with a usable value.
+  Enabling this creates a *fresh* token; you then migrate CI to it and revoke the
+  old one. Rotating later (`terraform taint` + `apply`) likewise mints a new secret.
+
+Given all that — especially on **local state** — this is genuinely optional and
+arguably not worth it until there's an encrypted remote backend. It's here so the
+option is codified and reviewed, not because you must use it.
+
+### If you do enable it
+
+```bash
+# 1. Grant the terraform token Account > Account API Tokens > Edit.
+# 2. Opt in and apply:
+terraform apply -var manage_ci_purge_token=true
+# 3. Read the secret and set it as the GitHub Actions secret:
+terraform output -raw ci_purge_token_value | gh secret set CLOUDFLARE_API_TOKEN
+# 4. Revoke the old hand-made purge token in the dashboard.
+```

--- a/deploy/terraform/tokens.tf
+++ b/deploy/terraform/tokens.tf
@@ -1,0 +1,51 @@
+# OPT-IN token management. Creating a Cloudflare token via Terraform has real
+# tradeoffs (see README "Managing tokens") — so this is disabled by default and
+# self-contained in one file. Set `manage_ci_purge_token = true` only after you
+# accept both of:
+#   1. the token Terraform runs with must gain Account > Account API Tokens >
+#      Edit — i.e. it can now mint arbitrary tokens (a privilege escalation), and
+#   2. the created token's secret is written to terraform state in plaintext
+#      (local state = a live credential on disk).
+#
+# Scope of what this manages: the narrow CI cache-purge token that the ETL's
+# purge-on-publish uses (GitHub Actions secret CLOUDFLARE_API_TOKEN). It is NOT
+# the terraform-admin token (Terraform can't create the token it authenticates
+# with) and NOT the R2/Cache-Rules token you run plan/apply with.
+
+variable "manage_ci_purge_token" {
+  type        = bool
+  default     = false
+  description = "Opt-in: create the CI cache-purge account token. Read the README's 'Managing tokens' tradeoffs first."
+}
+
+# Resolve the global "Cache Purge" permission group id (no magic GUID).
+data "cloudflare_account_api_token_permission_groups_list" "cache_purge" {
+  count      = var.manage_ci_purge_token ? 1 : 0
+  account_id = var.cloudflare_account_id
+  name       = "Cache Purge"
+}
+
+# Account-owned (not user-owned) so it survives any individual leaving — the
+# right shape for a durable CI credential. Narrow: Cache Purge on the one zone.
+resource "cloudflare_account_token" "ci_purge" {
+  count      = var.manage_ci_purge_token ? 1 : 0
+  account_id = var.cloudflare_account_id
+  name       = "spicy-regs-ci-cache-purge"
+
+  policies = [{
+    effect            = "allow"
+    permission_groups = [{ id = data.cloudflare_account_api_token_permission_groups_list.cache_purge[0].result[0].id }]
+    resources = jsonencode({
+      "com.cloudflare.api.account.zone.${var.cloudflare_zone_id}" = "*"
+    })
+  }]
+}
+
+# Retrieve with `terraform output -raw ci_purge_token_value`, then set it as the
+# GitHub Actions secret CLOUDFLARE_API_TOKEN. Rotating = taint + apply (a NEW
+# secret each time — Cloudflare only reveals it at creation).
+output "ci_purge_token_value" {
+  value       = var.manage_ci_purge_token ? cloudflare_account_token.ci_purge[0].value : null
+  sensitive   = true
+  description = "Secret for the CI cache-purge token. Put it in the GitHub secret CLOUDFLARE_API_TOKEN."
+}


### PR DESCRIPTION
Follow-on to #159. Codifies the **CI cache-purge token** (the ETL's purge-on-publish credential, stored as the GitHub Actions secret `CLOUDFLARE_API_TOKEN`) as a `cloudflare_account_token`, so a service token's scope is reviewable in version control instead of hand-made in the dashboard.

**Off by default — merging this creates nothing.** `manage_ci_purge_token` defaults to `false`. It's opt-in because token creation carries tradeoffs the bucket/cache-rule resources don't:

- **Bootstrap** — Terraform can't create the token it authenticates *with*, so this manages only *service* tokens, never the R2/Cache-Rules admin token you run `plan`/`apply` with.
- **Privilege escalation** — enabling it requires the terraform token to gain **Account · Account API Tokens · Edit** (the power to mint arbitrary tokens).
- **Secret in state** — the created token's `value` is written to `terraform.tfstate` in plaintext. On **local state that's a live credential on disk**.
- **No import / rotation mints a new secret** — Cloudflare reveals a token's secret only at creation, so this creates a *fresh* token (a migration for anything already using the old one).

## My honest recommendation

On **local state**, this is arguably not worth it until there's an encrypted remote backend — the README says so plainly. It's here so the option is **codified and reviewed**, not because you should flip it on today. If you do, it's account-owned (survives any individual leaving — the right shape for a durable CI credential) and narrowly scoped to Cache Purge on the one zone.

## Design notes

- Self-contained in `tokens.tf` (variable + data source + resource + output) so it's easy to review or drop.
- Permission-group ID resolved via the `cloudflare_account_api_token_permission_groups_list` data source — no magic GUID.
- `terraform validate` passes against the Cloudflare v5 provider.

## Enable flow (documented in README)

```bash
# after granting the terraform token Account > Account API Tokens > Edit
terraform apply -var manage_ci_purge_token=true
terraform output -raw ci_purge_token_value | gh secret set CLOUDFLARE_API_TOKEN
# then revoke the old hand-made purge token
```

## Why this doesn't include the terraform-admin token

That's the bootstrap paradox — you can't have Terraform create the token it runs with. That one stays hand-made (the account-owned token with R2 Storage + Cache Rules you're setting up now).