### PR TITLE
fix(terraform): disable the edge cache rule (parquet caching corrupts DuckDB)

### DIFF
--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -35,8 +35,10 @@ Cloudflare quirk.
 
 - `cloudflare_r2_bucket.corpus` — the `spicy-regs` bucket.
 - `cloudflare_r2_data_catalog.corpus` — the Iceberg catalog (comments system of record).
-- `cloudflare_ruleset.r2_cache` — the edge cache rule (respect-origin; the ETL's
-  purge-on-publish handles invalidation). Keep in sync with `sources/r2.py` headers.
+- `cloudflare_ruleset.r2_cache` — the edge cache rule, **kept `enabled = false`**.
+  Edge-caching parquet corrupts DuckDB's concurrent byte-range reads (see
+  `sources/r2.py`, which serves parquet `no-cache`); the resource stays so
+  Terraform owns the disabled state and an `apply` can't re-enable the corruption.
 
 ## Not importable (provider limitation)
 

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -36,10 +36,12 @@ resource "cloudflare_r2_data_catalog" "corpus" {
   bucket_name = cloudflare_r2_bucket.corpus.name
 }
 
-# Edge cache rule for the corpus. Codifies what is currently a hand-created rule:
-# scoped to the data host only (so docs./mcp./app. subdomains are untouched),
-# eligible for cache, respecting the origin Cache-Control (purge-on-publish in the
-# ETL handles invalidation). Keep this in sync with sources/r2.py's headers.
+# Edge cache rule for the corpus — DISABLED. Edge-caching parquet corrupts
+# DuckDB's concurrent byte-range reads (utf-8/ETag failures at scale; see
+# sources/r2.py, which serves parquet no-cache). Kept as a resource (rather than
+# deleted) so Terraform owns the disabled state and a future apply can't silently
+# re-enable it. To cache only the UI's non-parquet MiniSearch json.gz, narrow the
+# expression to that suffix and flip enabled back on — never match .parquet.
 resource "cloudflare_ruleset" "r2_cache" {
   zone_id = var.cloudflare_zone_id
   name    = "default"
@@ -51,7 +53,7 @@ resource "cloudflare_ruleset" "r2_cache" {
     description = "Cache public data corpus at edge; respect origin Cache-Control (purge-on-publish invalidates)"
     expression  = "(http.host eq \"${var.custom_domain}\")"
     action      = "set_cache_settings"
-    enabled     = true
+    enabled     = false
     action_parameters = {
       cache = true
       edge_ttl = {


### PR DESCRIPTION
Reconciles Terraform with #165: edge-caching parquet corrupts DuckDB concurrent range reads. The rule was disabled out-of-band but main.tf still said enabled=true, so a `terraform apply` would re-enable the corruption. Sets `cloudflare_ruleset.r2_cache` to `enabled = false` (kept as a resource so TF owns the disabled state; documents the narrow-to-json.gz path). terraform validate passes.