### PR TITLE
fix(r2): parquet must be no-cache — edge caching corrupts DuckDB rang…

### DIFF
--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -174,16 +174,20 @@ def upload_file(local_path: Path, remote_key: str | None = None) -> None:
     remote_size = _get_remote_size(client, bucket, remote_key)
     _assert_upload_safe(local_size_bytes, remote_size, remote_key)
 
-    # Cache-Control policy. Parquet readers issue many byte-range requests, and
-    # serving stale ranges across an object replacement can mix two versions and
-    # corrupt a read — so historically Parquet was marked `no-cache`. That is now
-    # handled by purge-on-publish below (we invalidate the exact URL we just
-    # wrote), which lets Parquet be cached like everything else. The `max-age` is
-    # a self-healing backstop: if a purge is ever missed, stale data still ages
-    # out within the hour rather than persisting to the next daily republish.
-    # `R2_CACHE_CONTROL` still overrides everything for ad-hoc testing.
+    # Cache-Control policy. Parquet MUST NOT be edge-cached: DuckDB (both the MCP
+    # server and the browser DuckDB-WASM UI) reads each file via many byte-range
+    # requests, and an edge cache serving inconsistent bytes across those ranges
+    # under concurrent load corrupts the read — observed as `utf-8 codec can't
+    # decode` / ETag-mismatch failures at ~c=10+. (This is why parquet was
+    # `no-cache` originally; a caching experiment reintroduced the corruption and
+    # was reverted.) Non-parquet artifacts (e.g. the UI MiniSearch json.gz, which
+    # is not read by DuckDB) may still be edge-cached. `R2_CACHE_CONTROL` overrides.
     configured_cache_control = getenv("R2_CACHE_CONTROL")
-    cache_control = configured_cache_control or "public, max-age=3600"
+    cache_control = configured_cache_control or (
+        "public, no-cache, must-revalidate"
+        if remote_key.endswith(".parquet")
+        else "public, max-age=3600, stale-while-revalidate=86400"
+    )
     client.upload_file(
         str(local_path),
         bucket,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -53,9 +53,9 @@ class TestUploadShrinkGuard:
         upload_to_r2(local)
         assert len(uploads) == 1
 
-    def test_parquet_upload_is_cacheable(self, tmp_path, monkeypatch):
-        """Parquet is now cacheable — freshness comes from purge-on-publish, with
-        the max-age as a self-healing backstop (see sources/cloudflare.py)."""
+    def test_parquet_upload_is_not_cached(self, tmp_path, monkeypatch):
+        """Parquet must be no-cache: edge-caching it corrupts DuckDB's concurrent
+        byte-range reads (utf-8/ETag failures at scale). Non-parquet may cache."""
         self._setup_env(monkeypatch)
         _, uploads = self._mock_r2_client(monkeypatch, remote_size=None)
         local = tmp_path / "rollup.parquet"
@@ -63,7 +63,7 @@ class TestUploadShrinkGuard:
 
         upload_to_r2(local)
 
-        assert uploads[0][2]["CacheControl"] == "public, max-age=3600"
+        assert uploads[0][2]["CacheControl"] == "public, no-cache, must-revalidate"
 
     def test_cache_control_env_override_wins(self, tmp_path, monkeypatch):
         self._setup_env(monkeypatch)


### PR DESCRIPTION
…e reads

#158 changed parquet Cache-Control from no-cache to max-age=3600 and added an edge cache rule, on the theory that purge-on-publish made caching safe. It doesn't. DuckDB — both the MCP server and the browser DuckDB-WASM UI — reads each parquet file via many byte-range requests, and the edge cache serving inconsistent bytes across those ranges under concurrent load corrupts the read. Observed as `'utf-8' codec can't decode byte 0x80` and ETag-mismatch tool errors starting at ~c=10, on an otherwise-identical Cloud Run revision that ran c=100 at 0% errors once the cache rule was disabled. This is exactly the hazard the original no-cache comment described.

Revert parquet to `public, no-cache, must-revalidate` (non-parquet artifacts like the UI's MiniSearch json.gz, which DuckDB never reads, keep the cacheable policy). The Cloudflare cache ruleset has been disabled out-of-band; a follow-up can reconcile the Terraform-managed rule (deploy/terraform) and, if desired, re-add a json.gz-only cache rule. purge-on-publish (sources/cloudflare.py) stays — harmless for no-cache parquet, still useful for the cacheable non-parquet artifacts.

Verified: with caching off, mcp.spicy-regs.dev on Cloud Run serves c=100 at p50 ~1.4s, 0% errors (300/300).

## Summary

<!-- What does this PR do? Why? Link any related issues with "Closes #123". -->

## Test plan

<!-- How did you verify this works? Paste relevant commands and output. -->

- [ ] `uv run pytest`
- [ ] `uv run ruff check .`
- [ ] Manually exercised the change (describe how)

## Checklist

- [ ] My change is scoped to one concern
- [ ] I added or updated tests for new behavior
- [ ] I updated docs (README / CONTRIBUTING / module READMEs) if relevant
- [ ] CI is green
