### PR TITLE
fix(r2): stop swallowing publish failures, and watch the base tables

### DIFF
--- a/.github/workflows/check-rollup-freshness.yml
+++ b/.github/workflows/check-rollup-freshness.yml
@@ -1,4 +1,10 @@
-name: Check external rollup freshness
+name: Check published table freshness
+
+# Watches the base tables the daily ETL publishes (dockets, documents) alongside
+# the external-source rollups. The base tables were added after a swallowed R2
+# upload failure froze `dockets` at 2026-07-02 for ~8 weeks with the ETL still
+# reporting success — comments had check-comments-freshness.yml, the rollups had
+# this check, and the two largest base tables had nothing watching them at all.
 
 on:
   schedule:
@@ -27,7 +33,7 @@ jobs:
           key: rollup-freshness-${{ github.run_id }}
           restore-keys: rollup-freshness-
 
-      - name: Check published rollups
+      - name: Check published tables
         run: uv run python scripts/check_rollup_freshness.py
 
       - name: Save row-count history

--- a/scripts/check_rollup_freshness.py
+++ b/scripts/check_rollup_freshness.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""Check public external-source rollups for stale watermarks and stalled growth.
+"""Check published tables for stale watermarks and stalled growth.
 
-Date-backed sources are checked against source-appropriate age budgets. Sources
-without a meaningful update date are either tracked by row-count change
-(``usaspending_recipients``) or explicitly skipped with a reason. The state file
-lets the daily workflow remember when a row count last changed.
+Covers both the base tables the daily ETL publishes (``dockets``, ``documents``)
+and the external-source rollups. Date-backed sources are checked against
+source-appropriate age budgets. Sources without a meaningful update date are
+either tracked by row-count change (``usaspending_recipients``) or explicitly
+skipped with a reason. The state file lets the daily workflow remember when a row
+count last changed.
 """
 
 from __future__ import annotations
@@ -33,7 +35,25 @@ class DateCheck:
     label: str | None = None
 
 
