### PR TITLE
fix(mcp): restore the setup landing page; stop the redeploy dropping the Iceberg catalog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ src/spicy_regs/
 ├── mcp_server.py         # stdio MCP server (`spicy-regs-mcp` script)
 └── vectordb/             # embedding pipeline (optional `embed` extra)
 
-mcp-server/               # standalone HTTP MCP server (Vercel-deployable)
+mcp-server/               # MCP server engineering notes (INTERNALS.md; server lives in src/)
 notebooks/                # exploratory Jupyter notebooks (Binder-runnable)
 sample-data/              # tiny fixtures used by tests
 scripts/                  # one-off operational scripts

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ A read-only MCP server exposes SQL over the corpus with three tools:
 
 | Client | Setup |
 |---|---|
-| **Claude.ai** or any remote MCP client | Add `https://mcp.spicy-regs.dev/mcp` as a Custom Connector. See [`mcp-server/README.md`](mcp-server/README.md). |
+| **Claude.ai** or any remote MCP client | Add `https://mcp.spicy-regs.dev/mcp` as a Custom Connector. Copy-paste setup for every client is at [mcp.spicy-regs.dev](https://mcp.spicy-regs.dev/). |
 | **Claude Code** (plugin) | `/plugin marketplace add civictechdc/spicy-regs` then `/plugin install spicyregs@spicy-regs-local` |
 | **Claude Code** (stdio, no deploy) | `claude mcp add spicy-regs -- uvx --from "spicy-regs @ git+https://github.com/civictechdc/spicy-regs" spicy-regs-mcp` |
 | **Cursor / Continue / OpenAI / others** | See [`plugins/spicyregs/INSTALL.md`](plugins/spicyregs/INSTALL.md) for the full matrix, including a prompt-only fallback for assistants without MCP support. |
@@ -254,7 +254,7 @@ src/spicy_regs/
 ├── data_dictionary.py# Generates the docs site from the schemas
 └── cli.py            # Local data CLI (download / stats / sample / search)
 
-mcp-server/           # Vercel deployment of the MCP server
+mcp-server/           # MCP server engineering notes (the server itself is src/spicy_regs/mcp_server.py)
 scripts/              # Operational tooling (dedupe, seed, freshness checks)
 notebooks/            # Example analyses (runnable on Binder)
 tests/                # Unit suite; integration tests are opt-in

--- a/deploy/cloudflare/worker/index.ts
+++ b/deploy/cloudflare/worker/index.ts
@@ -33,7 +33,14 @@ export class McpContainer extends Container<Env> {
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const { pathname } = new URL(request.url);
-    if (pathname === "/mcp" || pathname.startsWith("/mcp/")) {
+    // /mcp is the protocol endpoint; / and /icon.png are the human-facing setup
+    // page, which the Python server serves (see mcp_server._register_landing_page).
+    if (
+      pathname === "/mcp" ||
+      pathname.startsWith("/mcp/") ||
+      pathname === "/" ||
+      pathname === "/icon.png"
+    ) {
       return getContainer(env.MCP_CONTAINER).fetch(request);
     }
     return new Response("Not found", { status: 404 });

--- a/deploy/cloudrun/deploy.sh
+++ b/deploy/cloudrun/deploy.sh
@@ -36,31 +36,67 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/../.." && pwd)"
 IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/${AR_REPO}/mcp:$(git -C "$ROOT" rev-parse --short HEAD)"
 
-echo "1/5 Enable APIs"
+echo "1/6 Enable APIs"
 gcloud services enable run.googleapis.com cloudbuild.googleapis.com artifactregistry.googleapis.com --project "$PROJECT"
 
-echo "2/5 Ensure Artifact Registry repo"
+echo "2/6 Ensure Artifact Registry repo"
 gcloud artifacts repositories describe "$AR_REPO" --location "$REGION" --project "$PROJECT" >/dev/null 2>&1 || \
   gcloud artifacts repositories create "$AR_REPO" --repository-format=docker --location "$REGION" --project "$PROJECT"
 
-echo "3/5 Build + push (amd64 — Cloud Run requires it; reuses the shared Dockerfile)"
+echo "3/6 Build + push (amd64 — Cloud Run requires it; reuses the shared Dockerfile)"
 gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
 docker build --platform linux/amd64 -f "$ROOT/deploy/cloudflare/Dockerfile" -t "$IMAGE" "$ROOT"
 docker push "$IMAGE"
 
-echo "4/5 Deploy"
+echo "4/6 Deploy"
 gcloud run deploy "$SERVICE" \
   --image "$IMAGE" --project "$PROJECT" --region "$REGION" \
   --allow-unauthenticated --port 8080 \
   --memory "$MEMORY" --cpu "$CPU" \
   --concurrency "$CONCURRENCY" --timeout "$TIMEOUT" \
   --min-instances "$MIN_INSTANCES" --max-instances "$MAX_INSTANCES" \
-  --set-env-vars "SPICY_REGS_MEMORY_LIMIT=${MEM_LIMIT},SPICY_REGS_TEMP_DIR=/tmp,SPICY_REGS_HOME_DIR=/tmp,SPICY_REGS_STATEMENT_TIMEOUT=${TIMEOUT}s,SPICY_REGS_R2_URL=https://data.spicy-regs.dev"
+  --update-env-vars "SPICY_REGS_MEMORY_LIMIT=${MEM_LIMIT},SPICY_REGS_TEMP_DIR=/tmp,SPICY_REGS_HOME_DIR=/tmp,SPICY_REGS_STATEMENT_TIMEOUT=${TIMEOUT}s,SPICY_REGS_R2_URL=https://data.spicy-regs.dev"
+
+# --update-env-vars, NOT --set-env-vars: the latter "removes all existing
+# environment variables first", which would strip the R2_CATALOG_* config wired
+# up after this script was written. Losing those is SILENT — _resolve_catalog_config
+# just returns None and `comments` falls back to the public parquet mirror,
+# giving up the deduped Iceberg system-of-record with no error anywhere.
 
 # --allow-unauthenticated needs the allUsers binding, which the org policy blocks
 # until relaxed. If the deploy warns the IAM binding failed, relax the policy
 # (README) then: gcloud run services add-iam-policy-binding "$SERVICE" \
 #   --region "$REGION" --member=allUsers --role=roles/run.invoker
 
-echo "5/5 URL:"
-gcloud run services describe "$SERVICE" --project "$PROJECT" --region "$REGION" --format='value(status.url)'
+echo "5/6 URL:"
+URL="$(gcloud run services describe "$SERVICE" --project "$PROJECT" --region "$REGION" --format='value(status.url)')"
+echo "$URL"
+
+echo "6/6 Smoke check (against the public domain, so it covers DNS + cert + routing)"
+BASE="${SMOKE_BASE:-https://mcp.spicy-regs.dev}"
+fail=0
+
+code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "$BASE/")"
+[ "$code" = 200 ] && echo "  ok   GET /            $code" || { echo "  FAIL GET /            $code"; fail=1; }
+
+tools="$(curl -sS --max-time 60 -X POST "$BASE/mcp" \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_sources","arguments":{}}}')"
+for t in rulemaking_lifecycles fr_docket_links discovery_signals; do
+  case "$tools" in
+    *"$t"*) echo "  ok   table $t" ;;
+    *)      echo "  FAIL table $t missing from list_sources"; fail=1 ;;
+  esac
+done
+
+# The catalog is the silent-failure mode above; this proves comments is still
+# reading the deduped system-of-record. ~7s over 25.7M rows.
+dedup="$(curl -sS --max-time 120 -X POST "$BASE/mcp" \
+  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"query_sql","arguments":{"sql":"SELECT count(*) = count(DISTINCT comment_id) AS deduped FROM comments"}}}')"
+case "$dedup" in
+  *'"deduped": true'*|*'"deduped":true'*) echo "  ok   comments deduped (catalog attached)" ;;
+  *) echo "  WARN comments not deduped — R2_CATALOG_* may be missing; check: gcloud run services describe $SERVICE --region $REGION --format='value(spec.template.spec.containers[0].env)'"; fail=1 ;;
+esac
+
+[ "$fail" = 0 ] && echo "Smoke check passed." || { echo "Smoke check FAILED — consider: gcloud run services update-traffic $SERVICE --region $REGION --to-revisions PREVIOUS=100"; exit 1; }

