### PR TITLE
feat(deploy): store Terraform state in Cloudflare R2 (s3 backend)

### DIFF
--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -54,3 +54,40 @@ to re-create/overwrite live config.
 - Validated with `terraform validate` against the Cloudflare v5 provider. `plan`
   and `apply` need a token and are intentionally left to a human — this repo has
   never had credentials, by design.
+
+## Remote state in R2
+
+State is stored in Cloudflare R2 via the Terraform `s3` backend (`backend.tf`) —
+in a **separate, private** bucket (`spicy-regs-tfstate`), never the public data
+bucket. R2 credentials come from the environment, never the committed config.
+
+### One-time setup / migrating from local state
+
+```bash
+# 1. Create the PRIVATE state bucket (do NOT give it a public domain).
+npx wrangler r2 bucket create spicy-regs-tfstate
+
+# 2. Point the s3 backend at R2 using your R2 S3 API credentials
+#    (the same access-key/secret the ETL uses; from .env).
+export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+
+# 3. Re-init; Terraform detects the new backend and offers to copy local state up.
+cd deploy/terraform
+terraform init -migrate-state    # answer "yes" to copy terraform.tfstate to R2
+
+# 4. Confirm, then the local state files are no longer authoritative.
+terraform plan                   # "No changes" — now reading state from R2
+rm -f terraform.tfstate terraform.tfstate.backup
+```
+
+Thereafter every `plan`/`apply` reads and locks state in R2 (the `AWS_*` env vars
+must be set). `use_lockfile` puts a lock object in the bucket for the duration of
+a run, so two people can't apply at once.
+
+Notes:
+- The state bucket **must stay private**. State can contain sensitive attributes;
+  a public state bucket would leak them.
+- The `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` names are just how the s3 backend
+  reads credentials — the values are your **R2** access key + secret, not AWS.
+- `*.tfstate*` is gitignored regardless, so state never lands in git even locally.

--- a/deploy/terraform/backend.tf
+++ b/deploy/terraform/backend.tf
@@ -1,0 +1,31 @@
+# Remote Terraform state in Cloudflare R2 (S3-compatible API).
+#
+# State lives in a SEPARATE, PRIVATE bucket (spicy-regs-tfstate) — never the
+# public data bucket, and never public, because state can hold sensitive values.
+# Credentials are read from the environment (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+# set to your R2 S3 access key + secret) and are NOT committed here.
+#
+# The R2-specific bits: region "auto"; the endpoints.s3 R2 URL; use_path_style +
+# the skip_* flags + skip_s3_checksum to bypass AWS behaviors R2 doesn't implement
+# (skip_s3_checksum is the one people miss — without it writes fail on R2); and
+# use_lockfile for S3-native state locking (Terraform >= 1.10), since R2 has no
+# DynamoDB for the classic lock table.
+terraform {
+  backend "s3" {
+    bucket = "spicy-regs-tfstate"
+    key    = "deploy/terraform.tfstate"
+    region = "auto"
+
+    endpoints = {
+      s3 = "https://a18589c7a7a0fc4febecadfc9c71b105.r2.cloudflarestorage.com"
+    }
+
+    use_lockfile                = true
+    use_path_style              = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+  }
+}


### PR DESCRIPTION
Follow-on to #159. Moves Terraform state off local disk into a **private R2 bucket** via the `s3` backend — durable, shared, and locked instead of living on one machine.

## `backend.tf`

Configures the R2-specific bits that trip people up:
- `region = "auto"`, the R2 `endpoints.s3` URL, `use_path_style`, the `skip_*` flags;
- **`skip_s3_checksum = true`** — the one people miss; writes fail on R2 without it;
- **`use_lockfile = true`** — S3-native state locking (Terraform ≥ 1.10), since R2 has no DynamoDB for the classic lock table.

## Safety choices

- State lives in a **separate, private** bucket (`spicy-regs-tfstate`) — never the public data bucket, and never public, since state can hold sensitive attributes.
- R2 S3 credentials are read from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in the environment (the same access-key/secret the ETL uses), **not committed**. Those AWS var names are just how the s3 backend reads creds — the values are your R2 keys.
- `*.tfstate*` stays gitignored regardless.

## One-time setup (README documents it)

```bash
npx wrangler r2 bucket create spicy-regs-tfstate      # PRIVATE — no public domain
export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
cd deploy/terraform && terraform init -migrate-state  # copies local state up to R2
```

Validated with `terraform validate` (backend=false). The bucket-create + migrate run with credentials, so they're left to a human.