### PR TITLE
fix(ci): let the dockets seed dry-run skip the catalog write lock

### DIFF
--- a/.github/workflows/seed-dockets-catalog.yml
+++ b/.github/workflows/seed-dockets-catalog.yml
@@ -35,12 +35,19 @@ on:
         type: boolean
 
 concurrency:
-  # Same group as the ETL and the dedupe/backfill workflows: every writer to the
-  # catalog must be serialized, since the upsert is DELETE+INSERT (DuckDB's
-  # Iceberg engine has no MERGE INTO) and is not safe under concurrent writers.
-  # cancel-in-progress:false so this queues behind an in-flight ETL run instead
-  # of cancelling it mid-write.
-  group: comments-catalog-write
+  # Writers share one group with the ETL and the dedupe/backfill workflows: every
+  # writer to the catalog must be serialized, since the upsert is DELETE+INSERT
+  # (DuckDB's Iceberg engine has no MERGE INTO) and is not safe under concurrent
+  # writers. cancel-in-progress:false so a write queues behind an in-flight ETL
+  # run instead of cancelling it mid-write.
+  #
+  # A dry run is exempt: it only counts rows and writes nothing, so holding it on
+  # the write lock bought no safety and made the diagnostic unusable exactly when
+  # it was needed — the first dispatch sat pending behind a sweep with ~4.5 hours
+  # of batches left. Giving it a per-run group lets it start immediately. Note
+  # the fallback is the write group, so a malformed or absent input serializes
+  # rather than running free.
+  group: ${{ inputs.dry_run == true && format('seed-dockets-dry-{0}', github.run_id) || 'comments-catalog-write' }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Problem

#177 put every dispatch of the seed workflow in the `comments-catalog-write` concurrency group. That's correct for a run that writes. It's wrong for a dry run, which only counts rows and writes nothing — the lock bought no safety and made the diagnostic unusable exactly when it was needed.

Observed: the first dry-run dispatch (33024775225) sat `pending` with no jobs behind an in-flight ETL sweep that still had ~4.5 hours of batches to go.

## Solution

```yaml
group: ${{ inputs.dry_run == true && format('seed-dockets-dry-{0}', github.run_id) || 'comments-catalog-write' }}
```

Dry runs get a per-run group and start immediately. Anything that can actually write still serializes with the ETL and the dedupe/backfill workflows — the upsert is DELETE+INSERT (DuckDB's Iceberg engine has no `MERGE INTO`) and is not safe under concurrent writers.

Two safety properties worth stating explicitly:

- **The fallback is the write group.** A malformed or absent `dry_run` input serializes rather than running free — the exemption is opt-in, not the default.
- **A dry run cannot write even if misdispatched.** `--dry-run` returns before the export/upload block, so `dry_run: true` + `upload: true` still writes nothing. The concurrency exemption can't be turned into a write path by an input combination.

## Test plan

- `python3 -c "yaml.safe_load(...)"` — parses; `concurrency.group` renders the expression, `cancel-in-progress: false` preserved, both inputs intact.
- Verified against the script: `main()` returns at the `--dry-run` branch before `_export_parquet` / `upload_file` are reachable.
- Behavioral confirmation comes on merge: dispatching with `dry_run: true` should start immediately rather than sitting `pending` behind the running ETL sweep.

Follow-up to #176 and #177. Unblocks the dockets seed rollout without cancelling the in-flight ETL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
