### PR TITLE
fix(backfill): let the comment-text backfill reach rows with no attachments_json

### DIFF
--- a/.github/workflows/backfill-comment-attachment-text.yml
+++ b/.github/workflows/backfill-comment-attachment-text.yml
@@ -12,13 +12,22 @@ name: Backfill comment attachment text (manual)
 #   3. publish-comments-mirror  — rebuilds the public read files so the UI /
 #      dashboard see the newly-filled text
 #
+# `discover_from_derived` (step 1 only, on by default) is what makes this reach
+# the historical corpus. `attachments_json` was dropped from the comment schema
+# for a stretch and the ingest manifest never revisits an already-processed key,
+# so nearly every pre-2023 comment row carries a NULL there — and the default
+# candidate gate (attachments_json truthy) skips it forever. With the flag, a
+# comment is a candidate on text_extraction_status alone and the per-docket
+# derived-data listing decides whether extracted text actually exists. Step 2
+# cannot take the same flag: it downloads the attachment URLs, which only
+# attachments_json carries.
+#
 # Manual dispatch only — it WRITES the production catalog and republishes the
 # public mirror, so it never runs on a schedule. Defaults to a single-agency
 # smoke test (NARA — small, has attachment comments, verified ~83% fill); flip
 # `full_load` on for every agency once the smoke test looks right. Both backfills
 # are incremental (rows with a text_extraction_status are skipped), so a re-run
-# only does new work. Attachments are ~0.4% of comments, so even the full load
-# touches only tens of thousands of rows.
+# only does new work.
 #
 # Requires these repo secrets:
 #   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT, R2_BUCKET_NAME, R2_PUBLIC_URL
@@ -55,6 +64,11 @@ on:
         description: 'Re-process rows that already have a text_extraction_status'
         required: false
         default: false
+        type: boolean
+      discover_from_derived:
+        description: 'Step 1: also consider comments with no attachments_json (needed for historical rows). Lists every docket in scope, so it is slower.'
+        required: false
+        default: true
         type: boolean
 
 concurrency:
@@ -108,11 +122,13 @@ jobs:
           AGENCY: ${{ inputs.agency }}
           LIMIT: ${{ inputs.limit }}
           OVERWRITE: ${{ inputs.overwrite }}
+          DISCOVER_FROM_DERIVED: ${{ inputs.discover_from_derived }}
         run: |
           args=()
           if [ "$FULL_LOAD" != "true" ] && [ -n "$AGENCY" ]; then args+=(--agency "$AGENCY"); fi
           if [ -n "$LIMIT" ] && [ "$LIMIT" != "0" ]; then args+=(--limit "$LIMIT"); fi
           if [ "$OVERWRITE" = "true" ]; then args+=(--overwrite); fi
+          if [ "$DISCOVER_FROM_DERIVED" = "true" ]; then args+=(--discover-from-derived); fi
           echo "Running: uv run backfill-comment-text --use-iceberg ${args[*]}"
           uv run backfill-comment-text --use-iceberg "${args[@]}"
 


### PR DESCRIPTION
## The problem

Comment `text_content` is almost never derived from attachment data, even though the enrichment is wired into the pipeline and on by default.

`EnrichCommentText` (`src/spicy_regs/transforms/enrich_derived_text.py:39`) gates on `attachments_json`:

```python
if record.get("attachments_json") and record.get("text_content") is None:
```

`attachments_json` was dropped from the comment schema in `cf999a1` ("drop unused attachments_json column") and only reinstated in the June refactor. The ingest manifest marks already-downloaded S3 keys as processed, so every comment staged in between keeps `attachments_json = NULL` permanently — and both the inline enrichment and the backfill skip it.

Published state today:

| | count |
|---|---|
| comments total | 25,779,403 |
| `attachments_json` non-null | 71,795 (0.28%) |
| `text_content` non-null | 58,780 (0.23%) |

EPA alone has **398,562** comments whose body is some variant of "see attached", against 15,177 with `attachments_json`. Per posted year, 2023/2024/2026 sit around 10% attachment coverage; 2005–2022 are essentially zero.

This is a stale-row problem, not an extractor bug. For `EPA-HQ-RCRA-2002-0031-0098` the raw Mirrulations JSON carries a full `included` attachments array and today's `_extract_comment` flattens it correctly. That docket has **471** derived-data extraction files in S3, and **0 of its 451 published comments have any text**.

`backfill_derived_text.py` already has `--discover-from-derived` for exactly this case (`src/spicy_regs/backfill_derived_text.py:117`) — it drops the `attachments_json` gate and lets the per-docket derived-data listing decide. The workflow just never passed it, so production backfills have only ever re-examined the same 71,795 rows.

## The change

- New `discover_from_derived` dispatch input, **defaulting to `true`**. The gated mode is now known to miss essentially the whole historical corpus, so on-by-default is the correct behavior; flip it off for the old attachments-only pass.
- Threaded into step 1 via `env:` → quoted bash array, matching the injection-safe pattern the other inputs use.
- Deliberately **not** added to step 2 (`enrich-pdf-text`): it downloads the attachment URLs, and only `attachments_json` carries those, so it structurally cannot discover rows without that column. Noted in the header.
- Dropped the header's "Attachments are ~0.4% of comments" line — that figure was the symptom of the missing column, not ground truth.

No source changes; the CLI flag already existed and is already covered by tests.

## Verification

- `backfill-comment-text --help` lists `--discover-from-derived`
- workflow YAML parses; the new input resolves with `default: true`
- `pytest -k "backfill or derived"` → 34 passed

## Before merging / dispatching

**Cost.** In discover mode the candidate set is every comment in the agency with no `text_extraction_status`, and each distinct docket costs one `list_objects` against the derived-data prefix. For EPA that's ~1.1M candidates across tens of thousands of dockets. Start with a single `agency` plus a `limit` rather than `full_load`.

**Suggested smoke test.** `agency: EPA` with a small `limit`. `EPA-HQ-RCRA-2002-0031` is the clean check — 451 published comments, 0 with text, 471 extraction files waiting in S3. The old gated path returns 0 selected for that entire docket.

Note that a plain re-ingest is not an alternative repair path: `merge_comments_partitioned` dedups by latest `modify_date`, and historical rows tie, so which copy wins is indeterminate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