--- a/plugins/spicyregs/INSTALL.md
+++ b/plugins/spicyregs/INSTALL.md
@@ -41,11 +41,14 @@ tools.
 Requires Pro, Max, Team, or Enterprise (custom connectors aren't available on
 free plans).
 
-1. Deploy `mcp-server/` to Vercel (see [`mcp-server/README.md`](../../mcp-server/README.md)).
-2. Open **Settings → Connectors → Add custom connector**.
-3. Name: `Spicy Regs`. URL: `https://<your-vercel-deploy>.vercel.app/mcp`.
+1. Open **Settings → Connectors → Add custom connector**.
+2. Name: `Spicy Regs`. URL: `https://mcp.spicy-regs.dev/mcp`.
    Authentication: None.
-4. Toggle the connector on in any conversation.
+3. Toggle the connector on in any conversation.
+
+The public server is already deployed — there's nothing to host yourself.
+[mcp.spicy-regs.dev](https://mcp.spicy-regs.dev/) has copy-paste config for
+every other client too.
 
 Claude.ai doesn't load repo skills directly, so paste the system prompt from
 [`provider-agnostic-prompt.md`](skills/spicyregs/references/provider-agnostic-prompt.md)

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import logging
 import os
 import re
@@ -9,6 +10,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from functools import lru_cache
+from pathlib import Path
 from time import monotonic as _monotonic
 from typing import Any
 from urllib.parse import urlparse
@@ -18,6 +21,8 @@ import duckdb
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import Icon
+from starlette.requests import Request
+from starlette.responses import Response
 
 from spicy_regs._icon import ICON_DATA_URI
 
@@ -391,6 +396,54 @@ def build_server() -> FastMCP:
     return mcp
 
 
+STATIC_DIR = Path(__file__).parent / "static"
+
+
+@lru_cache(maxsize=1)
+def _landing_page() -> bytes:
+    """The setup page served at /, with its view list rendered from TABLES.
+
+    The list used to be hand-maintained in the HTML and had drifted seven
+    tables behind by the time this page was restored; substituting it here
+    keeps the page honest as TABLES grows.
+    """
+    views = " ·\n        ".join(f'<code class="inline">{table}</code>' for table in TABLES)
+    html = (STATIC_DIR / "index.html").read_text(encoding="utf-8")
+    return html.replace("<!--VIEWS-->", views).encode("utf-8")
+
+
+@lru_cache(maxsize=1)
+def _landing_icon() -> bytes:
+    """Decoded from ICON_DATA_URI so the PNG has exactly one home in the package."""
+    return base64.b64decode(ICON_DATA_URI.split(",", 1)[1])
+
+
+def _register_landing_page(mcp: FastMCP) -> None:
+    """Serve the human-facing setup page alongside the MCP endpoint.
+
+    Vercel served this as a static file at the site root; when that deploy was
+    retired the page went with it, leaving mcp.spicy-regs.dev/ a bare 404. It
+    lives in the canonical server now so every host (Cloud Run, the Cloudflare
+    container) gets it without host-specific static-file config.
+    """
+
+    @mcp.custom_route("/", methods=["GET"])
+    async def landing(_request: Request) -> Response:
+        return Response(
+            _landing_page(),
+            media_type="text/html; charset=utf-8",
+            headers={"Cache-Control": "public, max-age=300"},
+        )
+
+    @mcp.custom_route("/icon.png", methods=["GET"])
+    async def icon(_request: Request) -> Response:
+        return Response(
+            _landing_icon(),
+            media_type="image/png",
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
+
+
 def build_app():
     mcp = FastMCP(
         "spicy-regs",
@@ -401,6 +454,7 @@ def build_app():
         transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
     )
     _register_tools(mcp)
+    _register_landing_page(mcp)
     return mcp.streamable_http_app()
 
 

--- a/src/spicy_regs/static/index.html
+++ b/src/spicy_regs/static/index.html
@@ -1,0 +1,291 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Spicy Regs MCP Server</title>
+  <meta name="description" content="Connect the Spicy Regs regulatory dataset (regulations.gov mirror) to Claude, Cursor, VS Code, and any MCP client." />
+  <link rel="icon" type="image/png" href="/icon.png" />
+  <style>
+    :root {
+      --blue: #5b9bdd;       /* accent: active-tab underline, links */
+      --blue-dark: #8fc0f5;  /* brighter accent: emphasis text on dark */
+      --ink: #e7eef7;
+      --muted: #94a8bd;
+      --line: #2a3543;
+      --bg: #0e1620;
+      --surface: #18222f;    /* raised surfaces: endpoint pill, inline code, badge */
+      --code-bg: #0a111c;
+      --code-ink: #e6edf6;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      color: var(--ink);
+      background: var(--bg);
+      line-height: 1.5;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 18px 20px;
+    }
+    a { color: var(--blue); }
+
+    .card { width: 100%; max-width: 660px; text-align: center; }
+
+    /* ---- brand ---- */
+    .brand img { width: 56px; height: 56px; border-radius: 14px; box-shadow: 0 6px 18px rgba(31,91,166,0.28); }
+    .brand h1 { margin: 8px 0 2px; font-size: 1.5rem; letter-spacing: -0.02em; }
+    .brand p { margin: 0; color: var(--muted); font-size: 0.95rem; }
+
+    /* ---- endpoint ---- */
+    .endpoint {
+      margin: 18px auto 0; display: inline-flex; align-items: center; gap: 10px;
+      background: var(--surface); border: 1px solid var(--line); border-radius: 11px;
+      padding: 7px 7px 7px 14px; box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+      max-width: 100%;
+    }
+    .endpoint .label { color: var(--muted); font-size: 0.74rem; text-transform: uppercase; letter-spacing: 0.06em; }
+    .endpoint code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; color: var(--blue-dark); font-size: 0.92rem; overflow-x: auto; }
+
+    /* ---- tabs ---- */
+    .tabs {
+      display: flex; justify-content: center; flex-wrap: wrap; gap: 2px;
+      margin: 18px 0 0; border-bottom: 2px solid var(--line);
+    }
+    .tab {
+      appearance: none; background: none; border: none; cursor: pointer;
+      font: inherit; font-size: 0.92rem; font-weight: 600; color: var(--muted);
+      padding: 9px 14px; white-space: nowrap; border-bottom: 2px solid transparent;
+      margin-bottom: -2px; border-radius: 8px 8px 0 0;
+    }
+    .tab:hover { color: var(--ink); background: var(--surface); }
+    .tab[aria-selected="true"] { color: var(--blue-dark); border-bottom-color: var(--blue); }
+
+    /* ---- panels (left-aligned content inside the centered card) ---- */
+    .panel { display: none; text-align: left; padding: 18px 0 0; }
+    .panel[data-active] { display: block; }
+    .panel .req { font-size: 0.85rem; color: var(--muted); margin: 0 0 12px; }
+    .panel .req .badge {
+      font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
+      color: #a9cdf5; background: #1c2c40; border-radius: 999px; padding: 2px 8px; margin-right: 6px;
+    }
+    .steps { margin: 0; padding-left: 20px; }
+    .steps li { margin: 5px 0; font-size: 0.95rem; }
+    .panel .hint { font-size: 0.85rem; color: var(--muted); margin: 0 0 3px; }
+    .pathline { color: var(--muted); font-size: 0.8rem; margin: 0 0 4px; font-family: ui-monospace, monospace; }
+    code.inline { background: var(--surface); color: #cdd9e6; padding: 1px 5px; border-radius: 5px; font-size: 0.92em; }
+
+    .codeblock { position: relative; background: var(--code-bg); color: var(--code-ink); border-radius: 9px; margin: 6px 0 14px; overflow: hidden; }
+    .codeblock pre {
+      margin: 0; padding: 13px 60px 13px 14px; overflow-x: auto;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.84rem; line-height: 1.45;
+    }
+    .copy {
+      background: #24364a; color: #cfe0f4; border: 1px solid rgba(255,255,255,0.18);
+      border-radius: 7px; font: inherit; font-size: 0.74rem; padding: 5px 10px; cursor: pointer;
+    }
+    .copy:hover { background: #324863; color: #fff; }
+    .copy.copied { color: #aef0c4; border-color: rgba(174,240,196,0.5); }
+    .codeblock .copy { position: absolute; top: 7px; right: 7px; box-shadow: -8px 0 10px 4px var(--code-bg); }
+
+    /* ---- tools section ---- */
+    .tools { text-align: left; margin: 16px 0 0; padding: 14px 0 0; border-top: 1px solid var(--line); }
+    .tools h2 { margin: 0 0 2px; font-size: 1.02rem; letter-spacing: -0.01em; }
+    .tools .sub { margin: 0 0 12px; font-size: 0.85rem; color: var(--muted); }
+    .tools dl { margin: 0; display: grid; grid-template-columns: auto 1fr; gap: 7px 14px; align-items: baseline; }
+    .tools dt { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.84rem; color: var(--blue-dark); white-space: nowrap; }
+    .tools dd { margin: 0; font-size: 0.9rem; color: var(--ink); }
+    .tools .views { margin: 13px 0 0; font-size: 0.85rem; color: var(--muted); }
+    .tools .views code { font-size: 0.92em; }
+
+    .meta { margin: 14px 0 0; font-size: 0.84rem; color: var(--muted); }
+    .meta a { text-decoration: none; }
+    .meta a:hover { text-decoration: underline; }
+    .meta .dot { margin: 0 8px; opacity: 0.5; }
+
+    @media (max-width: 540px) {
+      .tools dl { grid-template-columns: 1fr; gap: 2px; }
+      .tools dt { margin-top: 8px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="brand">
+      <img src="/icon.png" alt="Spicy Regs logo" />
+      <h1>Spicy Regs MCP Server</h1>
+      <p>A regulations.gov mirror, queryable from your AI tools.</p>
+    </div>
+
+    <div class="endpoint">
+      <span class="label">Endpoint</span>
+      <code>https://mcp.spicy-regs.dev/mcp</code>
+      <button class="copy" type="button" data-copy="https://mcp.spicy-regs.dev/mcp">Copy</button>
+    </div>
+
+    <div class="tabs" role="tablist" aria-label="Setup instructions by tool">
+      <button class="tab" role="tab" aria-selected="true" data-tab="claude-ai">Claude.ai</button>
+      <button class="tab" role="tab" aria-selected="false" data-tab="claude-code">Claude Code</button>
+      <button class="tab" role="tab" aria-selected="false" data-tab="cursor">Cursor</button>
+      <button class="tab" role="tab" aria-selected="false" data-tab="vscode">VS Code</button>
+      <button class="tab" role="tab" aria-selected="false" data-tab="windsurf">Windsurf</button>
+      <button class="tab" role="tab" aria-selected="false" data-tab="other">Other clients</button>
+    </div>
+
+    <!-- Claude.ai -->
+    <section class="panel" id="panel-claude-ai" role="tabpanel" data-active>
+      <p class="req"><span class="badge">Pro · Max · Team · Enterprise</span>web &amp; desktop</p>
+      <ol class="steps">
+        <li>Open <strong>Settings → Connectors → Add custom connector</strong>.</li>
+        <li>Name it <strong>Spicy Regs</strong>.</li>
+        <li>Set the URL to the endpoint above.</li>
+        <li>Leave authentication as <strong>None</strong> — the dataset is public.</li>
+        <li>Save, then toggle the connector on in any conversation.</li>
+      </ol>
+    </section>
+
+    <!-- Claude Code -->
+    <section class="panel" id="panel-claude-code" role="tabpanel">
+      <p class="hint">Remote HTTP:</p>
+      <div class="codeblock">
+        <button class="copy" type="button">Copy</button>
+        <pre><code>claude mcp add --transport http spicy-regs https://mcp.spicy-regs.dev/mcp</code></pre>
+      </div>
+      <p class="hint">Local stdio via <code class="inline">uvx</code> (no remote dependency):</p>
+      <div class="codeblock">
+        <button class="copy" type="button">Copy</button>
+        <pre><code>claude mcp add spicy-regs -- uvx --from "spicy-regs @ git+https://github.com/civictechdc/spicy-regs" spicy-regs-mcp</code></pre>
+      </div>
+    </section>
+
+    <!-- Cursor -->
+    <section class="panel" id="panel-cursor" role="tabpanel">
+      <p class="hint">Add to your MCP config, then enable it under <strong>Settings → MCP</strong>.</p>
+      <p class="pathline">~/.cursor/mcp.json (global) · .cursor/mcp.json (per-project)</p>
+      <div class="codeblock">
+        <button class="copy" type="button">Copy</button>
+        <pre><code>{
+  "mcpServers": {
+    "spicy-regs": { "url": "https://mcp.spicy-regs.dev/mcp" }
+  }
+}</code></pre>
+      </div>
+    </section>
+
+    <!-- VS Code -->
+    <section class="panel" id="panel-vscode" role="tabpanel">
+      <p class="hint">Add a workspace MCP config (Copilot Agent mode required).</p>
+      <p class="pathline">.vscode/mcp.json</p>
+      <div class="codeblock">
+        <button class="copy" type="button">Copy</button>
+        <pre><code>{
+  "servers": {
+    "spicy-regs": { "type": "http", "url": "https://mcp.spicy-regs.dev/mcp" }
+  }
+}</code></pre>
+      </div>
+    </section>
+
+    <!-- Windsurf -->
+    <section class="panel" id="panel-windsurf" role="tabpanel">
+      <p class="hint">Add to the Cascade MCP config, then refresh the server list.</p>
+      <p class="pathline">~/.codeium/windsurf/mcp_config.json</p>
+      <div class="codeblock">
+        <button class="copy" type="button">Copy</button>
+        <pre><code>{
+  "mcpServers": {
+    "spicy-regs": { "serverUrl": "https://mcp.spicy-regs.dev/mcp" }
+  }
+}</code></pre>
+      </div>
+    </section>
+
+    <!-- Other -->
+    <section class="panel" id="panel-other" role="tabpanel">
+      <p class="hint">Most clients accept a remote streamable-HTTP URL:</p>
+      <div class="codeblock">
+        <button class="copy" type="button">Copy</button>
+        <pre><code>https://mcp.spicy-regs.dev/mcp</code></pre>
+      </div>
+      <p class="hint">Or run it locally over stdio with <code class="inline">uvx</code>:</p>
+      <div class="codeblock">
+        <button class="copy" type="button">Copy</button>
+        <pre><code>uvx --from "spicy-regs @ git+https://github.com/civictechdc/spicy-regs" spicy-regs-mcp</code></pre>
+      </div>
+    </section>
+
+    <!-- Tools -->
+    <div class="tools">
+      <h2>Tools exposed</h2>
+      <p class="sub">Three read-only tools, querying parquet on Cloudflare R2 via DuckDB.</p>
+      <dl>
+        <dt>list_sources</dt>
+        <dd>List the logical tables available in the dataset.</dd>
+        <dt>describe_table(table)</dt>
+        <dd>Return the column schema for one table.</dd>
+        <dt>query_sql(sql, max_rows=25)</dt>
+        <dd>Run a read-only SQL query against the views below (always <code class="inline">LIMIT</code> while exploring).</dd>
+      </dl>
+      <p class="views">
+        <strong>Views:</strong>
+        <!--VIEWS-->
+      </p>
+    </div>
+
+    <p class="meta">
+      <a href="https://docs.spicy-regs.dev/">Data dictionary</a>
+      <span class="dot">·</span>
+      <a href="https://github.com/civictechdc/spicy-regs">GitHub</a>
+      <span class="dot">·</span>
+      <a href="https://modelcontextprotocol.io">About MCP</a>
+    </p>
+  </div>
+
+  <script>
+    var tabs = Array.prototype.slice.call(document.querySelectorAll(".tab"));
+    var panels = {
+      "claude-ai": "panel-claude-ai", "claude-code": "panel-claude-code",
+      "cursor": "panel-cursor", "vscode": "panel-vscode",
+      "windsurf": "panel-windsurf", "other": "panel-other"
+    };
+    function select(name) {
+      tabs.forEach(function (t) {
+        t.setAttribute("aria-selected", t.dataset.tab === name ? "true" : "false");
+      });
+      Object.keys(panels).forEach(function (k) {
+        var el = document.getElementById(panels[k]);
+        if (k === name) el.setAttribute("data-active", ""); else el.removeAttribute("data-active");
+      });
+    }
+    tabs.forEach(function (t, i) {
+      t.addEventListener("click", function () { select(t.dataset.tab); });
+      t.addEventListener("keydown", function (e) {
+        if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+        e.preventDefault();
+        var next = (i + (e.key === "ArrowRight" ? 1 : tabs.length - 1)) % tabs.length;
+        tabs[next].focus(); select(tabs[next].dataset.tab);
+      });
+    });
+
+    document.querySelectorAll(".copy").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var text = btn.dataset.copy;
+        if (!text) {
+          var code = btn.parentElement.querySelector("code");
+          text = code ? code.innerText : "";
+        }
+        navigator.clipboard.writeText(text).then(function () {
+          var prev = btn.textContent;
+          btn.textContent = "Copied";
+          btn.classList.add("copied");
+          setTimeout(function () { btn.textContent = prev; btn.classList.remove("copied"); }, 1500);
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -16,6 +16,7 @@ import pytest
 
 from spicy_regs import mcp_server
 
+
 def test_jsonify_primitives_pass_through():
     assert mcp_server._jsonify(None) is None
     assert mcp_server._jsonify("hi") == "hi"
@@ -29,9 +30,7 @@ def test_jsonify_coerces_non_json_types():
     assert j(date(2024, 1, 2)) == "2024-01-02"
     assert j(datetime(2024, 1, 2, 3, 4, 5)) == "2024-01-02T03:04:05"
     assert j(Decimal("1.50")) == "1.50"
-    assert j(UUID("12345678-1234-5678-1234-567812345678")) == (
-        "12345678-1234-5678-1234-567812345678"
-    )
+    assert j(UUID("12345678-1234-5678-1234-567812345678")) == ("12345678-1234-5678-1234-567812345678")
     assert j(b"\x00\xff") == "00ff"
     assert j([Decimal("1"), date(2024, 1, 1)]) == ["1", "2024-01-01"]
     assert j({"a": Decimal("2"), "b": [b"\xab"]}) == {"a": "2", "b": ["ab"]}
@@ -172,10 +171,7 @@ def test_sandbox_survives_temp_spill():
     out-of-memory error — never the confusing permission error.
     """
     con = _sandboxed_connection(memory_limit="20MB")
-    spilling_sql = (
-        "SELECT i, count(*) AS c FROM range(3_000_000) r(i) "
-        "GROUP BY i ORDER BY c, i DESC"
-    )
+    spilling_sql = "SELECT i, count(*) AS c FROM range(3_000_000) r(i) GROUP BY i ORDER BY c, i DESC"
     try:
         con.execute(spilling_sql).fetchall()
     except duckdb.OutOfMemoryException:
@@ -237,9 +233,7 @@ def test_comments_catalog_view_dedups_on_read():
     )
     rows = con.execute("SELECT comment_id, comment FROM comments ORDER BY comment_id").fetchall()
     assert rows == [("c1", "new"), ("c2", "only-null"), ("c3", "unique")]
-    counts = con.execute(
-        "SELECT count(*), count(DISTINCT comment_id) FROM comments"
-    ).fetchone()
+    counts = con.execute("SELECT count(*), count(DISTINCT comment_id) FROM comments").fetchone()
     assert counts is not None
     total, distinct = counts
     assert total == distinct == 3
@@ -360,9 +354,7 @@ def test_query_sql_reuses_one_connection_across_calls(monkeypatch):
     server = module.build_server()
 
     for _ in range(2):
-        asyncio.run(
-            server.call_tool("query_sql", {"sql": "SELECT docket_count FROM agency_stats", "max_rows": 1})
-        )
+        asyncio.run(server.call_tool("query_sql", {"sql": "SELECT docket_count FROM agency_stats", "max_rows": 1}))
 
     assert build_count["n"] == 1
     module._reset_connection_cache()
@@ -434,3 +426,57 @@ def test_security_settings_honor_memory_and_temp(tmp_path, monkeypatch):
     mcp_server._apply_security_settings(con)
     assert _setting(con, "temp_directory") == str(tmp_path)
     assert _setting(con, "memory_limit") not in ("", None)
+
+
+def test_landing_page_renders_every_table():
+    """The view list is substituted from TABLES, not hand-maintained in the HTML.
+
+    The restored page shipped a hardcoded list that had drifted seven tables
+    behind; this pins the substitution so it cannot silently rot again.
+    """
+    html = mcp_server._landing_page().decode("utf-8")
+    assert "<!--VIEWS-->" not in html
+    for table in mcp_server.TABLES:
+        assert f'<code class="inline">{table}</code>' in html
+
+
+def test_landing_assets_exist_in_package():
+    """Both assets must ship inside the installed package — the container
+    installs the wheel and has no repo checkout to read them from."""
+    assert (mcp_server.STATIC_DIR / "index.html").is_file()
+    assert mcp_server._landing_icon()[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_app_serves_landing_page_and_mcp_endpoint():
+    """/ serves the setup page and /mcp still speaks the protocol."""
+    from starlette.testclient import TestClient
+
+    with TestClient(mcp_server.build_app()) as client:
+        page = client.get("/")
+        assert page.status_code == 200
+        assert page.headers["content-type"].startswith("text/html")
+        assert b"Spicy Regs MCP Server" in page.content
+
+        icon = client.get("/icon.png")
+        assert icon.status_code == 200
+        assert icon.headers["content-type"] == "image/png"
+
+        handshake = client.post(
+            "/mcp",
+            headers={
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+            },
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1"},
+                },
+            },
+        )
+        assert handshake.status_code == 200
+        assert b'"spicy-regs"' in handshake.content


### PR DESCRIPTION
Reported as "the MCP server seems to be down". It wasn't — the protocol endpoint was healthy throughout (`initialize`, `tools/list`, and a real `query_sql` all returned in well under a second). What was gone was the human-facing **setup page at the root**, and chasing that turned up a second, unrelated landmine in the deploy script.

## 1. The landing page (`7ca0f6d`)

`mcp.spicy-regs.dev/` had been a bare 404 since #166. The page was `mcp-server/public/index.html`, served **by Vercel** as a static file at the site root; retiring that deploy deleted `public/` along with the rest of the Vercel scaffolding. Cloud Run runs `build_app()`, which only mounts the streamable-HTTP transport at `/mcp` — so nothing was left serving `/`.

Fixed by serving it from the canonical server via `FastMCP.custom_route`, so it isn't tied to one host's static-file config:

- `src/spicy_regs/static/index.html`, restored from `9748ed8^`
- `/` and `/icon.png` routes registered in `build_app()`
- The icon is decoded from the `ICON_DATA_URI` the package already ships rather than committing a second copy of the same 15 KB PNG (verified byte-identical to `assets/icon.png`)
- The page's hardcoded "Views:" list had drifted **seven tables behind**, so it is now substituted from `TABLES` at render time and pinned by a test

`uv_build` includes the package's non-Python files by default, so the asset lands in the wheel the container installs with `--no-deps` — verified by building the wheel and booting it in a venv holding only mcp/duckdb/uvicorn.

The Cloudflare fallback worker hard-404s every path but `/mcp`, so it now forwards `/` and `/icon.png` too.

### Also #166 collateral
- `README.md` linked to the deleted `mcp-server/README.md`
- `plugins/spicyregs/INSTALL.md` told Claude.ai users to deploy their **own** Vercel instance; now points at the public server
- `README.md` / `CONTRIBUTING.md` still described `mcp-server/` as a Vercel deployment; it holds only `INTERNALS.md`

## 2. The deploy script would have broken `comments` (`45096e8`)

Found while preparing the redeploy, and worth a careful look — this is the riskier half of the PR.

`deploy.sh` passed `--set-env-vars`, which per `gcloud run deploy --help` *"removes all existing environment variables first"*. The `R2_CATALOG_*` config was wired up **after** that script was written (README: "Iceberg catalog — Done"), so the next run would have stripped it.

The failure is silent at every layer: `_resolve_catalog_config()` returns `None` if any of URI/WAREHOUSE/TOKEN is missing, `_attach_catalog` catches and logs rather than raising, and `comments` quietly falls back to the public parquet mirror — losing the deduped system-of-record with nothing surfaced to callers.

Not hypothetical: the dedup canary returned `true` against the live service *before* the deploy, confirming the config was live and would have been removed.

Switched to `--update-env-vars` (merges, so out-of-band config survives) and added a post-deploy smoke check that runs against the **public domain**, so it covers DNS, cert, and routing rather than just the raw Cloud Run URL.

## Verified

`ruff` / `ty` / `pytest` (556) / `spicy-regs-dict` all green.

The smoke check was validated in both directions — it failed on exactly the stale bits before the deploy, and passes after:

| Check | Before | After |
|---|---|---|
| `GET /` | 404 | **200** |
| `GET /icon.png` | 404 | 200 |
| `rulemaking_lifecycles` | missing | 26,437 rows |
| `fr_docket_links` | missing | 717,906 rows |
| `discovery_signals` | missing | 12 rows |
| `comments` deduped | true | **true** (catalog survived) |

Server is now 1.29.1; `comments` is 25,779,403 rows and still deduped.

> [!IMPORTANT]
> **This is already deployed.** `mcp.spicy-regs.dev` is running this branch — the redeploy was needed to bring back the landing page and expose the three lifecycle rollups (whose parquet files were already live on R2). So this PR documents what is in production rather than proposing a change to it, and `main` is currently behind the deployed service. Worth reviewing with that ordering in mind.

## Not covered

The Cloudflare worker change is untypechecked locally (no `node_modules`). It is a three-line boolean condition on the fallback host, which is not currently serving traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)