### PR TITLE
fix(federal-register): prevent truncated snapshots

### DIFF
--- a/src/spicy_regs/sources/federal_register.py
+++ b/src/spicy_regs/sources/federal_register.py
@@ -1,18 +1,26 @@
 """Reader connector for the federalregister.gov public REST API (v1).
 
-Brings Federal Register ingestion *in-repo*. Previously ``federal_register.parquet``
-was produced by a separate ingestion path and only consumed here (see
-``transforms/build_fr_docket_links``); this reader lets this repo produce it.
+Brings Federal Register ingestion *in-repo*. A separate ingestion path used to
+produce ``federal_register.parquet``, which this repo only consumed (see
+``transforms/build_fr_docket_links``); this reader produces it here.
 
 The reader is a *pure source*: it yields raw FR document payloads (dicts) exactly
 as the API returns them. Shaping them into the published 22-column schema is the
 job of :func:`~spicy_regs.transforms.build_federal_register.build_federal_register`.
 
-The FR documents endpoint truncates any single query to a bounded number of
-results, so a naive "page through everything" loop silently drops documents on
-busy date ranges. Instead we fetch **date windows** and split a window whenever
-the rows fall short of the reported ``count`` or that count reaches the API's
-cap. Recursion continues down to a single day, where ambiguity aborts the fetch.
+The 10,000-result cap
+---------------------
+The documents endpoint clamps both pagination and its reported ``count`` at
+10,000, so an overfull window looks exactly like a complete one. Ask it for the
+whole archive and it answers ``count: 10000`` and hands back 10,000 rows; the
+archive really holds 1,007,747 documents. Every single year since 1994 reports
+10,000 as well. A loop that pages "until the rows run out" therefore publishes
+about 1% of the corpus and calls the run a success.
+
+The reader instead fetches bounded **date windows** and calls a window ambiguous
+when the rows fall short of the reported ``count`` or that count reaches the cap.
+It halves an ambiguous window and refetches both halves, down to a single day. A
+single day that still reads ambiguous aborts the run rather than publish a hole.
 
 No API key is required; federalregister.gov is fully open.
 """
@@ -30,24 +38,25 @@ from spicy_regs.sources.base import Reader
 
 API_BASE = "https://www.federalregister.gov/api/v1"
 
-# Max the API accepts per page. Windows are still subdivided on truncation, so
-# this is only a round-trip-count optimization, not a correctness knob.
+# Largest page the API accepts. It saves round trips only: an ambiguous window is
+# subdivided at any page size, so this is not a correctness knob.
 PER_PAGE = 1000
 
-# The API caps both pagination and its reported ``count`` at 10,000. A response
-# with exactly this count is therefore ambiguous and must be subdivided even
-# when all 10,000 visible rows were collected.
+# The API clamps both pagination and its reported ``count`` at 10,000, so a window
+# holding a million documents reports the same count as one holding exactly
+# 10,000. Any window reporting this count must be subdivided, even after all
+# 10,000 visible rows arrive.
 RESULT_CAP = 10_000
 
-# Not a correctness knob — ``_fetch_window`` bisects the whole span on its own.
-# It is a cost bound: bisecting 1994..today from the top pays a full capped
-# traversal (10,000 rows, 10 pages) at every node above the split threshold,
-# ~127 nodes and ~1,300 requests whose rows are all discarded. Sized off the
-# live archive, whose busiest 90-day window holds 9,122 documents; a quarter
-# that does exceed the cap is still split recursively by ``_fetch_window``.
+# A cost bound, not a correctness knob: ``_fetch_window`` bisects whatever span it
+# is handed. Give it 1994..today in one piece and it pays a full capped traversal
+# (10,000 rows, 10 pages) at each of the ~127 nodes above the split threshold —
+# ~1,270 requests whose rows all get thrown away. Sized off the live archive,
+# whose busiest 90-day window holds 9,122 documents, 91% of the cap and a thin
+# margin; a quarter that does exceed the cap still gets split by ``_fetch_window``.
 MAX_WINDOW_DAYS = 90
 
