### PR TITLE
feat(deploy): Cloud Run as the primary MCP host (load-tested to c=100)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -33,3 +33,12 @@ both rely on the platform-agnostic env knobs added alongside this
 1. `terraform/` — stand up (or import) the bucket, domain, CORS, catalog, cache rule.
 2. Populate the corpus (the ETL / rollups on GitHub Actions).
 3. `cloudflare/` — build + deploy the MCP container.
+
+## Update 2026-08-18: Cloud Run is the primary MCP host
+
+After load-testing, the MCP server runs on **Google Cloud Run** (`cloudrun/`) —
+it autoscales to 100 concurrent at ~2s p50 with ~0% errors and supports a warm
+floor (`--min-instances`) for events. The `cloudflare/` container target is kept
+as a documented, working single-instance fallback (it thrashes multi-instance on
+the current beta account limit). Terraform (`terraform/`) still manages the R2
+bucket + cache rule regardless of where the MCP server runs.

--- a/deploy/cloudrun/README.md
+++ b/deploy/cloudrun/README.md
@@ -1,0 +1,55 @@
+# MCP server on Google Cloud Run (primary)
+
+Cloud Run is the primary host for the MCP server. It won on the two things every
+other option tripped on:
+
+- **Autoscaling that actually scales.** Load-tested to **c=100 at p50 ~2s, ~0%
+  errors** (Cloudflare Containers thrashed at any real concurrency on a beta
+  account limit; Vercel was memory-capped). Heavy `count(DISTINCT)` over 25.7M
+  rows returns in ~7s.
+- **A real warm floor.** `--min-instances=N` keeps N instances warm — set it 0
+  normally (scale to zero, no idle cost) and bump it the morning of an event.
+
+Same image as `deploy/cloudflare/` — the Dockerfile is platform-agnostic, so this
+just points `gcloud` at it. 16 GiB RAM (`SPICY_REGS_MEMORY_LIMIT=12GB` leaves
+headroom); `/tmp` spill is RAM-backed on Cloud Run, so RAM is the real ceiling.
+
+## Deploy
+
+```bash
+gcloud auth login
+PROJECT=spicy-regs-mcp ./deploy/cloudrun/deploy.sh
+```
+
+The script enables APIs, ensures the Artifact Registry repo, builds+pushes the
+image (amd64), and deploys. It prints the service URL.
+
+## Two one-time hurdles we hit (documented so you don't rediscover them)
+
+1. **Billing quota.** Linking a *new* project to the Primary billing account
+   failed with `Cloud billing quota exceeded` (cap on projects per billing
+   account). Fix: bill `spicy-regs-mcp` to the **secondary** billing account, or
+   free a slot / use an existing billing-enabled project.
+2. **Org policy blocks public access.** The kvec.ai org enforces
+   `iam.allowedPolicyMemberDomains` (Domain Restricted Sharing), so `allUsers`
+   can't be granted `run.invoker` and the service 403s. Fix (needs org-policy
+   admin, via Console): IAM & Admin → Organization Policies → *Domain restricted
+   sharing* → Manage policy → Override parent's policy → **Allow All** → Save.
+   Scoped to this project only. Then the deploy's `allUsers` binding succeeds
+   (allow ~1 min for propagation).
+
+## Event day
+
+```bash
+gcloud run services update spicy-regs-mcp --region us-east1 --min-instances 5   # warm floor
+# ... after the event ...
+gcloud run services update spicy-regs-mcp --region us-east1 --min-instances 0   # back to scale-to-zero
+```
+
+## Still to do before it's the canonical endpoint
+
+- **Custom domain:** map `mcp.spicy-regs.dev` to the service (`gcloud run domain-mappings create`) and repoint DNS from Vercel.
+- **Iceberg catalog:** add `R2_CATALOG_TOKEN` (a secret — use Secret Manager +
+  `--set-secrets`) and the `R2_CATALOG_*` vars so `comments` reads the deduped
+  system-of-record instead of the public parquet mirror.
+- Retire the Vercel deploy + `mcp-server/api/index.py` copy once cut over.