-DATE_CHECKS = (
+# Base tables published by the daily ETL (etl-new-pipeline.yml). They are not
+# external rollups, but they share this machinery — a max watermark over the
+# published Parquet on R2 — and nothing else was watching them. A silently
+# swallowed upload failure froze `dockets` at 2026-07-02 for ~8 weeks without a
+# single alert, while `comments` (covered by check-comments-freshness.yml) and
+# every external rollup stayed green.
+#
+# `modify_date` is the watermark for both, NOT `posted_date`: documents carry
+# future effective dates (months ahead of today), so max(posted_date) reads as
+# fresh forever and can never detect a stall.
+#
+# 4-day budget: enough slack to ride out a three-day federal holiday weekend
+# without paging, tight enough that a real break surfaces the same week.
+BASE_TABLE_CHECKS = (
+    DateCheck("dockets", "modify_date", 4),
+    DateCheck("documents", "modify_date", 4),
+)
+
+EXTERNAL_DATE_CHECKS = (
     DateCheck("federal_register", "publication_date", 3),
     DateCheck("lobbying_filings", "dt_posted", 3),
     # Both metrics matter: update_date alone can stay green while recent
@@ -46,6 +66,8 @@ DATE_CHECKS = (
     DateCheck("gao_reports", "published_date", 14),
     DateCheck("crs_reports", "published_date", 14),
 )
+
+DATE_CHECKS = BASE_TABLE_CHECKS + EXTERNAL_DATE_CHECKS
 
 ROW_CHANGE_BUDGETS = {"usaspending_recipients": 14}
 SKIPPED = {
@@ -168,7 +190,7 @@ def main() -> int:
         for failure in failures:
             print(f"- {failure}")
         return 1
-    print("\nAll monitored external-source rollups are within budget.")
+    print("\nAll monitored base tables and external-source rollups are within budget.")
     return 0
 
 

--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -14,7 +14,7 @@ where a transient download error produced an empty local file that overwrote the
 3.3 GB historical ``comments.parquet`` on R2.
 """
 
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from os import getenv
 from pathlib import Path
 
@@ -230,6 +230,20 @@ def upload_dataset(output_dir: Path, data_types: list[str]) -> None:
 
     Rollups (feed_summary, agency_stats, ...) are no longer published here — each
     is built and uploaded by its own decoupled ``run-rollup-*`` pipeline.
+
+    Every upload is awaited and its outcome inspected. This used to be a bare
+    ``executor.map(upload_file, files_to_upload)`` whose return value was
+    discarded — and ``map`` yields a *lazy* iterator, so an exception raised in a
+    worker is only re-raised when the results are consumed. Nothing consumed
+    them, so every publish failure was swallowed and the ETL still exited 0.
+    That masked an 8-week ``dockets`` outage: the shrink guard was correctly
+    refusing a truncated ``dockets.parquet`` on every single run (the Iceberg
+    dockets table was never seeded, so the exported snapshot held ~5k rows
+    instead of ~276k) while the workflow stayed green and the published table sat
+    frozen at 2026-07-02.
+
+    Failures are collected rather than raised on the first one, so a broken table
+    can never hide a second broken table behind it.
     """
     files_to_upload = []
     for data_type in data_types:
@@ -241,8 +255,26 @@ def upload_dataset(output_dir: Path, data_types: list[str]) -> None:
     if manifest_file.exists():
         files_to_upload.append(manifest_file)
 
+    # ThreadPoolExecutor rejects max_workers=0, so an empty publish set would
+    # otherwise raise ValueError rather than being the no-op it should be.
+    if not files_to_upload:
+        logger.warning("upload_dataset: no files to publish in {}", output_dir)
+        return
+
+    failures: list[tuple[Path, BaseException]] = []
     with ThreadPoolExecutor(max_workers=len(files_to_upload)) as executor:
-        executor.map(upload_file, files_to_upload)
+        futures = {executor.submit(upload_file, pf): pf for pf in files_to_upload}
+        for future in as_completed(futures):
+            if (error := future.exception()) is not None:
+                failures.append((futures[future], error))
+
+    if failures:
+        for path, error in failures:
+            logger.error("Failed to publish {}: {}", path.name, error)
+        names = ", ".join(sorted(path.name for path, _ in failures))
+        raise RuntimeError(
+            f"Failed to publish {len(failures)} of {len(files_to_upload)} file(s) to R2: {names}"
+        ) from failures[0][1]
 
 
 def upload_comment_partitions(output_dir: Path, changed_files: list[Path]) -> None:

--- a/tests/test_r2.py
+++ b/tests/test_r2.py
@@ -34,9 +34,7 @@ def test_upload_dataset_uploads_existing_files(tmp_path: Path, monkeypatch: pyte
     }
 
 
-def test_upload_comment_partitions_uploads_changed_and_index(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_upload_comment_partitions_uploads_changed_and_index(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """upload_comment_partitions publishes each changed partition and the index."""
     changed = tmp_path / "comments" / "agency_code=EPA" / "part-0.parquet"
     changed.parent.mkdir(parents=True)
@@ -99,3 +97,49 @@ def test_upload_file_survives_unreachable_edge(tmp_path: Path, monkeypatch: pyte
 
     # Must complete normally despite the purge failing underneath.
     r2.upload_file(tmp_path / "agency_stats.parquet")
+
+
+def test_upload_dataset_raises_when_an_upload_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failing publish must surface, not be swallowed by the executor.
+
+    Regression: `executor.map`'s lazy iterator was discarded, so the shrink
+    guard's refusal to overwrite dockets.parquet never propagated and the ETL
+    reported success while the table sat frozen for 8 weeks.
+    """
+    (tmp_path / "dockets.parquet").write_bytes(b"d")
+    (tmp_path / "documents.parquet").write_bytes(b"x")
+
+    def fake_upload(path: Path, remote_key: str | None = None) -> None:
+        if path.name == "dockets.parquet":
+            raise RuntimeError("Refusing to upload dockets.parquet: would shrink remote")
+
+    monkeypatch.setattr(r2, "upload_file", fake_upload)
+
+    with pytest.raises(RuntimeError, match="dockets.parquet"):
+        r2.upload_dataset(tmp_path, ["dockets", "documents"])
+
+
+def test_upload_dataset_reports_every_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """One broken table must not hide another behind it."""
+    (tmp_path / "dockets.parquet").write_bytes(b"d")
+    (tmp_path / "documents.parquet").write_bytes(b"x")
+
+    def fake_upload(path: Path, remote_key: str | None = None) -> None:
+        raise RuntimeError(f"boom: {path.name}")
+
+    monkeypatch.setattr(r2, "upload_file", fake_upload)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        r2.upload_dataset(tmp_path, ["dockets", "documents"])
+
+    message = str(excinfo.value)
+    assert "dockets.parquet" in message
+    assert "documents.parquet" in message
+    assert "2 of 2" in message
+
+
+def test_upload_dataset_is_a_noop_with_nothing_to_publish(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty publish set must not blow up on max_workers=0."""
+    monkeypatch.setattr(r2, "upload_file", lambda p, remote_key=None: None)
+
+    r2.upload_dataset(tmp_path, ["dockets"])

--- a/tests/test_rollup_freshness.py
+++ b/tests/test_rollup_freshness.py
@@ -25,3 +25,32 @@ def test_row_count_change_resets_the_clock():
     rows = [("usaspending_recipients", "row count", None, 100_000)]
     assert evaluate_row_changes(rows, state, date(2026, 7, 20)) == []
     assert state["usaspending_recipients"] == {"count": 100_000, "last_changed": "2026-07-20"}
+
+
+def test_base_tables_are_monitored():
+    """dockets/documents must stay covered — nothing watched them for 8 weeks."""
+    from scripts.check_rollup_freshness import DATE_CHECKS
+
+    monitored = {(c.table, c.column) for c in DATE_CHECKS}
+    assert ("dockets", "modify_date") in monitored
+    assert ("documents", "modify_date") in monitored
+
+
+def test_base_table_checks_avoid_future_dated_posted_date():
+    """documents.posted_date carries future effective dates and can't detect a stall."""
+    from scripts.check_rollup_freshness import DATE_CHECKS
+
+    assert ("documents", "posted_date") not in {(c.table, c.column) for c in DATE_CHECKS}
+
+
+def test_frozen_dockets_watermark_fails():
+    """The exact production regression: dockets stuck at 2026-07-02."""
+    rows = [("dockets", "modify_date", "2026-07-02T20:46:17Z", 276_326)]
+    failures = evaluate_date_rows(rows, date(2026, 8, 26))
+    assert len(failures) == 1
+    assert "dockets" in failures[0]
+
+
+def test_current_dockets_watermark_passes():
+    rows = [("dockets", "modify_date", "2026-08-25T12:00:00Z", 278_000)]
+    assert evaluate_date_rows(rows, date(2026, 8, 26)) == []


### PR DESCRIPTION
## Problem

`dockets.parquet` has been frozen at `2026-07-02T20:46:17Z` for ~8 weeks. 1,865 dockets referenced by documents posted since July 1 are missing entirely, and the docket-derived rollups (`feed_summary`) inherit the freeze. Every ETL run in that window reported success.

Three things had to line up:

**1. The Iceberg `dockets` table was never seeded.** `4413ca5` added the Iceberg dockets path and `0ba09bc` made every scheduled run use it. Comments got a real cutover — `seed_comments_from_parquet()` plus `seed-comments-catalog.yml` — that bulk-loaded the existing 25.7M rows. Dockets got no equivalent, so the catalog table only ever accumulated rows staged *after* the cutover:

```
iceberg: dockets now holds 5,386 rows        ← should be ~276,000
iceberg: comments now holds 25,783,462 rows  ← correctly seeded
```

**2. `_export_parquet` then exports that sliver as the full public snapshot** — a 0.4 MB file meant to replace production.

**3. The shrink guard refused, and the refusal was swallowed.** `_assert_upload_safe` raising is *correct* — it's the only reason production data wasn't wiped. But `upload_dataset` did:

```python
with ThreadPoolExecutor(max_workers=len(files_to_upload)) as executor:
    executor.map(upload_file, files_to_upload)
```

`ThreadPoolExecutor.map` returns a **lazy iterator**. Nothing consumed it, so the exception was never re-raised in the main thread. Visible in every batch of every run:

```
Uploading dockets.parquet (0.4 MB) to R2...   ← logged before the guard
Uploaded: ***/documents.parquet
Uploaded: ***/manifest.parquet
Uploaded: ***/comments_index.parquet
```

Every other file gets its `Uploaded:` confirmation. Dockets never does — no line, no traceback, exit 0.

And nothing was watching: `comments` had `check-comments-freshness.yml`, the rollups had `check_rollup_freshness.py`, and the two largest base tables had **no monitor at all**.

## Solution

**Fix 1 — `upload_dataset` (`src/spicy_regs/sources/r2.py`).** Submit uploads as futures and inspect each result. Failures are collected rather than raised on the first, so one broken table can't hide another behind it. Also guards the empty-file-set case, which would otherwise raise on `max_workers=0`.

**Fix 2 — freshness coverage (`scripts/check_rollup_freshness.py`).** Add `dockets` and `documents` as `BASE_TABLE_CHECKS`. Watermark is `modify_date`, deliberately **not** `posted_date` — documents carry future effective dates (max is currently `2026-12-13`), so `max(posted_date)` reads as fresh forever and could never detect a stall. 4-day budget: rides out a three-day federal holiday weekend, catches a real break the same week.

This PR does **not** seed the Iceberg dockets table — that writes production R2 and should be a deliberate, watched run.

## Test plan

- `uv run pytest` — **546 passed**.
- New regression tests: a failing upload raises; every failure is reported; an empty publish set is a no-op; a dockets watermark frozen at `2026-07-02` fails the freshness check; `documents.posted_date` is asserted *not* to be used as a watermark.
- `uv run python scripts/check_rollup_freshness.py` against production R2 catches the live outage:
  ```
  STALE: dockets (modify_date) latest=2026-07-02 age=55d budget=4d rows=276,326
  OK: documents (modify_date) latest=2026-08-26 age=0d budget=4d rows=1,996,251
  ```
- `uv run ty check` and `uv run ruff check` clean.

## Reviewer notes — two things to decide

**This check is already red every day and has been for 12+ days.** `congress_bills` is stuck at `2025-04-07` — **506 days** stale. A monitor that always fails monitors nothing, so adding `dockets` to it buys real coverage only if the workflow can get back to green. Either fix the `congress_bills` ingest or move it to `SKIPPED` with an explicit reason.

**`dockets` will keep failing this check until the Iceberg table is seeded.** That's intended — it's reporting a real, ongoing outage, not a flaky test. Follow-up work, in order:

1. Seed the Iceberg `dockets` table from the current 276,326-row `dockets.parquet` (generalize `seed_comments_from_parquet` rather than writing a second one).
2. Re-run the docket-derived rollups once dockets is current again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