-# FR's oldest documents. A full backfill with no prior table walks from here.
+# The oldest documents the API serves. A backfill with no prior table starts here.
 FR_EPOCH = date(1994, 1, 1)
 
 # Fields requested from the documents endpoint. Names are the API's; the
@@ -77,19 +86,22 @@ FIELDS = (
     "executive_order_number",
 )
 
-# Transport hygiene: bound every request and retry transient failures with
-# backoff so a flaky window fails slow-then-recovers rather than dropping docs.
+# Transport hygiene: bound every request, and retry transient failures with
+# backoff so a flaky window recovers slowly instead of dropping documents.
 _TIMEOUT = httpx.Timeout(60.0, connect=30.0)
 _MAX_RETRIES = 5
+
+# Emit a progress line every this many documents yielded.
 _PROGRESS_EVERY = 20_000
 
 
 class FederalRegisterReader(Reader):
     """Yields raw FR document dicts published in ``[since, until]`` (inclusive).
 
-    ``since`` / ``until`` default to the full FR archive and today. Callers doing
-    incremental runs pass ``since`` = (max published date already stored) so only
-    new documents are fetched; the transform handles merging with the prior table.
+    ``since`` defaults to the start of the archive and ``until`` to today. An
+    incremental run passes ``since`` = the last publication date already stored,
+    less a re-check overlap, so it fetches only new documents; the transform
+    merges what comes back with the prior table.
     """
 
     def __init__(
@@ -108,6 +120,7 @@ class FederalRegisterReader(Reader):
         self._seen = 0
 
     def iter_records(self) -> Iterator[dict]:
+        """Walk ``[since, until]`` in ``MAX_WINDOW_DAYS`` chunks, subdividing each as needed."""
         if self.since > self.until:
             logger.info("FR: since {} is after until {} — nothing to fetch", self.since, self.until)
             return
@@ -127,12 +140,12 @@ class FederalRegisterReader(Reader):
     # -- window fetching -----------------------------------------------------
 
     def _fetch_window(self, gte: date, lte: date) -> Iterator[dict]:
-        """Fetch one publication-date window, subdividing on truncation."""
+        """Yield one publication-date window, halving it while its contents stay ambiguous."""
         collected, count = self._page_window(gte, lte)
         truncated = len(collected) < count or count >= RESULT_CAP
         if truncated and gte < lte:
-            # The API truncated this window; halve it and recurse so no document
-            # in the range is lost.
+            # These rows may be a truncated view of the window, so throw them
+            # away and ask for each half instead. Nothing in the range is lost.
             mid = gte + (lte - gte) // 2
             if self.verbose:
                 logger.debug(
@@ -142,8 +155,9 @@ class FederalRegisterReader(Reader):
             yield from self._fetch_window(mid + timedelta(days=1), lte)
             return
         if truncated:
-            # A single day cannot be subdivided further. Publishing it would
-            # silently turn a transport/API limit into corpus data loss.
+            # A single day cannot be split further, so nothing here can reveal
+            # what the cap hides. Publishing it would turn an API limit into a
+            # silent hole in the corpus.
             raise RuntimeError(f"Federal Register API truncated {gte} at {len(collected)}/{count} documents")
         for doc in collected:
             self._seen += 1
@@ -152,7 +166,7 @@ class FederalRegisterReader(Reader):
             yield doc
 
     def _page_window(self, gte: date, lte: date) -> tuple[list[dict], int]:
-        """Page through a window, following ``next_page_url``. Returns (docs, count)."""
+        """Follow ``next_page_url`` through one window; return its rows and the reported ``count``."""
         params: dict[str, object] = {
             "per_page": self.per_page,
             "order": "oldest",
@@ -173,7 +187,7 @@ class FederalRegisterReader(Reader):
         return docs, count
 
     def _get(self, url: str, params: dict | None) -> dict:
-        """GET with bounded retries; exhaustions abort the source snapshot."""
+        """GET with bounded retries. Exhausting the budget raises, aborting the snapshot."""
         assert self._client is not None
         for attempt in range(1, _MAX_RETRIES + 1):
             try:
@@ -188,7 +202,10 @@ class FederalRegisterReader(Reader):
                 backoff = min(2**attempt, 30)
                 logger.warning("FR: {} (attempt {}/{}), retrying in {}s", exc, attempt, _MAX_RETRIES, backoff)
                 time.sleep(backoff)
-        # Only reached if the retry budget is non-positive; ``_get`` must never
-        # fall through to an implicit None, which pagination would read as an
-        # empty final page and publish as a complete window.
+        # Unreachable while ``_MAX_RETRIES >= 1``; a non-positive budget makes
+        # ``range(1, 1)`` empty and drops through to here. Raise rather than fall
+        # off the end: ``ty`` rejects the implicit ``None`` against the ``-> dict``
+        # return, and the tempting way to silence that — returning ``{}`` — is
+        # worse, because ``_page_window`` would read it as an empty final page and
+        # publish the window as complete.
         raise RuntimeError(f"Federal Register retry budget _MAX_RETRIES={_MAX_RETRIES} makes no request: {url}")

--- a/src/spicy_regs/sources/federal_register.py
+++ b/src/spicy_regs/sources/federal_register.py
@@ -39,10 +39,12 @@ PER_PAGE = 1000
 # when all 10,000 visible rows were collected.
 RESULT_CAP = 10_000
 
-# Avoid paying for a capped 10,000-row traversal of the full archive before
-# discovering that it must be split. Quarter-sized top-level windows remain
-# below the cap in normal Federal Register history; unusually busy quarters are
-# still split recursively by ``_fetch_window``.
+# Not a correctness knob — ``_fetch_window`` bisects the whole span on its own.
+# It is a cost bound: bisecting 1994..today from the top pays a full capped
+# traversal (10,000 rows, 10 pages) at every node above the split threshold,
+# ~127 nodes and ~1,300 requests whose rows are all discarded. Sized off the
+# live archive, whose busiest 90-day window holds 9,122 documents; a quarter
+# that does exceed the cap is still split recursively by ``_fetch_window``.
 MAX_WINDOW_DAYS = 90
 
 # FR's oldest documents. A full backfill with no prior table walks from here.
@@ -186,4 +188,7 @@ class FederalRegisterReader(Reader):
                 backoff = min(2**attempt, 30)
                 logger.warning("FR: {} (attempt {}/{}), retrying in {}s", exc, attempt, _MAX_RETRIES, backoff)
                 time.sleep(backoff)
-        raise AssertionError("unreachable")
+        # Only reached if the retry budget is non-positive; ``_get`` must never
+        # fall through to an implicit None, which pagination would read as an
+        # empty final page and publish as a complete window.
+        raise RuntimeError(f"Federal Register retry budget _MAX_RETRIES={_MAX_RETRIES} makes no request: {url}")

--- a/src/spicy_regs/sources/federal_register.py
+++ b/src/spicy_regs/sources/federal_register.py
@@ -10,10 +10,9 @@ job of :func:`~spicy_regs.transforms.build_federal_register.build_federal_regist
 
 The FR documents endpoint truncates any single query to a bounded number of
 results, so a naive "page through everything" loop silently drops documents on
-busy date ranges. Instead we fetch **date windows** and, whenever a window comes
-back truncated (fewer collected than the reported ``count``), split it in half
-and recurse — down to a single day. This makes correctness independent of the
-API's exact page cap.
+busy date ranges. Instead we fetch **date windows** and split a window whenever
+the rows fall short of the reported ``count`` or that count reaches the API's
+cap. Recursion continues down to a single day, where ambiguity aborts the fetch.
 
 No API key is required; federalregister.gov is fully open.
 """
@@ -34,6 +33,17 @@ API_BASE = "https://www.federalregister.gov/api/v1"
 # Max the API accepts per page. Windows are still subdivided on truncation, so
 # this is only a round-trip-count optimization, not a correctness knob.
 PER_PAGE = 1000
+
+# The API caps both pagination and its reported ``count`` at 10,000. A response
+# with exactly this count is therefore ambiguous and must be subdivided even
+# when all 10,000 visible rows were collected.
+RESULT_CAP = 10_000
+
+# Avoid paying for a capped 10,000-row traversal of the full archive before
+# discovering that it must be split. Quarter-sized top-level windows remain
+# below the cap in normal Federal Register history; unusually busy quarters are
+# still split recursively by ``_fetch_window``.
+MAX_WINDOW_DAYS = 90
 
 # FR's oldest documents. A full backfill with no prior table walks from here.
 FR_EPOCH = date(1994, 1, 1)
@@ -102,7 +112,14 @@ class FederalRegisterReader(Reader):
         logger.info("FR: fetching documents published {} .. {}", self.since, self.until)
         with httpx.Client(timeout=_TIMEOUT, headers={"Accept": "application/json"}) as client:
             self._client = client
-            yield from self._fetch_window(self.since, self.until)
+            window_start = self.since
+            while window_start <= self.until:
+                window_end = min(
+                    window_start + timedelta(days=MAX_WINDOW_DAYS - 1),
+                    self.until,
+                )
+                yield from self._fetch_window(window_start, window_end)
+                window_start = window_end + timedelta(days=1)
         logger.info("FR: yielded {:,} documents", self._seen)
 
     # -- window fetching -----------------------------------------------------
@@ -110,7 +127,8 @@ class FederalRegisterReader(Reader):
     def _fetch_window(self, gte: date, lte: date) -> Iterator[dict]:
         """Fetch one publication-date window, subdividing on truncation."""
         collected, count = self._page_window(gte, lte)
-        if len(collected) < count and gte < lte:
+        truncated = len(collected) < count or count >= RESULT_CAP
+        if truncated and gte < lte:
             # The API truncated this window; halve it and recurse so no document
             # in the range is lost.
             mid = gte + (lte - gte) // 2
@@ -121,10 +139,10 @@ class FederalRegisterReader(Reader):
             yield from self._fetch_window(gte, mid)
             yield from self._fetch_window(mid + timedelta(days=1), lte)
             return
-        if len(collected) < count:
-            # A single day still truncated — accept what we have, but make the
-            # gap loud rather than silent.
-            logger.warning("FR: single day {} truncated at {}/{} documents", gte, len(collected), count)
+        if truncated:
+            # A single day cannot be subdivided further. Publishing it would
+            # silently turn a transport/API limit into corpus data loss.
+            raise RuntimeError(f"Federal Register API truncated {gte} at {len(collected)}/{count} documents")
         for doc in collected:
             self._seen += 1
             if self._seen % _PROGRESS_EVERY == 0:
@@ -147,15 +165,13 @@ class FederalRegisterReader(Reader):
         while url:
             payload = self._get(url, params if first else None)
             first = False
-            if payload is None:
-                break
             count = payload.get("count", count)
             docs.extend(payload.get("results", []))
             url = payload.get("next_page_url") or ""
         return docs, count
 
-    def _get(self, url: str, params: dict | None) -> dict | None:
-        """GET with bounded retries + exponential backoff. Returns parsed JSON or None."""
+    def _get(self, url: str, params: dict | None) -> dict:
+        """GET with bounded retries; exhaustions abort the source snapshot."""
         assert self._client is not None
         for attempt in range(1, _MAX_RETRIES + 1):
             try:
@@ -166,9 +182,8 @@ class FederalRegisterReader(Reader):
                 return resp.json()
             except (httpx.HTTPError, ValueError) as exc:
                 if attempt == _MAX_RETRIES:
-                    logger.error("FR: giving up on {} after {} attempts: {}", url, attempt, exc)
-                    return None
+                    raise RuntimeError(f"Federal Register request failed after {attempt} attempts: {url}") from exc
                 backoff = min(2**attempt, 30)
                 logger.warning("FR: {} (attempt {}/{}), retrying in {}s", exc, attempt, _MAX_RETRIES, backoff)
                 time.sleep(backoff)
-        return None
+        raise AssertionError("unreachable")

--- a/tests/test_federal_register.py
+++ b/tests/test_federal_register.py
@@ -1,8 +1,8 @@
 """Hermetic tests for the Federal Register ingest (no network).
 
-Covers the two pieces with real logic: the raw-doc → published-schema mapping
-(``_shape``) and the date-window subdivision the reader uses to work around the
-API's per-query truncation.
+Covers the raw-doc → published-schema mapping (``_shape``), the date-window
+subdivision that works around the API's 10,000-result cap, and the refusal to
+publish once the HTTP retry budget runs out.
 """
 
 from __future__ import annotations
@@ -62,7 +62,7 @@ def test_shape_maps_and_serializes_fields():
     # Integer scalars stringify (schema is all-VARCHAR).
     assert row["volume"] == "89"
     assert row["start_page"] == "1234"
-    # Null passthrough, and modify_date is unknown from the REST API.
+    # Nulls pass through, and the REST API never reports modify_date.
     assert row["effective_on"] is None
     assert row["executive_order_number"] is None
     assert row["modify_date"] is None
@@ -81,11 +81,10 @@ def _doc(n: int, day: str) -> dict:
     return {"document_number": f"D{n}", "publication_date": day}
 
 
-# The two signals that make a window's contents unknowable, and so must force a
-# split: fewer rows than the reported ``count``, or a ``count`` sitting on the
-# API's cap (which clamps at 10,000 and hides the true total). ``result_cap``
-# is the value RESULT_CAP is set to for the case, so the cap case can be
-# written with 2 rows instead of 10,000.
+# The two signals that leave a window's contents unknowable, and so must force a
+# split: fewer rows than the reported ``count``, or a ``count`` sitting on the API
+# cap, which clamps at 10,000 and hides the true total. Each case patches
+# RESULT_CAP to its ``result_cap``, so the cap case needs 2 rows, not 10,000.
 _AMBIGUOUS_WINDOWS = [
     pytest.param(1, 2, federal_register_source.RESULT_CAP, id="rows-short-of-reported-count"),
     pytest.param(2, 2, 2, id="reported-count-at-api-cap"),
@@ -94,10 +93,10 @@ _AMBIGUOUS_WINDOWS = [
 
 @pytest.mark.parametrize(("rows", "count", "result_cap"), _AMBIGUOUS_WINDOWS)
 def test_ambiguous_window_subdivides_so_no_document_is_dropped(monkeypatch, rows, count, result_cap):
-    """An ambiguous multi-day window must split and recurse until days answer completely.
+    """An ambiguous multi-day window must keep splitting until single days answer completely.
 
-    The fake API is ambiguous for any multi-day window but returns each single
-    day's full (small) result set, so a correct reader recovers both documents.
+    The fake API answers ambiguously for every multi-day window but returns each
+    single day's full (tiny) result set, so a correct reader recovers both documents.
     """
     reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 1, 2))
     monkeypatch.setattr(federal_register_source, "RESULT_CAP", result_cap)
@@ -105,8 +104,9 @@ def test_ambiguous_window_subdivides_so_no_document_is_dropped(monkeypatch, rows
     def fake_page_window(gte: date, lte: date):
         if gte == lte:
             return [_doc(gte.day, gte.isoformat())], 1
-        # Rows from an ambiguous window must never reach the caller, so they are
-        # numbered apart: publishing them unsplit fails the assertion below.
+        # Rows from an ambiguous window must never reach the caller, so number them
+        # apart from the single-day rows. Otherwise a reader that yields the window
+        # unsplit returns the expected documents by coincidence and the test passes.
         return [_doc(900 + n, gte.isoformat()) for n in range(1, rows + 1)], count
 
     monkeypatch.setattr(reader, "_page_window", fake_page_window)
@@ -117,10 +117,10 @@ def test_ambiguous_window_subdivides_so_no_document_is_dropped(monkeypatch, rows
 
 @pytest.mark.parametrize(("rows", "count", "result_cap"), _AMBIGUOUS_WINDOWS)
 def test_ambiguous_single_day_refuses_instead_of_publishing_partial_data(monkeypatch, rows, count, result_cap):
-    """A single day cannot be subdivided further, so ambiguity there must abort the run.
+    """A single day cannot be split further, so ambiguity there must abort the run.
 
     This replaced a tolerant path that logged the gap and published the partial
-    page; without the refusal an API limit becomes silent corpus loss.
+    page. Without the refusal, an API limit becomes silent corpus loss.
     """
     reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 1, 1))
     monkeypatch.setattr(federal_register_source, "RESULT_CAP", result_cap)
@@ -137,9 +137,9 @@ def test_ambiguous_single_day_refuses_instead_of_publishing_partial_data(monkeyp
 def test_archive_fetch_uses_bounded_top_level_windows(monkeypatch):
     """Top-level windows must be capped in width *and* tile [since, until] exactly.
 
-    Width alone is not enough: a stride that skipped or repeated a day would
-    still produce narrow windows, so the gap/overlap check is what catches an
-    off-by-one in the walk.
+    Width alone missed an off-by-one: a stride of +2 days still yields narrow
+    windows while dropping every 91st day of the archive. Only the gap-and-overlap
+    assertion catches that.
     """
     reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 12, 31))
     windows: list[tuple[date, date]] = []

--- a/tests/test_federal_register.py
+++ b/tests/test_federal_register.py
@@ -8,7 +8,7 @@ API's per-query truncation.
 from __future__ import annotations
 
 import json
-from datetime import date
+from datetime import date, timedelta
 
 import httpx
 import pytest
@@ -81,21 +81,33 @@ def _doc(n: int, day: str) -> dict:
     return {"document_number": f"D{n}", "publication_date": day}
 
 
-def test_window_subdivides_on_truncation(monkeypatch):
-    """A truncated window must split and recurse so no document is dropped.
+# The two signals that make a window's contents unknowable, and so must force a
+# split: fewer rows than the reported ``count``, or a ``count`` sitting on the
+# API's cap (which clamps at 10,000 and hides the true total). ``result_cap``
+# is the value RESULT_CAP is set to for the case, so the cap case can be
+# written with 2 rows instead of 10,000.
+_AMBIGUOUS_WINDOWS = [
+    pytest.param(1, 2, federal_register_source.RESULT_CAP, id="rows-short-of-reported-count"),
+    pytest.param(2, 2, 2, id="reported-count-at-api-cap"),
+]
 
-    We simulate an API that returns only 1 of 2 documents for any multi-day
-    window, but the full set for a single day. The reader should recover all
-    documents by subdividing down to single days.
+
+@pytest.mark.parametrize(("rows", "count", "result_cap"), _AMBIGUOUS_WINDOWS)
+def test_ambiguous_window_subdivides_so_no_document_is_dropped(monkeypatch, rows, count, result_cap):
+    """An ambiguous multi-day window must split and recurse until days answer completely.
+
+    The fake API is ambiguous for any multi-day window but returns each single
+    day's full (small) result set, so a correct reader recovers both documents.
     """
     reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 1, 2))
+    monkeypatch.setattr(federal_register_source, "RESULT_CAP", result_cap)
 
     def fake_page_window(gte: date, lte: date):
         if gte == lte:
-            # Single day: return that day's full (small) result set.
             return [_doc(gte.day, gte.isoformat())], 1
-        # Multi-day window: report 2 total but only hand back 1 (truncated).
-        return [_doc(gte.day, gte.isoformat())], 2
+        # Rows from an ambiguous window must never reach the caller, so they are
+        # numbered apart: publishing them unsplit fails the assertion below.
+        return [_doc(900 + n, gte.isoformat()) for n in range(1, rows + 1)], count
 
     monkeypatch.setattr(reader, "_page_window", fake_page_window)
     # _fetch_window doesn't need the httpx client once _page_window is stubbed.
@@ -103,50 +115,32 @@ def test_window_subdivides_on_truncation(monkeypatch):
     assert sorted(got) == ["D1", "D2"]
 
 
-def test_single_day_truncation_aborts_instead_of_dropping_documents(monkeypatch):
+@pytest.mark.parametrize(("rows", "count", "result_cap"), _AMBIGUOUS_WINDOWS)
+def test_ambiguous_single_day_refuses_instead_of_publishing_partial_data(monkeypatch, rows, count, result_cap):
+    """A single day cannot be subdivided further, so ambiguity there must abort the run.
+
+    This replaced a tolerant path that logged the gap and published the partial
+    page; without the refusal an API limit becomes silent corpus loss.
+    """
     reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 1, 1))
+    monkeypatch.setattr(federal_register_source, "RESULT_CAP", result_cap)
     monkeypatch.setattr(
         reader,
         "_page_window",
-        lambda gte, lte: ([_doc(1, gte.isoformat())], 2),
+        lambda gte, lte: ([_doc(n, gte.isoformat()) for n in range(1, rows + 1)], count),
     )
 
-    with pytest.raises(RuntimeError, match="truncated"):
-        list(reader._fetch_window(date(2024, 1, 1), date(2024, 1, 1)))
-
-
-def test_reported_result_cap_subdivides_even_when_visible_rows_are_complete(monkeypatch):
-    reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 1, 2))
-    monkeypatch.setattr(federal_register_source, "RESULT_CAP", 2)
-
-    def fake_page_window(gte: date, lte: date):
-        if gte == lte:
-            return [_doc(gte.day, gte.isoformat())], 1
-        return [
-            _doc(1, "2024-01-01"),
-            _doc(2, "2024-01-02"),
-        ], 2
-
-    monkeypatch.setattr(reader, "_page_window", fake_page_window)
-
-    got = [d["document_number"] for d in reader._fetch_window(date(2024, 1, 1), date(2024, 1, 2))]
-    assert got == ["D1", "D2"]
-
-
-def test_capped_single_day_refuses_ambiguous_source_state(monkeypatch):
-    reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 1, 1))
-    monkeypatch.setattr(federal_register_source, "RESULT_CAP", 2)
-    monkeypatch.setattr(
-        reader,
-        "_page_window",
-        lambda gte, lte: ([_doc(1, gte.isoformat()), _doc(2, gte.isoformat())], 2),
-    )
-
-    with pytest.raises(RuntimeError, match="truncated.*2/2"):
+    with pytest.raises(RuntimeError, match=f"truncated.*{rows}/{count}"):
         list(reader._fetch_window(date(2024, 1, 1), date(2024, 1, 1)))
 
 
 def test_archive_fetch_uses_bounded_top_level_windows(monkeypatch):
+    """Top-level windows must be capped in width *and* tile [since, until] exactly.
+
+    Width alone is not enough: a stride that skipped or repeated a day would
+    still produce narrow windows, so the gap/overlap check is what catches an
+    off-by-one in the walk.
+    """
     reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 12, 31))
     windows: list[tuple[date, date]] = []
 
@@ -158,6 +152,9 @@ def test_archive_fetch_uses_bounded_top_level_windows(monkeypatch):
     assert list(reader.iter_records()) == []
     assert len(windows) > 1
     assert all((lte - gte).days < federal_register_source.MAX_WINDOW_DAYS for gte, lte in windows)
+    assert windows[0][0] == reader.since
+    assert windows[-1][1] == reader.until
+    assert all(nxt[0] == prev[1] + timedelta(days=1) for prev, nxt in zip(windows, windows[1:]))
 
 
 def test_request_exhaustion_aborts_instead_of_returning_partial_data(monkeypatch):

--- a/tests/test_federal_register.py
+++ b/tests/test_federal_register.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 import json
 from datetime import date
 
+import httpx
+import pytest
+
+from spicy_regs.sources import federal_register as federal_register_source
 from spicy_regs.sources.federal_register import FederalRegisterReader
 from spicy_regs.transforms.build_federal_register import COLUMNS, _shape
 
@@ -97,3 +101,74 @@ def test_window_subdivides_on_truncation(monkeypatch):
     # _fetch_window doesn't need the httpx client once _page_window is stubbed.
     got = [d["document_number"] for d in reader._fetch_window(date(2024, 1, 1), date(2024, 1, 2))]
     assert sorted(got) == ["D1", "D2"]
+
+
+def test_single_day_truncation_aborts_instead_of_dropping_documents(monkeypatch):
+    reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 1, 1))
+    monkeypatch.setattr(
+        reader,
+        "_page_window",
+        lambda gte, lte: ([_doc(1, gte.isoformat())], 2),
+    )
+
+    with pytest.raises(RuntimeError, match="truncated"):
+        list(reader._fetch_window(date(2024, 1, 1), date(2024, 1, 1)))
+
+
+def test_reported_result_cap_subdivides_even_when_visible_rows_are_complete(monkeypatch):
+    reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 1, 2))
+    monkeypatch.setattr(federal_register_source, "RESULT_CAP", 2)
+
+    def fake_page_window(gte: date, lte: date):
+        if gte == lte:
+            return [_doc(gte.day, gte.isoformat())], 1
+        return [
+            _doc(1, "2024-01-01"),
+            _doc(2, "2024-01-02"),
+        ], 2
+
+    monkeypatch.setattr(reader, "_page_window", fake_page_window)
+
+    got = [d["document_number"] for d in reader._fetch_window(date(2024, 1, 1), date(2024, 1, 2))]
+    assert got == ["D1", "D2"]
+
+
+def test_capped_single_day_refuses_ambiguous_source_state(monkeypatch):
+    reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 1, 1))
+    monkeypatch.setattr(federal_register_source, "RESULT_CAP", 2)
+    monkeypatch.setattr(
+        reader,
+        "_page_window",
+        lambda gte, lte: ([_doc(1, gte.isoformat()), _doc(2, gte.isoformat())], 2),
+    )
+
+    with pytest.raises(RuntimeError, match="truncated.*2/2"):
+        list(reader._fetch_window(date(2024, 1, 1), date(2024, 1, 1)))
+
+
+def test_archive_fetch_uses_bounded_top_level_windows(monkeypatch):
+    reader = FederalRegisterReader(since=date(2024, 1, 1), until=date(2024, 12, 31))
+    windows: list[tuple[date, date]] = []
+
+    def fake_fetch_window(gte: date, lte: date):
+        windows.append((gte, lte))
+        return iter(())
+
+    monkeypatch.setattr(reader, "_fetch_window", fake_fetch_window)
+    assert list(reader.iter_records()) == []
+    assert len(windows) > 1
+    assert all((lte - gte).days < federal_register_source.MAX_WINDOW_DAYS for gte, lte in windows)
+
+
+def test_request_exhaustion_aborts_instead_of_returning_partial_data(monkeypatch):
+    reader = FederalRegisterReader()
+
+    class FailingClient:
+        def get(self, url, params=None):
+            raise httpx.ConnectError("offline")
+
+    monkeypatch.setattr(reader, "_client", FailingClient())
+    monkeypatch.setattr(federal_register_source, "_MAX_RETRIES", 1)
+
+    with pytest.raises(RuntimeError, match="request failed after 1 attempts"):
+        reader._get("https://example.test/documents.json", None)


### PR DESCRIPTION
The Federal Register API silently caps every query at 10,000 results — including the "how many are there" count it reports back. Our importer used that count to tell whether it had received a complete answer, so it could never detect the cap: it asked for the whole archive, got 10,000 documents and a count of 10,000, and concluded it was done. The archive actually holds about 1,007,000 documents, so a full rebuild would have published roughly 1% of the Federal Register and reported success. This changes the importer to pull in quarter-year slices, split any slice that comes back at the cap, and stop with an error rather than publish a partial day. Worth flagging for operations: this source will now fail loudly where it previously succeeded quietly — a failed run is recoverable, a silently truncated publish is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)