### PR TITLE
feat(iceberg): seed the dockets catalog table from the published snapshot

### DIFF
--- a/.github/workflows/seed-dockets-catalog.yml
+++ b/.github/workflows/seed-dockets-catalog.yml
@@ -1,0 +1,95 @@
+name: Seed dockets catalog (manual)
+
+# Cutover repair for the R2 Data Catalog `dockets` table. When the dockets ETL
+# moved onto the catalog, `comments` got a real seed (seed-comments-catalog.yml)
+# and `dockets` got none — so the catalog table only ever held rows staged AFTER
+# the cutover (~5.4k of ~276k). Every run exported that sliver as the "full"
+# public snapshot, the shrink guard correctly refused it, and the refusal was
+# swallowed by a discarded executor.map iterator (fixed in #176). The published
+# dockets.parquet sat frozen at 2026-07-02 for eight weeks with the ETL green.
+#
+# This backfills ONLY the docket_ids the catalog is missing: the rows already in
+# the catalog are the post-cutover updates and are newer than the frozen
+# snapshot, so overwriting them from Parquet would roll back eight weeks of
+# ingested changes. That also makes a re-run a no-op rather than a double-load.
+#
+# Manual dispatch only — it WRITES the production catalog, so it never runs on a
+# schedule. Defaults to dry_run: check the numbers first, then dispatch again
+# with dry_run off.
+#
+# Requires the same secrets as the ETL:
+#   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT, R2_BUCKET_NAME  (read the source snapshot)
+#   R2_CATALOG_URI, R2_CATALOG_WAREHOUSE, R2_CATALOG_TOKEN               (write the catalog table)
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report what would be backfilled and write nothing'
+        required: false
+        default: true
+        type: boolean
+      upload:
+        description: 'Publish the rebuilt dockets.parquet to R2 immediately (otherwise the next ETL publishes it)'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  # Same group as the ETL and the dedupe/backfill workflows: every writer to the
+  # catalog must be serialized, since the upsert is DELETE+INSERT (DuckDB's
+  # Iceberg engine has no MERGE INTO) and is not safe under concurrent writers.
+  # cancel-in-progress:false so this queues behind an in-flight ETL run instead
+  # of cancelling it mid-write.
+  group: comments-catalog-write
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    # One monolithic ~276k-row file — far smaller than the comments seed, but the
+    # catalog commit itself can be slow, so leave real headroom.
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Seed dockets catalog from the published snapshot
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          # Cloudflare edge-cache purge after publish (best-effort; no-op if unset).
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          R2_CATALOG_URI: ${{ secrets.R2_CATALOG_URI }}
+          R2_CATALOG_WAREHOUSE: ${{ secrets.R2_CATALOG_WAREHOUSE }}
+          R2_CATALOG_TOKEN: ${{ secrets.R2_CATALOG_TOKEN }}
+          R2_CATALOG_NAMESPACE: ${{ secrets.R2_CATALOG_NAMESPACE }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          UPLOAD: ${{ inputs.upload }}
+        run: |
+          set -euo pipefail
+          ARGS=()
+          if [ "$DRY_RUN" = "true" ]; then ARGS+=(--dry-run); fi
+          if [ "$UPLOAD" = "true" ]; then ARGS+=(--upload); fi
+          echo "Running: uv run python scripts/seed_dockets_catalog.py ${ARGS[*]-}"
+          uv run python scripts/seed_dockets_catalog.py ${ARGS[@]+"${ARGS[@]}"}
+
+      - name: Verify published freshness
+        # Only meaningful once the rebuilt snapshot is actually published.
+        if: ${{ inputs.dry_run == false && inputs.upload == true }}
+        run: uv run python scripts/check_rollup_freshness.py

--- a/scripts/seed_comments_catalog.py
+++ b/scripts/seed_comments_catalog.py
@@ -31,43 +31,12 @@ import argparse
 import sys
 from os import getenv
 from pathlib import Path
-from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 from loguru import logger
 
 from spicy_regs.schemas import COMMENT
 from spicy_regs.sources import iceberg, r2
-
-_REQUIRED_S3_ENV = ("R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "R2_ENDPOINT")
-
-
-def _create_s3_secret(con) -> None:
-    """Register R2's S3 API as a DuckDB secret so the partition tree can be globbed.
-
-    Reads over the public HTTPS URL can't list directories (the whole reason the
-    catalog cutover exists), so the source partitions are read via the S3 API,
-    which does support listing/globbing.
-    """
-    missing = [v for v in _REQUIRED_S3_ENV if not getenv(v)]
-    if missing:
-        raise RuntimeError("Missing R2 S3 env var(s): " + ", ".join(missing))
-    # R2_ENDPOINT is a full URL for boto3; DuckDB wants the bare host + USE_SSL.
-    endpoint = getenv("R2_ENDPOINT", "")
-    host = urlparse(endpoint).netloc or endpoint.replace("https://", "").replace("http://", "")
-    con.execute(
-        f"""
-        CREATE OR REPLACE SECRET r2_s3_secret (
-            TYPE S3,
-            KEY_ID '{iceberg._sql_str(getenv("R2_ACCESS_KEY_ID", ""))}',
-            SECRET '{iceberg._sql_str(getenv("R2_SECRET_ACCESS_KEY", ""))}',
-            ENDPOINT '{iceberg._sql_str(host)}',
-            URL_STYLE 'path',
-            USE_SSL true,
-            REGION 'auto'
-        );
-        """
-    )
 
 
 def _agencies(con, bucket: str, only: str | None) -> list[str]:
@@ -104,13 +73,15 @@ def main() -> int:
     parser.add_argument("--agency", help="Load only this agency_code (default: all)")
     parser.add_argument("--output-dir", type=Path, default=Path("output"))
     parser.add_argument(
-        "--append", action="store_true",
+        "--append",
+        action="store_true",
         help="Allow loading into a non-empty catalog table (default: refuse). "
-             "The load is idempotent per agency (each agency's rows are replaced), "
-             "so this is safe for resuming an interrupted run.",
+        "The load is idempotent per agency (each agency's rows are replaced), "
+        "so this is safe for resuming an interrupted run.",
     )
     parser.add_argument(
-        "--upload-index", action="store_true",
+        "--upload-index",
+        action="store_true",
         help="Publish the rebuilt comments_index.parquet to R2 after loading",
     )
     args = parser.parse_args()
@@ -119,17 +90,16 @@ def main() -> int:
 
     con = iceberg._connect()  # iceberg + httpfs loaded, catalog attached
     try:
-        _create_s3_secret(con)
+        iceberg.create_s3_secret(con)
         iceberg._ensure_table(con, COMMENT)
 
-        existing = con.execute(
-            f"SELECT count(*) FROM {iceberg._qualified(COMMENT)}"
-        ).fetchone()[0]
+        existing = con.execute(f"SELECT count(*) FROM {iceberg._qualified(COMMENT)}").fetchone()[0]
         if existing and not args.append:
             logger.error(
                 "Catalog comments table already has {:,} rows. Re-run with --append "
                 "to load anyway — the load is idempotent per agency (each agency's "
-                "rows are replaced), so this is safe.", existing,
+                "rows are replaced), so this is safe.",
+                existing,
             )
             return 1
 
@@ -146,25 +116,16 @@ def main() -> int:
             # agency loads via a single atomic INSERT, so a nonzero count that
             # matches means it completed — no partial-agency state to worry about.
             want = expected.get(agency)
-            have = con.execute(
-                f"SELECT count(*) FROM {qualified} WHERE agency_code = '{safe}'"
-            ).fetchone()[0]
+            have = con.execute(f"SELECT count(*) FROM {qualified} WHERE agency_code = '{safe}'").fetchone()[0]
             if want is not None and have == want and have > 0:
-                logger.info(
-                    "  [{}/{}] {}: already loaded ({:,} rows) — skipping", i, len(agencies), agency, have
-                )
+                logger.info("  [{}/{}] {}: already loaded ({:,} rows) — skipping", i, len(agencies), agency, have)
                 skipped += 1
                 continue
-            glob = (
-                f"s3://{bucket}/comments/agency_code={safe}/"
-                "docket_id=*/year=*/month=*/part-0.parquet"
-            )
+            glob = f"s3://{bucket}/comments/agency_code={safe}/docket_id=*/year=*/month=*/part-0.parquet"
             try:
                 # replace_agency makes each agency load idempotent: a re-run
                 # replaces that agency's rows rather than duplicating them.
-                total = iceberg.seed_comments_from_parquet(
-                    con, glob, COMMENT, replace_agency=agency
-                )
+                total = iceberg.seed_comments_from_parquet(con, glob, COMMENT, replace_agency=agency)
                 loaded += 1
             except Exception as exc:  # noqa: BLE001 — keep going, report at the end
                 logger.warning("  [{}/{}] {}: skipped ({})", i, len(agencies), agency, exc)
@@ -173,9 +134,10 @@ def main() -> int:
 
         total = con.execute(f"SELECT count(*) FROM {qualified}").fetchone()[0]
         logger.info(
-            "Load complete: {:,} rows in the catalog comments table "
-            "({} agencies loaded, {} already-current skipped)",
-            total, loaded, skipped,
+            "Load complete: {:,} rows in the catalog comments table ({} agencies loaded, {} already-current skipped)",
+            total,
+            loaded,
+            skipped,
         )
 
         index_file = iceberg._build_comments_index(con, COMMENT, args.output_dir)
@@ -187,9 +149,7 @@ def main() -> int:
         logger.info("Uploading rebuilt comments index to R2...")
         r2.upload_file(index_file, remote_key="comments_index.parquet")
 
-    logger.info(
-        "Done. Verify with: uv run python scripts/check_comments_freshness.py"
-    )
+    logger.info("Done. Verify with: uv run python scripts/check_comments_freshness.py")
     return 0
 
 

--- a/scripts/seed_dockets_catalog.py
+++ b/scripts/seed_dockets_catalog.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Seed the Iceberg catalog ``dockets`` table from the published ``dockets.parquet``.
+
+Cutover repair. When the dockets ETL moved onto the R2 Data Catalog, ``comments``
+got a real seed (``scripts/seed_comments_catalog.py``) and ``dockets`` got none —
+so the catalog table only ever held rows staged *after* the cutover: ~5.4k of
+~276k. Every run exported that sliver as the "full" public snapshot,
+``_assert_upload_safe`` correctly refused to overwrite production with it, and
+the refusal was swallowed by a discarded ``executor.map`` iterator (fixed in
+#176). ``dockets.parquet`` sat frozen at 2026-07-02 with the ETL green.
+
+This backfills the missing historical rows so the next ETL export is full-size
+and publishes normally. It inserts **only** docket_ids the catalog lacks: the
+rows already there are the post-cutover updates and are newer than the frozen
+snapshot, so overwriting them from Parquet would roll back eight weeks of
+ingested changes. That also makes a re-run a no-op instead of a double-load.
+
+Unlike the comments tree, the source here is one monolithic file — no globbing,
+no per-agency chunking. It is read over the S3 API (not the public URL) to match
+the comments seeder and to sidestep edge-cache range-read corruption.
+
+Needs both credential sets in the environment:
+
+* R2 S3 keys (to read the source snapshot):
+  ``R2_ACCESS_KEY_ID``, ``R2_SECRET_ACCESS_KEY``, ``R2_ENDPOINT``,
+  ``R2_BUCKET_NAME`` (default ``spicy-regs``)
+* R2 Data Catalog creds (to write the table):
+  ``R2_CATALOG_URI``, ``R2_CATALOG_WAREHOUSE``, ``R2_CATALOG_TOKEN``
+  (+ optional ``R2_CATALOG_NAMESPACE``)
+
+Usage:
+    uv run python scripts/seed_dockets_catalog.py --dry-run   # report, write nothing
+    uv run python scripts/seed_dockets_catalog.py             # backfill the catalog
+    uv run python scripts/seed_dockets_catalog.py --export    # + write the public snapshot locally
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from os import getenv
+from pathlib import Path
+
+from dotenv import load_dotenv
+from loguru import logger
+
+from spicy_regs.schemas import DOCKET
+from spicy_regs.sources import iceberg
+from spicy_regs.sources.r2 import upload_file
+
+# The catalog table is expected to be badly under-populated (that is the bug);
+# a source snapshot that is *itself* small would mean R2 already lost the
+# historical rows, and backfilling from it would cement the loss. Refuse rather
+# than seed from a truncated source.
+MIN_SOURCE_ROWS = 100_000
+
+
+def main() -> int:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-key", default="dockets.parquet", help="Source object key in the R2 bucket")
+    parser.add_argument("--output-dir", type=Path, default=Path("output"))
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be backfilled and write nothing",
+    )
+    parser.add_argument(
+        "--export",
+        action="store_true",
+        help="Export the public dockets.parquet snapshot locally after backfilling",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Publish the exported snapshot to R2 (implies --export). The next scheduled "
+        "ETL would publish it anyway; use this to close the gap immediately.",
+    )
+    args = parser.parse_args()
+
+    bucket = getenv("R2_BUCKET_NAME", "spicy-regs")
+    source_uri = f"s3://{bucket}/{args.source_key}"
+
+    out_file: Path | None = None
+    con = iceberg._connect()  # iceberg + httpfs loaded, catalog attached
+    try:
+        iceberg.create_s3_secret(con)
+        iceberg._ensure_table(con, DOCKET)
+
+        qualified = iceberg._qualified(DOCKET)
+        before = con.execute(f"SELECT count(*) FROM {qualified}").fetchone()[0]
+        source_rows = con.execute(f"SELECT count(*) FROM read_parquet('{iceberg._sql_str(source_uri)}')").fetchone()[0]
+
+        logger.info("Catalog {} holds {:,} rows", DOCKET.name, before)
+        logger.info("Source {} holds {:,} rows", source_uri, source_rows)
+
+        if source_rows < MIN_SOURCE_ROWS:
+            logger.error(
+                "Source snapshot has only {:,} rows (expected >= {:,}). Refusing to "
+                "backfill from what looks like a truncated file.",
+                source_rows,
+                MIN_SOURCE_ROWS,
+            )
+            return 1
+
+        missing = con.execute(
+            f"""
+            SELECT count(*) FROM (
+                SELECT DISTINCT "{DOCKET.dedup_key}" AS k
+                FROM read_parquet('{iceberg._sql_str(source_uri)}')
+                WHERE "{DOCKET.dedup_key}" IS NOT NULL
+            ) src
+            WHERE NOT EXISTS (
+                SELECT 1 FROM {qualified} t WHERE t."{DOCKET.dedup_key}" = src.k
+            );
+            """
+        ).fetchone()[0]
+        logger.info("{:,} source docket_id(s) are missing from the catalog", missing)
+
+        if args.dry_run:
+            logger.info("--dry-run: nothing written. Would backfill {:,} row(s).", missing)
+            return 0
+
+        if not missing:
+            logger.info("Catalog already holds every source docket_id — nothing to backfill.")
+            inserted, total = 0, before
+        else:
+            inserted, total = iceberg.backfill_missing_from_parquet(con, source_uri, DOCKET)
+            logger.info("Backfilled {:,} row(s); catalog {} now holds {:,}", inserted, DOCKET.name, total)
+
+        if total < source_rows:
+            logger.warning(
+                "Catalog ({:,}) still holds fewer rows than the source ({:,}) — investigate "
+                "before relying on the next export.",
+                total,
+                source_rows,
+            )
+
+        if args.export or args.upload:
+            out_file = iceberg._export_parquet(con, DOCKET, args.output_dir)
+            exported = con.execute(
+                f"SELECT count(*) FROM read_parquet('{iceberg._sql_str(str(out_file))}')"
+            ).fetchone()[0]
+            logger.info("Exported public snapshot to {} ({:,} rows)", out_file, exported)
+    finally:
+        con.close()
+
+    if args.upload and out_file is not None:
+        # Goes through the ordinary publish path, shrink guard included — if the
+        # backfill somehow left the export short, this refuses rather than
+        # overwriting production with a truncated file.
+        logger.info("Publishing {} to R2...", out_file.name)
+        upload_file(out_file, remote_key=args.source_key)
+
+    logger.info("Done. Verify with: uv run python scripts/check_rollup_freshness.py")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/spicy_regs/sources/iceberg.py
+++ b/src/spicy_regs/sources/iceberg.py
@@ -36,6 +36,7 @@ Credentials are read from the environment, alongside the existing ``R2_*`` vars:
 
 from os import getenv
 from pathlib import Path
+from urllib.parse import urlparse
 
 from loguru import logger
 
@@ -317,6 +318,98 @@ def seed_comments_from_parquet(
     return con.execute(f"SELECT count(*) FROM {_qualified(record_type)}").fetchone()[0]
 
 
+_REQUIRED_S3_ENV = ("R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY", "R2_ENDPOINT")
+
+
+def create_s3_secret(con) -> None:
+    """Register R2's S3 API as a DuckDB secret so bucket objects can be read/globbed.
+
+    Reads over the public HTTPS URL can't list directories (the whole reason the
+    catalog cutover exists), so source Parquet is read via the S3 API, which does
+    support listing/globbing. Shared by the catalog seeding scripts.
+    """
+    missing = [v for v in _REQUIRED_S3_ENV if not getenv(v)]
+    if missing:
+        raise RuntimeError("Missing R2 S3 env var(s): " + ", ".join(missing))
+    # R2_ENDPOINT is a full URL for boto3; DuckDB wants the bare host + USE_SSL.
+    endpoint = getenv("R2_ENDPOINT", "")
+    host = urlparse(endpoint).netloc or endpoint.replace("https://", "").replace("http://", "")
+    con.execute(
+        f"""
+        CREATE OR REPLACE SECRET r2_s3_secret (
+            TYPE S3,
+            KEY_ID '{_sql_str(getenv("R2_ACCESS_KEY_ID", ""))}',
+            SECRET '{_sql_str(getenv("R2_SECRET_ACCESS_KEY", ""))}',
+            ENDPOINT '{_sql_str(host)}',
+            URL_STYLE 'path',
+            USE_SSL true,
+            REGION 'auto'
+        );
+        """
+    )
+
+
+def backfill_missing_from_parquet(con, source_uri: str, record_type: RecordType) -> tuple[int, int]:
+    """Insert published-Parquet rows the catalog table is missing; return ``(inserted, total)``.
+
+    The cutover counterpart to :func:`seed_comments_from_parquet`, for a table
+    that was routed through the catalog without ever being seeded from the
+    Parquet that preceded it. ``dockets`` was exactly that: the Iceberg path
+    landed while ``comments`` got a real seed and ``dockets`` got none, so the
+    catalog table only ever accumulated rows staged *after* the cutover (~5.4k of
+    ~276k). Every run then exported that sliver as the "full" public snapshot and
+    the shrink guard refused it, freezing the published table for eight weeks.
+
+    Rows are matched on ``record_type.dedup_key`` and only source keys **absent**
+    from the table are inserted. That ordering matters: the catalog's rows are
+    *newer* than the frozen snapshot (they are the post-cutover updates), so
+    overwriting them from Parquet would silently roll back eight weeks of
+    ingested changes. Backfilling only what is missing keeps the newer row
+    authoritative in every case, and makes a re-run a no-op rather than a
+    duplicate load — this does a plain ``INSERT``, with no dedup of its own.
+
+    Expressed as an anti-join rather than ``NOT IN`` because a single NULL key on
+    either side makes ``NOT IN`` return NULL for every row and quietly insert
+    nothing. The source is de-duplicated on its own key (latest ``modify_date``
+    wins) so a snapshot with repeats can't fan out into duplicate rows.
+    """
+    key = record_type.dedup_key
+    columns = list(record_type.schema)
+    esc = _sql_str(source_uri)
+    qualified = _qualified(record_type)
+
+    present = {
+        row[0]
+        for row in con.execute(
+            f"DESCRIBE SELECT * FROM read_parquet('{esc}', union_by_name=true, hive_partitioning=false)"
+        ).fetchall()
+    }
+    if key not in present:
+        raise RuntimeError(f"Source {source_uri} has no '{key}' column; refusing to backfill {record_type.name}")
+
+    projection = ", ".join(
+        f'CAST("{c}" AS VARCHAR) AS "{c}"' if c in present else f'CAST(NULL AS VARCHAR) AS "{c}"' for c in columns
+    )
+    col_list = ", ".join(f'"{c}"' for c in columns)
+
+    before = con.execute(f"SELECT count(*) FROM {qualified}").fetchone()[0]
+    con.execute(
+        f"""
+        INSERT INTO {qualified} ({col_list})
+        WITH src AS (
+            SELECT {projection}
+            FROM read_parquet('{esc}', union_by_name=true, hive_partitioning=false)
+            QUALIFY row_number() OVER (PARTITION BY "{key}" ORDER BY "modify_date" DESC NULLS LAST) = 1
+        )
+        SELECT {col_list} FROM src
+        WHERE src."{key}" IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM {qualified} t WHERE t."{key}" = src."{key}");
+        """
+    )
+    total = con.execute(f"SELECT count(*) FROM {qualified}").fetchone()[0]
+    return total - before, total
+
+
 def upsert_comment_text(con, record_type: RecordType, agency: str, updates) -> None:
     """Upsert filled ``text_content`` / ``text_extraction_status`` for one agency.
 
@@ -370,7 +463,9 @@ def upsert_comment_text(con, record_type: RecordType, agency: str, updates) -> N
         WHERE r.comment_id = u.comment_id;
         """
     )
-    con.execute(f"DELETE FROM {tbl} WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _uct_replacement);")
+    con.execute(
+        f"DELETE FROM {tbl} WHERE agency_code = '{ag}' AND comment_id IN (SELECT comment_id FROM _uct_replacement);"
+    )
     con.execute(f"INSERT INTO {tbl} ({col_list}) SELECT {col_list} FROM _uct_replacement;")
     con.execute("DROP TABLE IF EXISTS _uct_updates;")
     con.execute("DROP TABLE IF EXISTS _uct_replacement;")

--- a/tests/test_iceberg.py
+++ b/tests/test_iceberg.py
@@ -409,13 +409,21 @@ def test_export_public_comments_rebuilds_mirror(tmp_path, local_catalog, monkeyp
     iceberg._ensure_table(con, COMMENT)
 
     staging = tmp_path / "staging"
-    _write_comment_staging(staging, "EPA", [
-        _comment("c1", "EPA-1", "EPA", "2025-01-15T00:00:00Z"),
-        _comment("c2", "EPA-2", "EPA", "2025-02-03T00:00:00Z"),
-    ])
-    _write_comment_staging(staging, "OMB", [
-        _comment("c3", "OMB-1", "OMB", "2026-06-29T00:00:00Z"),
-    ])
+    _write_comment_staging(
+        staging,
+        "EPA",
+        [
+            _comment("c1", "EPA-1", "EPA", "2025-01-15T00:00:00Z"),
+            _comment("c2", "EPA-2", "EPA", "2025-02-03T00:00:00Z"),
+        ],
+    )
+    _write_comment_staging(
+        staging,
+        "OMB",
+        [
+            _comment("c3", "OMB-1", "OMB", "2026-06-29T00:00:00Z"),
+        ],
+    )
     iceberg._merge(con, iceberg._staging_files(staging, COMMENT), COMMENT)
 
     # export_public_comments opens its own catalog connection; point it at the
@@ -477,9 +485,7 @@ def test_audit_and_dedupe_table(tmp_path, local_catalog) -> None:
 
     # Clean afterward, and c1 kept its latest modify_date.
     assert iceberg.audit_duplicates(con, COMMENT) == []
-    kept = con.execute(
-        f"SELECT modify_date FROM {iceberg._qualified(COMMENT)} WHERE comment_id = 'c1'"
-    ).fetchone()[0]
+    kept = con.execute(f"SELECT modify_date FROM {iceberg._qualified(COMMENT)} WHERE comment_id = 'c1'").fetchone()[0]
     assert kept == "2025-03-09T00:00:00Z"
 
 
@@ -514,9 +520,7 @@ def test_dedupe_table_sub_batches_large_agency(tmp_path, local_catalog, monkeypa
     assert after == 20  # one row per distinct comment_id
 
     assert iceberg.audit_duplicates(con, COMMENT) == []
-    kept = con.execute(
-        f"SELECT modify_date FROM {iceberg._qualified(COMMENT)} WHERE comment_id = 'c0'"
-    ).fetchone()[0]
+    kept = con.execute(f"SELECT modify_date FROM {iceberg._qualified(COMMENT)} WHERE comment_id = 'c0'").fetchone()[0]
     assert kept == "2025-06-01T00:00:00Z"  # newest version survived the bucketed dedup
 
 
@@ -623,3 +627,108 @@ def test_dedupe_table_resumes_interrupted_swap(tmp_path, local_catalog) -> None:
     assert con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0] == 3
     with pytest.raises(duckdb.Error):
         con.execute(f"SELECT 1 FROM {dedup_tbl} LIMIT 1")
+
+
+def _write_snapshot(path: Path, rows: list[dict]) -> None:
+    """A published monolithic {name}.parquet snapshot."""
+    pl.DataFrame(rows, schema={c: pl.Utf8 for c in DOCKET.schema}).write_parquet(path)
+
+
+def test_backfill_inserts_only_missing_keys(tmp_path, local_catalog) -> None:
+    """The cutover repair: historical rows land, post-cutover rows are untouched."""
+    con = local_catalog
+    iceberg._ensure_table(con, DOCKET)
+
+    # The catalog holds only post-cutover rows - the production failure shape.
+    _write_staging(tmp_path / "staging", "EPA", [_docket("EPA-NEW", "EPA", "post-cutover", "2026-08-01T00:00:00Z")])
+    iceberg._merge(con, iceberg._staging_files(tmp_path / "staging", DOCKET), DOCKET)
+
+    snapshot = tmp_path / "dockets.parquet"
+    _write_snapshot(
+        snapshot,
+        [
+            _docket("EPA-OLD", "EPA", "historical", "2015-01-01T00:00:00Z"),
+            _docket("EPA-NEW", "EPA", "STALE SNAPSHOT COPY", "2026-07-02T00:00:00Z"),
+        ],
+    )
+
+    inserted, total = iceberg.backfill_missing_from_parquet(con, str(snapshot), DOCKET)
+    assert (inserted, total) == (1, 2)
+
+    rows = dict(con.execute(f"SELECT docket_id, title FROM {iceberg._qualified(DOCKET)} ORDER BY docket_id").fetchall())
+    assert rows["EPA-OLD"] == "historical"
+    # The newer catalog row must win - backfilling must never roll it back.
+    assert rows["EPA-NEW"] == "post-cutover"
+
+
+def test_backfill_is_idempotent(tmp_path, local_catalog) -> None:
+    """A re-run inserts nothing: the backfill does a plain INSERT with no dedup."""
+    con = local_catalog
+    iceberg._ensure_table(con, DOCKET)
+
+    snapshot = tmp_path / "dockets.parquet"
+    _write_snapshot(snapshot, [_docket("EPA-1", "EPA", "one", "2025-01-01T00:00:00Z")])
+
+    assert iceberg.backfill_missing_from_parquet(con, str(snapshot), DOCKET) == (1, 1)
+    assert iceberg.backfill_missing_from_parquet(con, str(snapshot), DOCKET) == (0, 1)
+
+
+def test_backfill_dedups_a_repeated_source_key(tmp_path, local_catalog) -> None:
+    """A snapshot with repeats cannot fan out into duplicate catalog rows."""
+    con = local_catalog
+    iceberg._ensure_table(con, DOCKET)
+
+    snapshot = tmp_path / "dockets.parquet"
+    _write_snapshot(
+        snapshot,
+        [
+            _docket("EPA-1", "EPA", "older", "2025-01-01T00:00:00Z"),
+            _docket("EPA-1", "EPA", "newer", "2025-06-01T00:00:00Z"),
+        ],
+    )
+
+    inserted, total = iceberg.backfill_missing_from_parquet(con, str(snapshot), DOCKET)
+    assert (inserted, total) == (1, 1)
+    title = con.execute(f"SELECT title FROM {iceberg._qualified(DOCKET)}").fetchone()[0]
+    assert title == "newer"
+
+
+def test_backfill_survives_a_null_key_in_the_catalog(tmp_path, local_catalog) -> None:
+    """NOT IN would return NULL for every row here and insert nothing; the anti-join must not."""
+    con = local_catalog
+    iceberg._ensure_table(con, DOCKET)
+    con.execute(f"INSERT INTO {iceberg._qualified(DOCKET)} (docket_id) VALUES (NULL);")
+
+    snapshot = tmp_path / "dockets.parquet"
+    _write_snapshot(snapshot, [_docket("EPA-1", "EPA", "one", "2025-01-01T00:00:00Z")])
+
+    inserted, _total = iceberg.backfill_missing_from_parquet(con, str(snapshot), DOCKET)
+    assert inserted == 1
+
+
+def test_backfill_skips_null_keys_in_the_source(tmp_path, local_catalog) -> None:
+    con = local_catalog
+    iceberg._ensure_table(con, DOCKET)
+
+    snapshot = tmp_path / "dockets.parquet"
+    _write_snapshot(
+        snapshot,
+        [
+            _docket("EPA-1", "EPA", "one", "2025-01-01T00:00:00Z"),
+            {col: None for col in DOCKET.schema},
+        ],
+    )
+
+    inserted, total = iceberg.backfill_missing_from_parquet(con, str(snapshot), DOCKET)
+    assert (inserted, total) == (1, 1)
+
+
+def test_backfill_rejects_a_source_without_the_key_column(tmp_path, local_catalog) -> None:
+    con = local_catalog
+    iceberg._ensure_table(con, DOCKET)
+
+    snapshot = tmp_path / "wrong.parquet"
+    pl.DataFrame({"agency_code": ["EPA"], "modify_date": ["2025-01-01T00:00:00Z"]}).write_parquet(snapshot)
+
+    with pytest.raises(RuntimeError, match="docket_id"):
+        iceberg.backfill_missing_from_parquet(con, str(snapshot), DOCKET)


### PR DESCRIPTION
Follow-up to #176, which fixed the *masking*. This fixes the underlying data.

## Problem

When the dockets ETL moved onto the R2 Data Catalog, `comments` got a real cutover (`seed_comments_catalog.py`, 25.7M rows) and `dockets` got **none**. The catalog table only ever accumulated rows staged *after* the cutover:

```
iceberg: dockets now holds 5,386 rows        ← should be ~276,000
iceberg: comments now holds 25,783,462 rows  ← correctly seeded
```

Every run exported that sliver as the "full" public snapshot, `_assert_upload_safe` correctly refused to overwrite production with 0.4 MB, and #176 showed the refusal was being swallowed. Net effect: `dockets.parquet` frozen at `2026-07-02` for eight weeks.

## Solution

`iceberg.backfill_missing_from_parquet` + `scripts/seed_dockets_catalog.py` + a manual-dispatch workflow.

**The one design decision that matters:** the backfill inserts **only keys the catalog lacks**, rather than replacing the table from Parquet. The rows already in the catalog are the post-cutover updates — they are *newer* than the frozen snapshot. Seeding over them would silently roll back eight weeks of correctly-ingested changes, turning a stale-data bug into a data-loss bug. Backfilling only what's missing keeps the newer row authoritative in every case, and makes a re-run a no-op instead of a double-load (the insert does no dedup of its own).

Two smaller correctness points:

- Expressed as an **anti-join, not `NOT IN`** — a single NULL key on either side makes `NOT IN` evaluate to NULL for every row and quietly insert nothing. There's a test pinning this.
- The source is **de-duplicated on its own key** (latest `modify_date` wins), so a snapshot with repeats can't fan out into duplicate catalog rows.

### Guardrails

- Refuses a source snapshot under 100k rows — a truncated source would cement the data loss rather than repair it.
- Defaults to `--dry-run`; the workflow input defaults to `dry_run: true`.
- Warns when the post-backfill count still trails the source.
- `--upload` publishes through the **ordinary** `upload_file` path, so the shrink guard still applies. If the backfill somehow left the export short, the publish refuses — and now, post-#176, that refusal is loud.
- The workflow joins the existing `comments-catalog-write` concurrency group, so it queues behind an in-flight ETL rather than writing the catalog concurrently (the upsert is DELETE+INSERT and unsafe under concurrent writers).

Also hoists the duplicated `_create_s3_secret` out of `seed_comments_catalog.py` into `iceberg.create_s3_secret`, following the precedent in b90bb27.

## Test plan

- `uv run pytest` — **553 passed**.
- New tests cover: the exact cutover shape (historical rows land, post-cutover rows survive untouched), idempotency across re-runs, source-side dedup, a NULL key on the catalog side, a NULL key on the source side, and a source missing the key column.
- `uv run ty check` and `uv run ruff check` clean.
- **Production dry-run is pending** — it needs the workflow on `main` before `workflow_dispatch` can target it. See below.

## Rollout after merge

1. Dispatch `Seed dockets catalog (manual)` with **`dry_run: true`**. Expect roughly `Catalog dockets holds ~5,400 rows` / `Source holds 276,326 rows` / `~271,000 missing`. Confirm those numbers before going further.
2. Re-dispatch with `dry_run: false`. Add `upload: true` to republish immediately; otherwise the next scheduled ETL publishes the now-full-size export on its own.
3. Confirm with `check_rollup_freshness.py` — `dockets` should drop from `age=55d` to current.
4. Re-run the docket-derived rollups (`feed_summary` et al.), which inherited the freeze.

⚠️ Note that this queues behind the ETL, which currently runs 3–8 hours per sweep at 06:25 and 18:25 UTC — so pick a window, or expect a wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