--- a/deploy/cloudrun/deploy.sh
+++ b/deploy/cloudrun/deploy.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Deploy the Spicy Regs MCP server to Google Cloud Run.
+#
+# Cloud Run is the primary host: it autoscales cleanly to 100+ concurrent (load-
+# tested: c=100 at p50 ~2s, ~0% errors), supports a warm floor via --min-instances
+# for event days, and gives 16 GiB RAM for heavy analytics. It reuses the SAME
+# image as the Cloudflare target (deploy/cloudflare/Dockerfile) — the Dockerfile
+# is platform-agnostic (canonical spicy_regs.mcp_server under uvicorn on $PORT).
+#
+# Prereqs (one-time, interactive / console):
+#   - gcloud auth login
+#   - a billing-enabled project (this repo used `spicy-regs-mcp`, billed to the
+#     secondary account after the Primary hit its project-link quota)
+#   - the org policy `iam.allowedPolicyMemberDomains` relaxed for the project
+#     (Allow All) so `allUsers` can be granted run.invoker — the kvec.ai org
+#     restricts public access by default. See README.
+#   - local Docker (for the amd64 build/push)
+#
+# Usage:
+#   PROJECT=spicy-regs-mcp ./deploy/cloudrun/deploy.sh
+set -euo pipefail
+
+: "${PROJECT:?set PROJECT to your GCP project id}"
+REGION="${REGION:-us-east1}"
+SERVICE="${SERVICE:-spicy-regs-mcp}"
+AR_REPO="${AR_REPO:-spicy-regs}"
+MEMORY="${MEMORY:-16Gi}"
+CPU="${CPU:-4}"
+CONCURRENCY="${CONCURRENCY:-8}"
+TIMEOUT="${TIMEOUT:-600}"
+MIN_INSTANCES="${MIN_INSTANCES:-0}"   # bump to N the morning of an event for a warm floor
+MAX_INSTANCES="${MAX_INSTANCES:-10}"
+MEM_LIMIT="${SPICY_REGS_MEMORY_LIMIT:-12GB}"   # under MEMORY so heavy queries spill to /tmp, not OOM-kill
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/${AR_REPO}/mcp:$(git -C "$ROOT" rev-parse --short HEAD)"
+
+echo "1/5 Enable APIs"
+gcloud services enable run.googleapis.com cloudbuild.googleapis.com artifactregistry.googleapis.com --project "$PROJECT"
+
+echo "2/5 Ensure Artifact Registry repo"
+gcloud artifacts repositories describe "$AR_REPO" --location "$REGION" --project "$PROJECT" >/dev/null 2>&1 || \
+  gcloud artifacts repositories create "$AR_REPO" --repository-format=docker --location "$REGION" --project "$PROJECT"
+
+echo "3/5 Build + push (amd64 — Cloud Run requires it; reuses the shared Dockerfile)"
+gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+docker build --platform linux/amd64 -f "$ROOT/deploy/cloudflare/Dockerfile" -t "$IMAGE" "$ROOT"
+docker push "$IMAGE"
+
+echo "4/5 Deploy"
+gcloud run deploy "$SERVICE" \
+  --image "$IMAGE" --project "$PROJECT" --region "$REGION" \
+  --allow-unauthenticated --port 8080 \
+  --memory "$MEMORY" --cpu "$CPU" \
+  --concurrency "$CONCURRENCY" --timeout "$TIMEOUT" \
+  --min-instances "$MIN_INSTANCES" --max-instances "$MAX_INSTANCES" \
+  --set-env-vars "SPICY_REGS_MEMORY_LIMIT=${MEM_LIMIT},SPICY_REGS_TEMP_DIR=/tmp,SPICY_REGS_HOME_DIR=/tmp,SPICY_REGS_STATEMENT_TIMEOUT=${TIMEOUT}s,SPICY_REGS_R2_URL=https://data.spicy-regs.dev"
+
+# --allow-unauthenticated needs the allUsers binding, which the org policy blocks
+# until relaxed. If the deploy warns the IAM binding failed, relax the policy
+# (README) then: gcloud run services add-iam-policy-binding "$SERVICE" \
+#   --region "$REGION" --member=allUsers --role=roles/run.invoker
+
+echo "5/5 URL:"
+gcloud run services describe "$SERVICE" --project "$PROJECT" --region "$REGION" --format='value(status.url)'


### PR DESCRIPTION
Captures the working Cloud Run deploy as reproducible IaC. **The MCP server is now live on Cloud Run, public, and load-tested to the hackathon target.**

## Why Cloud Run won

We hit a real wall on every other option — Vercel (memory), Cloudflare Containers (beta account instance limit → thrashing), Cloud Run attempt 1 (billing quota), attempt 2 (org policy). Cloud Run cleared them and delivered:

| Concurrency | p50 | p95 | Errors |
|---|---|---|---|
| 25 | 1.3s | 6.5s | 1.3% |
| 50 | 1.4s | 15s | **0%** |
| **100** | **2.0s** | **6.3s** | **0.3%** |

Plus `count(DISTINCT comment_id)` over 25.7M rows in **~7s**, and a real **`--min-instances` warm floor** for event days (which Cloudflare's beta lacks).

## What's in here

- `deploy/cloudrun/deploy.sh` — reproduces the deploy: APIs, Artifact Registry, build+push the **shared** `deploy/cloudflare/Dockerfile` (amd64), `gcloud run deploy` with 16Gi / 4 vCPU / concurrency 8 / min 0 / max 10 + the DuckDB/R2 env.
- `deploy/cloudrun/README.md` — runbook + the **two one-time hurdles documented** so nobody rediscovers them:
  1. **Billing quota** — new-project link to Primary billing failed; bill to the secondary account.
  2. **Org policy** — kvec.ai blocks `allUsers`; relax *Domain Restricted Sharing* for the project (Console), then the `allUsers` binding takes.
- `deploy/README.md` — updated: Cloud Run primary, Cloudflare kept as documented single-instance fallback, Terraform still owns the R2 bucket + cache rule.

## Live now

`https://spicy-regs-mcp-440672474468.us-east1.run.app/mcp` — public, `min-instances=0` (scale to zero).

## Follow-ups (not blocking)

- Map `mcp.spicy-regs.dev` → the service and repoint DNS off Vercel.
- Add the Iceberg catalog (`R2_CATALOG_TOKEN` via Secret Manager) for `comments` dedup parity.
- Retire the Vercel deploy + `mcp-server/api/index.py` copy after cutover.