### PR TITLE
docs: changelog for the 2026.08.26 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,98 @@ All notable changes to the Spicy Regs data pipeline are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Entries link to the pull request that introduced the change.
 
+## [2026.08.26]
+
+The headline of this cycle: the MCP server moved off Vercel onto **Cloud Run**,
+where it is load-tested to **100 concurrent users at ~0% errors**, and the
+deployment itself became infrastructure-as-code under a new `deploy/` folder.
+Along the way the **FCC** joined the corpus as its own two tables, and a pass
+over "how do I actually use this data" turned up — and fixed — several
+documented access paths that did not work.
+
+### Added
+
+- **FCC ECFS** ingestion — `fcc_proceedings` and `fcc_filings`, the FCC's docket
+  and comment equivalents for the rulemaking that never reaches
+  regulations.gov ([#149]).
+- **Cloud Run** as the primary MCP host, captured as a reproducible deploy
+  script plus a runbook for the billing-quota and org-policy hurdles
+  ([#164]).
+- **`deploy/` folder with Terraform IaC** for the R2 bucket, its
+  `data.spicy-regs.dev` domain, CORS, the Iceberg catalog, and the edge cache
+  rule — import-first, so it adopts existing production rather than recreating
+  it ([#159]); Terraform state moved into a private R2 bucket over the `s3`
+  backend with native locking ([#161]).
+- **Cloudflare Containers** deploy, authored in [#159] and made actually
+  deployable in [#162] (build context, generated Worker bindings); kept as the
+  documented single-instance fallback.
+- **Cloudflare purge-on-publish** (`sources/cloudflare.py`), a no-op without
+  credentials and never able to fail a publish that already wrote its data
+  ([#158]).
+- Docs: `mcp-server/INTERNALS.md` as the committed home for server rationale
+  ([#153]); a README reworked into a project front page ([#150]); a
+  `getting_started.ipynb` covering the rollups, the non-core tables, and
+  cross-source joins ([#156]).
+
+### Changed
+
+- **Performance:** the MCP server caches its DuckDB connection across tool
+  calls instead of reinstalling extensions, reattaching the catalog, and
+  recreating 20 views per request — **34.5s → 0.21s** warm ([#157]).
+- **`.env` loads in CLI entry points, not at import time**, so importing the
+  package no longer mutates `os.environ`; one AST test locks it in ([#155]).
+- The public corpus hostname is `data.spicy-regs.dev` ([#150]).
+- **MCP:** all code comments moved out of the server modules into
+  `INTERNALS.md`, keeping the `@mcp.tool()` docstrings that FastMCP reflects
+  over to build client-facing tool descriptions ([#153]).
+- **Vercel:** pinned `mcp<2` and raised `maxDuration` to the real 800s Pro
+  ceiling ([#151], [#152]) — both superseded when that deploy was retired
+  ([#166]).
+
+### Removed
+
+- The **Vercel MCP deployment** and its dependency-light parallel copy of the
+  server, now that `mcp.spicy-regs.dev` points at Cloud Run running the
+  canonical `spicy_regs.mcp_server` ([#166]).
+
+### Fixed
+
+- **Parquet must be `no-cache`.** Edge-caching it corrupts DuckDB's concurrent
+  byte-range reads — observed as decode and ETag-mismatch errors from ~c=10 on
+  a revision that otherwise ran c=100 cleanly. Reverted the [#158] cache policy
+  for Parquet ([#165]) and set the Terraform-managed cache rule to
+  `enabled = false` so an apply cannot re-enable it ([#167]). Non-Parquet
+  artifacts, which DuckDB never reads, stay cacheable.
+- **The `spicy-regs` CLI was broken end to end** — Cloudflare 403s the default
+  urllib User-Agent, so `download`, `stats`, `sample`, `search`, and `agencies`
+  all failed; downloads now stream to a `.partial` sibling so a truncated write
+  can't masquerade as a complete one. Also repointed the published query docs
+  off a comments tree that no longer gets written, and added
+  `--discover-from-derived` so the comment-text backfill can see the 99.8% of
+  rows the `attachments_json` gate hid from it ([#156]).
+- **Unit tests were downloading the production corpus** — a developer's `.env`
+  reached "hermetic" tests through an import-time `load_dotenv()`, making them
+  838s locally and green-by-accident in CI ([#154]).
+
+[2026.08.26]: https://github.com/civictechdc/spicy-regs/releases/tag/2026.08.26
+[#149]: https://github.com/civictechdc/spicy-regs/pull/149
+[#150]: https://github.com/civictechdc/spicy-regs/pull/150
+[#151]: https://github.com/civictechdc/spicy-regs/pull/151
+[#152]: https://github.com/civictechdc/spicy-regs/pull/152
+[#153]: https://github.com/civictechdc/spicy-regs/pull/153
+[#154]: https://github.com/civictechdc/spicy-regs/pull/154
+[#155]: https://github.com/civictechdc/spicy-regs/pull/155
+[#156]: https://github.com/civictechdc/spicy-regs/pull/156
+[#157]: https://github.com/civictechdc/spicy-regs/pull/157
+[#158]: https://github.com/civictechdc/spicy-regs/pull/158
+[#159]: https://github.com/civictechdc/spicy-regs/pull/159
+[#161]: https://github.com/civictechdc/spicy-regs/pull/161
+[#162]: https://github.com/civictechdc/spicy-regs/pull/162
+[#164]: https://github.com/civictechdc/spicy-regs/pull/164
+[#165]: https://github.com/civictechdc/spicy-regs/pull/165
+[#166]: https://github.com/civictechdc/spicy-regs/pull/166
+[#167]: https://github.com/civictechdc/spicy-regs/pull/167
+
 ## [2026.07.22]
 
 The headline of this cycle: the pipeline went from mirroring regulations.gov and
@@ -51,7 +143,7 @@ this cycle hardened the rollups and made the published corpus edge-cacheable.
 - Matrix sweep + full agency coverage to stop batch starvation ([#121]).
 - Stop marking failed downloads as processed in the ETL manifest ([#120]).
 
-[2026.07.22]: https://github.com/civictechdc/spicy-regs/releases/tag/v2026.07.22
+[2026.07.22]: https://github.com/civictechdc/spicy-regs/releases/tag/2026.07.21
 [#120]: https://github.com/civictechdc/spicy-regs/pull/120
 [#121]: https://github.com/civictechdc/spicy-regs/pull/121
 [#123]: https://github.com/civictechdc/spicy-regs/pull/123

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,69 @@ per-release copy lives in [`CHANGELOG.md`](https://github.com/civictechdc/spicy-
 at the repository root and on the
 [GitHub Releases](https://github.com/civictechdc/spicy-regs/releases) page.
 
+## 2026-08-26
+
+This cycle was mostly about how the data is served rather than what's in it: the
+MCP server moved off Vercel onto **Cloud Run**, load-tested to **100 concurrent
+users at ~0% errors**, with the deployment codified as infrastructure-as-code.
+The corpus itself gained the **FCC**, and several documented access paths that
+didn't actually work were fixed.
+
+!!! note "New tables"
+    Both tables are published as `https://data.spicy-regs.dev/<name>.parquet`
+    and documented under **Tables** in the nav.
+
+### New data sources
+
+| Table | Source | PR |
+| --- | --- | --- |
+| `fcc_proceedings` | FCC ECFS — the FCC's docket equivalent, keyed by `name` (e.g. `17-108`) | [#149](https://github.com/civictechdc/spicy-regs/pull/149) |
+| `fcc_filings` | FCC ECFS — the comment equivalent, keyed by `id_submission` | [#149](https://github.com/civictechdc/spicy-regs/pull/149) |
+
+The FCC does not participate in regulations.gov, so its rulemaking record lives
+only here. `fcc_filings.proceeding_names_json` joins to `fcc_proceedings.name`,
+and `text_data` carries the full comment text for express comments.
+
+### Serving and performance
+
+- **The MCP server now runs on Cloud Run** at `mcp.spicy-regs.dev` — load-tested
+  to c=100 (p50 2.0s, 0.3% errors), with `count(DISTINCT comment_id)` over 25.7M
+  rows in ~7s ([#164](https://github.com/civictechdc/spicy-regs/pull/164)). The Vercel deploy is retired ([#166](https://github.com/civictechdc/spicy-regs/pull/166)).
+- **DuckDB connections are cached across tool calls** instead of rebuilt per
+  request: **34.5s → 0.21s** warm ([#157](https://github.com/civictechdc/spicy-regs/pull/157)).
+- **Parquet is served `no-cache`, deliberately.** Edge-caching it corrupts
+  DuckDB's concurrent byte-range reads — including in the browser DuckDB-WASM UI
+  ([#165](https://github.com/civictechdc/spicy-regs/pull/165), [#167](https://github.com/civictechdc/spicy-regs/pull/167)). Non-Parquet artifacts like the search
+  `json.gz` stay cacheable, and purge-on-publish ([#158](https://github.com/civictechdc/spicy-regs/pull/158)) keeps them
+  fresh.
+
+### Fixed
+
+- **The `spicy-regs` CLI now works.** Cloudflare 403s the default urllib
+  User-Agent, so `download`, `stats`, `sample`, `search`, and `agencies` all
+  failed ([#156](https://github.com/civictechdc/spicy-regs/pull/156)).
+- **Query docs corrected.** The recommended comments glob pointed at a tree that
+  is no longer written, and R2's public HTTPS endpoint can't expand a glob at
+  all. Use `comments/agency/agency_code={X}/part-0.parquet`, and
+  `comments_index.parquet` for counts ([#156](https://github.com/civictechdc/spicy-regs/pull/156)).
+- **Notebooks refreshed** against live production, plus a new
+  `getting_started.ipynb` covering the rollups, the non-core tables, and
+  cross-source joins ([#156](https://github.com/civictechdc/spicy-regs/pull/156)).
+- Comment-text backfill gained `--discover-from-derived`, so it can see rows
+  ingested before `attachments_json` was recorded ([#156](https://github.com/civictechdc/spicy-regs/pull/156)).
+- Unit tests no longer download the production corpus ([#154](https://github.com/civictechdc/spicy-regs/pull/154),
+  [#155](https://github.com/civictechdc/spicy-regs/pull/155)).
+
+### Infrastructure
+
+- A new `deploy/` folder with **Terraform** owning the R2 bucket, its
+  `data.spicy-regs.dev` domain, CORS, the Iceberg catalog, and the (now
+  disabled) cache rule ([#159](https://github.com/civictechdc/spicy-regs/pull/159)), with state in a private R2 bucket
+  ([#161](https://github.com/civictechdc/spicy-regs/pull/161)). Cloudflare Containers is kept as a documented fallback
+  ([#162](https://github.com/civictechdc/spicy-regs/pull/162)).
+- Docs: the README is now a project front page ([#150](https://github.com/civictechdc/spicy-regs/pull/150)) and MCP server
+  rationale lives in `mcp-server/INTERNALS.md` ([#153](https://github.com/civictechdc/spicy-regs/pull/153)).
+
 ## 2026-07-22
 
 This cycle expanded the dataset from a regulations.gov + Federal Register mirror


### PR DESCRIPTION
## Why

There's been a release's worth of work since `2026.07.21` — 17 merged PRs (#149–#167; #160 and #163 were closed unmerged) — with no changelog entry. This adds it to both the root `CHANGELOG.md` and the docs-site copy, then the `2026.08.26` tag gets cut on the squash of this PR (same as #148 → `2026.07.21`).

## The cycle, in one line

The MCP server moved off Vercel onto **Cloud Run**, load-tested to **c=100 at ~0% errors**, with the deployment codified as Terraform IaC under a new `deploy/` folder. The corpus gained the **FCC** (`fcc_proceedings` + `fcc_filings`), and a pass over the documented data-access paths fixed several that didn't work.

## Two judgment calls

**The #158 → #165 reversal is reported, not netted out.** Edge caching was turned on and reverted inside the same cycle, so `Fixed` states plainly that parquet must stay `no-cache` because edge caching corrupts DuckDB's concurrent byte-range reads. That's the single most operationally important fact in the release for anyone pointing DuckDB — or the DuckDB-WASM UI — at the bucket, and it would vanish if the two PRs were cancelled against each other.

Same reasoning, smaller scale, for the Vercel `mcp<2` pin and the `maxDuration` raise (#151, #152): both listed, both marked superseded by #166.

**Fixed a broken link in the previous entry.** The `[2026.07.22]` heading pointed at `releases/tag/v2026.07.22`; the real tag is `2026.07.21` with no `v` prefix, so it 404'd. Repointed at the real tag and used the bare form for the new one. The heading text still reads `2026.07.22` (the publish date) — worth deciding whether headings should track tags or publish dates, but not something this PR changes.

## Test plan

- [x] Both files' PR links generated from the merged-PR list, so no hand-typed numbers
- [x] `docs/tables/fcc_proceedings.md` and `fcc_filings.md` exist and are in the mkdocs nav, so the new entry's table references hold under `mkdocs build --strict`
- [x] Docs-only change — no code, tests, or published data touched

## Checklist

- [x] My change is scoped to one concern
- [ ] I added or updated tests for new behavior — n/a, docs only
- [x] I updated docs (this is the docs change)
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)