### PR TITLE
fix(r2): preflight data before advancing the manifest

### DIFF
--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -11,10 +11,11 @@ This is also the run file. Invoke it via the ``run-pipeline`` console script::
     2. Extract → stage  — ``stage_agencies`` fans agencies out in parallel; each
        record stream flows Mirrulations Reader (raw JSON) -> ExtractRecords
        transform (flatten) -> StagingWriter (local Parquet).
-    3. Merge      — per-agency staging Parquet is merged + deduplicated (a bulk,
-       whole-dataset transform).
-    4. Load       — the Manifest is persisted and the dataset published to R2
-       (upload is off by default while this path is being vetted).
+    3. Merge      — merge and deduplicate the per-agency staging Parquet in one
+       whole-dataset transform.
+    4. Load       — save the Manifest, then publish to R2 (``_publish``, which
+       advances the manifest strictly last). Publishing stays off until this
+       path is vetted; pass ``--no-skip-upload`` to turn it on.
 
 The reusable pieces live elsewhere: connection details + the reader factory in
 ``sources.mirrulations``, the json→record transform in ``transforms.extract``,
@@ -95,10 +96,9 @@ class RegulationsPipeline(Pipeline):
         record_types = self._record_types()
         agencies = self._agencies()
 
-        # Chunked comments path: for an agency too large to buffer whole (millions
-        # of comments would OOM), ingest its comments in bounded key-chunks,
-        # committing each into the catalog. Only meaningful for the iceberg
-        # comments-only case (the catalog is a row-level upsert surface).
+        # Chunked comments path (see _ingest_comments_chunked). Only the Iceberg
+        # comments-only case can use it: the catalog is a row-level upsert
+        # surface, so each chunk commits on its own.
         if self.chunk_size and self.only_comments and self.use_iceberg:
             manifest = Manifest.empty() if self.full_refresh else Manifest.load(output_dir)
             for agency in agencies:
@@ -184,11 +184,13 @@ class RegulationsPipeline(Pipeline):
     ) -> None:
         """Publish this run's output to R2, advancing the manifest strictly last.
 
-        ``manifest.parquet`` is the retry checkpoint: republishing it retires the
-        keys this run consumed, so it must not land while a data file is still
-        unpublished or the next run will never re-fetch what went missing. Every
-        planned object is therefore size-guarded up front, and the manifest is
-        uploaded only once every data upload has returned.
+        ``manifest.parquet`` is the restart checkpoint: a fresh workspace pulls
+        it from R2 and skips every key it lists, so publishing it retires the
+        work this run consumed. Publish it while a data file is still missing
+        and the next run skips those keys as already processed — the rows stay
+        missing from the bucket until a ``--full-refresh``. So every planned
+        object clears its size guard first, and the manifest uploads last, once
+        every data upload has returned.
         """
         base_data_types = [rt.name for rt in record_types if rt.name != "comments"]
         index_file = output_dir / "comments_index.parquet"
@@ -199,8 +201,8 @@ class RegulationsPipeline(Pipeline):
         publish_index = bool(changed_comments) or (self.use_iceberg and staged.get("comments", 0) > 0)
         if publish_index and not index_file.exists():
             raise RuntimeError("Expected comments_index.parquet after publishing comment data")
-        # Manifest.save only writes when this run recorded keys; without a
-        # checkpoint to advance there is nothing to publish last.
+        # Manifest.save writes only when this run recorded keys, so a missing
+        # file means there is no checkpoint to advance.
         publish_manifest = manifest_file.exists()
 
         planned = r2.dataset_files(output_dir, base_data_types) + changed_comments
@@ -210,6 +212,8 @@ class RegulationsPipeline(Pipeline):
             planned.append(manifest_file)
         r2.preflight_uploads(output_dir, planned)
 
+        # Redundant-looking, but --only-comments leaves base_data_types empty and
+        # upload_dataset would log a misleading "no files to publish" warning.
         if base_data_types:
             r2.upload_dataset(output_dir, base_data_types)
         # Comments are partitioned, not monolithic: publish the partitions
@@ -228,10 +232,9 @@ class RegulationsPipeline(Pipeline):
         """Ingest one agency's comments in bounded key-chunks, committing each.
 
         Downloads at most ``chunk_size`` comment files at a time, stages them,
-        MERGEs them into the catalog, then frees memory before the next chunk —
-        so a multi-million-comment agency (which would otherwise buffer every
-        record and OOM) ingests in even, durable pieces. Deleting the staging
-        chunk between iterations keeps peak memory ~one chunk.
+        MERGEs them into the catalog, then deletes the staging chunk — so peak
+        memory stays at about one chunk and a multi-million-comment agency, which
+        would otherwise buffer every record and OOM, ingests in durable pieces.
         """
         comment_rt = RECORD_TYPES["comments"]
         resource = mirrulations.s3_resource()
@@ -343,8 +346,6 @@ class RegulationsPipeline(Pipeline):
         """
         for rt in record_types:
             if rt.name == "comments":
-                # Partitions are fetched on demand at merge, but the index is
-                # global — prime it so the rebuild keeps untouched partitions.
                 index_file = output_dir / "comments_index.parquet"
                 if not index_file.exists():
                     r2.download("comments_index.parquet", index_file)

--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -171,43 +171,58 @@ class RegulationsPipeline(Pipeline):
             logger.info("skip_upload=True — output left in {}", output_dir)
         elif any(staged.values()):
             logger.info("Uploading to R2...")
-            base_data_types = [rt.name for rt in record_types if rt.name != "comments"]
-            files_to_preflight = [
-                (output_dir / f"{data_type}.parquet", f"{data_type}.parquet")
-                for data_type in base_data_types
-                if (output_dir / f"{data_type}.parquet").exists()
-            ]
-            files_to_preflight.extend((path, str(path.relative_to(output_dir))) for path in changed_comments)
-            index_file = output_dir / "comments_index.parquet"
-            publish_comments_index = bool(changed_comments) or (self.use_iceberg and staged.get("comments", 0) > 0)
-            if publish_comments_index and not index_file.exists():
-                raise RuntimeError("Expected comments_index.parquet after publishing comment data")
-            if publish_comments_index:
-                files_to_preflight.append((index_file, "comments_index.parquet"))
-            manifest_file = output_dir / "manifest.parquet"
-            if manifest_file.exists():
-                files_to_preflight.append((manifest_file, "manifest.parquet"))
-
-            r2.preflight_uploads(files_to_preflight)
-            if base_data_types:
-                r2.upload_dataset(output_dir, base_data_types)
-            # Comments are partitioned, not monolithic: publish the partitions
-            # changed this run plus the refreshed index.
-            if changed_comments:
-                logger.info("Uploading {} changed comment partitions...", len(changed_comments))
-                r2.upload_comment_partitions(output_dir, changed_comments)
-            # Iceberg comments path: the MERGE wrote the rows through the catalog
-            # (not under the public comments/ prefix), so there are no partition
-            # files to push — only the refreshed index needs publishing.
-            elif publish_comments_index:
-                if index_file.exists():
-                    logger.info("Uploading refreshed comments index (Iceberg path)...")
-                    r2.upload_file(index_file, remote_key="comments_index.parquet")
-            if manifest_file.exists():
-                logger.info("Uploading manifest after all data files succeeded...")
-                r2.upload_file(manifest_file, remote_key="manifest.parquet")
+            self._publish(output_dir, record_types, staged, changed_comments)
 
         logger.info("Done!")
+
+    def _publish(
+        self,
+        output_dir: Path,
+        record_types: list[RecordType],
+        staged: dict[str, int],
+        changed_comments: list[Path],
+    ) -> None:
+        """Publish this run's output to R2, advancing the manifest strictly last.
+
+        ``manifest.parquet`` is the retry checkpoint: republishing it retires the
+        keys this run consumed, so it must not land while a data file is still
+        unpublished or the next run will never re-fetch what went missing. Every
+        planned object is therefore size-guarded up front, and the manifest is
+        uploaded only once every data upload has returned.
+        """
+        base_data_types = [rt.name for rt in record_types if rt.name != "comments"]
+        index_file = output_dir / "comments_index.parquet"
+        manifest_file = output_dir / "manifest.parquet"
+        # The Iceberg comments path MERGEs rows through the catalog rather than
+        # under the public comments/ prefix, so it changes no partition files —
+        # only the refreshed index needs publishing.
+        publish_index = bool(changed_comments) or (self.use_iceberg and staged.get("comments", 0) > 0)
+        if publish_index and not index_file.exists():
+            raise RuntimeError("Expected comments_index.parquet after publishing comment data")
+        # Manifest.save only writes when this run recorded keys; without a
+        # checkpoint to advance there is nothing to publish last.
+        publish_manifest = manifest_file.exists()
+
+        planned = r2.dataset_files(output_dir, base_data_types) + changed_comments
+        if publish_index:
+            planned.append(index_file)
+        if publish_manifest:
+            planned.append(manifest_file)
+        r2.preflight_uploads(output_dir, planned)
+
+        if base_data_types:
+            r2.upload_dataset(output_dir, base_data_types)
+        # Comments are partitioned, not monolithic: publish the partitions
+        # changed this run plus the refreshed index.
+        if changed_comments:
+            logger.info("Uploading {} changed comment partitions...", len(changed_comments))
+            r2.upload_comment_partitions(output_dir, changed_comments)
+        elif publish_index:
+            logger.info("Uploading refreshed comments index (Iceberg path)...")
+            r2.upload_file(index_file, remote_key="comments_index.parquet")
+        if publish_manifest:
+            logger.info("Uploading manifest after all data files succeeded...")
+            r2.upload_file(manifest_file, remote_key="manifest.parquet")
 
     def _ingest_comments_chunked(self, agency: str, output_dir: Path, staging_dir: Path, manifest: Manifest) -> None:
         """Ingest one agency's comments in bounded key-chunks, committing each.

--- a/src/spicy_regs/pipelines/regulations.py
+++ b/src/spicy_regs/pipelines/regulations.py
@@ -171,7 +171,26 @@ class RegulationsPipeline(Pipeline):
             logger.info("skip_upload=True — output left in {}", output_dir)
         elif any(staged.values()):
             logger.info("Uploading to R2...")
-            r2.upload_dataset(output_dir, [rt.name for rt in record_types if rt.name != "comments"])
+            base_data_types = [rt.name for rt in record_types if rt.name != "comments"]
+            files_to_preflight = [
+                (output_dir / f"{data_type}.parquet", f"{data_type}.parquet")
+                for data_type in base_data_types
+                if (output_dir / f"{data_type}.parquet").exists()
+            ]
+            files_to_preflight.extend((path, str(path.relative_to(output_dir))) for path in changed_comments)
+            index_file = output_dir / "comments_index.parquet"
+            publish_comments_index = bool(changed_comments) or (self.use_iceberg and staged.get("comments", 0) > 0)
+            if publish_comments_index and not index_file.exists():
+                raise RuntimeError("Expected comments_index.parquet after publishing comment data")
+            if publish_comments_index:
+                files_to_preflight.append((index_file, "comments_index.parquet"))
+            manifest_file = output_dir / "manifest.parquet"
+            if manifest_file.exists():
+                files_to_preflight.append((manifest_file, "manifest.parquet"))
+
+            r2.preflight_uploads(files_to_preflight)
+            if base_data_types:
+                r2.upload_dataset(output_dir, base_data_types)
             # Comments are partitioned, not monolithic: publish the partitions
             # changed this run plus the refreshed index.
             if changed_comments:
@@ -180,11 +199,13 @@ class RegulationsPipeline(Pipeline):
             # Iceberg comments path: the MERGE wrote the rows through the catalog
             # (not under the public comments/ prefix), so there are no partition
             # files to push — only the refreshed index needs publishing.
-            elif self.use_iceberg and staged.get("comments", 0) > 0:
-                index_file = output_dir / "comments_index.parquet"
+            elif publish_comments_index:
                 if index_file.exists():
                     logger.info("Uploading refreshed comments index (Iceberg path)...")
                     r2.upload_file(index_file, remote_key="comments_index.parquet")
+            if manifest_file.exists():
+                logger.info("Uploading manifest after all data files succeeded...")
+                r2.upload_file(manifest_file, remote_key="manifest.parquet")
 
         logger.info("Done!")
 

--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -333,13 +333,18 @@ def upload_dataset(output_dir: Path, data_types: list[str]) -> None:
 
 
 def upload_comment_partitions(output_dir: Path, changed_files: list[Path]) -> None:
-    """Publish the changed comment partitions, then the refreshed comments index."""
+    """Publish the changed comment partitions, then the refreshed comments index.
+
+    Refuses before the first upload if the index is missing: partitions the
+    index cannot see are rows nobody can find.
+    """
+    index_file = output_dir / "comments_index.parquet"
+    if not index_file.exists():
+        raise RuntimeError("Expected comments_index.parquet beside the changed partitions")
+
     for local_path in changed_files:
         upload_file(local_path, remote_key=_remote_key(output_dir, local_path))
-
-    index_file = output_dir / "comments_index.parquet"
-    if index_file.exists():
-        upload_file(index_file, remote_key="comments_index.parquet")
+    upload_file(index_file, remote_key="comments_index.parquet")
 
     logger.info("Uploaded {} comment partitions + index", len(changed_files))
 

--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -147,6 +147,38 @@ def _assert_upload_safe(
         )
 
 
+def preflight_uploads(files_to_upload: list[tuple[Path, str]]) -> None:
+    """Run every size guard before a multi-file publication starts.
+
+    This closes the predictable partial-publication path where one worker can
+    replace an object before another worker discovers that its local file would
+    catastrophically shrink production. Transfers can still fail after the
+    preflight, so callers must keep the manifest unchanged unless every data
+    file upload succeeds.
+    """
+    if not getenv("R2_ACCESS_KEY_ID"):
+        return
+
+    bucket = getenv("R2_BUCKET_NAME", "spicy-regs")
+    client = get_r2_client()
+    failures: list[tuple[str, Exception]] = []
+
+    for local_path, remote_key in files_to_upload:
+        try:
+            remote_size = _get_remote_size(client, bucket, remote_key)
+            _assert_upload_safe(local_path.stat().st_size, remote_size, remote_key)
+        except Exception as error:
+            failures.append((remote_key, error))
+
+    if failures:
+        for remote_key, error in failures:
+            logger.error("Publication preflight failed for {}: {}", remote_key, error)
+        names = ", ".join(sorted(remote_key for remote_key, _ in failures))
+        raise RuntimeError(
+            f"Publication preflight failed for {len(failures)} of {len(files_to_upload)} file(s): {names}"
+        ) from failures[0][1]
+
+
 def upload_file(local_path: Path, remote_key: str | None = None) -> None:
     """Publish a single file to R2 (remote key defaults to the filename).
 
@@ -226,7 +258,7 @@ def upload_directory_to_r2(local_dir: Path, remote_prefix: str | None = None) ->
 
 
 def upload_dataset(output_dir: Path, data_types: list[str]) -> None:
-    """Publish the merged ``{data_type}.parquet`` base tables (+ manifest) in parallel.
+    """Publish merged base tables in parallel.
 
     Rollups (feed_summary, agency_stats, ...) are no longer published here — each
     is built and uploaded by its own decoupled ``run-rollup-*`` pipeline.
@@ -242,38 +274,46 @@ def upload_dataset(output_dir: Path, data_types: list[str]) -> None:
     instead of ~276k) while the workflow stayed green and the published table sat
     frozen at 2026-07-02.
 
-    Failures are collected rather than raised on the first one, so a broken table
-    can never hide a second broken table behind it.
+    The size guard is preflighted for every candidate before any upload starts.
+    Failures are then collected rather than raised on the first transfer, so a
+    broken table can never hide a second broken table behind it.
+
+    R2 fixed object keys do not provide an atomic multi-object commit. This
+    ordering prevents known guard failures from publishing anything; it does not
+    make the base table uploads atomic against network or service failures. The
+    caller owns publishing ``manifest.parquet`` only after every base and
+    partitioned data file succeeds.
     """
-    files_to_upload = []
+    base_files = []
     for data_type in data_types:
         pf = output_dir / f"{data_type}.parquet"
         if pf.exists():
-            files_to_upload.append(pf)
+            base_files.append(pf)
 
-    manifest_file = output_dir / "manifest.parquet"
-    if manifest_file.exists():
-        files_to_upload.append(manifest_file)
+    files_to_preflight = [(path, path.name) for path in base_files]
 
     # ThreadPoolExecutor rejects max_workers=0, so an empty publish set would
     # otherwise raise ValueError rather than being the no-op it should be.
-    if not files_to_upload:
+    if not files_to_preflight:
         logger.warning("upload_dataset: no files to publish in {}", output_dir)
         return
 
+    preflight_uploads(files_to_preflight)
+
     failures: list[tuple[Path, BaseException]] = []
-    with ThreadPoolExecutor(max_workers=len(files_to_upload)) as executor:
-        futures = {executor.submit(upload_file, pf): pf for pf in files_to_upload}
-        for future in as_completed(futures):
-            if (error := future.exception()) is not None:
-                failures.append((futures[future], error))
+    if base_files:
+        with ThreadPoolExecutor(max_workers=len(base_files)) as executor:
+            futures = {executor.submit(upload_file, pf): pf for pf in base_files}
+            for future in as_completed(futures):
+                if (error := future.exception()) is not None:
+                    failures.append((futures[future], error))
 
     if failures:
         for path, error in failures:
             logger.error("Failed to publish {}: {}", path.name, error)
         names = ", ".join(sorted(path.name for path, _ in failures))
         raise RuntimeError(
-            f"Failed to publish {len(failures)} of {len(files_to_upload)} file(s) to R2: {names}"
+            f"Failed to publish {len(failures)} of {len(base_files)} base file(s) to R2: {names}"
         ) from failures[0][1]
 
 

--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -1,17 +1,14 @@
-"""Cloudflare R2 storage connector.
+"""Cloudflare R2 storage connector — both bookends of an incremental run.
 
-The project's single home for R2 — both bookends of an incremental run: pulling
-existing datasets down so a run can append to them (:func:`download_from_r2`),
-and publishing finished Parquet, partitions, and the manifest back to the bucket
-(:func:`upload_file` / :func:`upload_dataset` / :func:`upload_comment_partitions`).
-This lets a pipeline treat "load" as one composable stage instead of reaching
-into storage internals.
+:func:`download_from_r2` pulls existing datasets down so a run can append to
+them. :func:`upload_file`, :func:`upload_dataset`, and
+:func:`upload_comment_partitions` publish the finished Parquet back.
 
 Downloads use the public ``R2_PUBLIC_URL`` over HTTPS; uploads use the S3 API
-with ``R2_*`` credentials. Uploads are guarded against catastrophic shrink (see
-:func:`_assert_upload_safe`) — the safeguard added after the March 2026 incident
-where a transient download error produced an empty local file that overwrote the
-3.3 GB historical ``comments.parquet`` on R2.
+with ``R2_*`` credentials. Every upload clears a shrink guard
+(:func:`_assert_upload_safe`), added after the March 2026 incident: a transient
+download error produced an empty local file, and the upload overwrote the
+historical 3.3 GB ``comments.parquet``.
 """
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -29,23 +26,20 @@ from spicy_regs.sources.cloudflare import purge_urls
 
 
 def download_from_r2(remote_key: str, local_path: Path) -> bool:
-    """Download a file from R2 bucket using the public URL.
+    """Download one object from R2 over the public URL.
 
-    Returns ``True`` if the file was downloaded, ``False`` if R2 is not
-    configured or the file does not exist on R2 (HTTP 404). Any other
-    error — 5xx responses, network failures, disk write errors — raises.
+    Returns ``True`` on success, ``False`` when R2 is unconfigured or the object
+    is missing (HTTP 404). Everything else — 5xx, network failures, disk write
+    errors — raises.
 
-    Silent failures here caused the March 2026 data-loss incident: a
-    transient download error on the 3.3 GB ``comments.parquet`` returned
-    ``False``, the merge step then wrote a fresh empty file, and the
-    upload step overwrote the historical data on R2. Raising forces the
-    pipeline to abort before the upload step instead of continuing with
-    an empty input.
+    Returning ``False`` for the rest caused the March 2026 data loss: a
+    transient error on the 3.3 GB ``comments.parquet`` read as "absent", the
+    merge wrote a fresh empty file, and the upload overwrote the history.
+    Raising aborts the run before it can publish an empty table.
 
-    The download is atomic: bytes are streamed to ``{local_path}.tmp``
-    and the temp file is renamed into place only after a successful
-    transfer. On any failure, the temp file is removed and any
-    pre-existing file at ``local_path`` is left untouched.
+    The download is atomic: bytes stream to ``{local_path}.tmp``, which is
+    renamed into place only after a complete transfer. Any failure deletes the
+    temp file and leaves an existing ``local_path`` untouched.
     """
     public_url = getenv("R2_PUBLIC_URL")
     if not public_url:
@@ -95,12 +89,11 @@ def get_r2_client():
 
 
 def _get_remote_size(client, bucket: str, remote_key: str) -> int | None:
-    """Return the existing R2 object size in bytes, or None if absent.
+    """Return the remote object's size in bytes, or ``None`` when it is absent.
 
-    Any other error (permissions, transient 5xx) propagates — callers
-    must not guess at whether the remote object exists, since the
-    upload guard depends on a correct answer to decide if a shrink is
-    catastrophic.
+    Permissions and transient 5xx errors propagate: the shrink guard skips its
+    check when nothing is there, so a guessed absence would wave every upload
+    through.
     """
     from botocore.exceptions import ClientError
 
@@ -150,9 +143,8 @@ def _assert_upload_safe(
 def _raise_for_failures(action: str, failures: list[tuple[str, BaseException]], total: int) -> None:
     """Log every failure, then raise one error naming them all.
 
-    Collecting instead of raising on the first failure keeps one broken file
-    from hiding a second broken file behind it — the whole point of awaiting
-    every outcome (see :func:`upload_dataset`).
+    Collecting rather than raising on the first keeps one broken file from
+    hiding the next behind it (see :func:`upload_dataset`).
     """
     if not failures:
         return
@@ -174,23 +166,29 @@ def _remote_key(output_dir: Path, local_path: Path) -> str:
 def dataset_files(output_dir: Path, data_types: list[str]) -> list[Path]:
     """The base-table ``{data_type}.parquet`` files that exist under ``output_dir``.
 
-    Shared so a caller can preflight or plan around exactly the set
-    :func:`upload_dataset` will publish, rather than rebuilding it.
+    Shared so a caller plans over exactly the set :func:`upload_dataset`
+    publishes instead of rebuilding it.
     """
     return [pf for data_type in data_types if (pf := output_dir / f"{data_type}.parquet").exists()]
 
 
 def preflight_uploads(output_dir: Path, files: list[Path]) -> None:
-    """Run every size guard before a multi-file publication writes its first byte.
+    """HEAD every planned object and run its size guard before the first byte lands.
 
-    Each file is keyed by its path relative to ``output_dir`` — the same
-    derivation :func:`upload_comment_partitions` uses to publish partitions.
+    One worker used to replace its object while a sibling was still discovering
+    that its own local file would catastrophically shrink production. Guarding
+    the whole set first makes that refusal stop the publication before it starts.
+    Each file is keyed by its path relative to ``output_dir``, the derivation
+    :func:`upload_comment_partitions` publishes under. Without R2 credentials
+    this is a no-op, like :func:`upload_file`.
 
-    This closes the predictable partial-publication path where one worker can
-    replace an object before another worker discovers that its local file would
-    catastrophically shrink production. Transfers can still fail after the
-    preflight, so callers must keep the manifest unchanged unless every data
-    file upload succeeds.
+    A transfer can still fail after a clean preflight, so callers must leave the
+    manifest unpublished until every data upload succeeds.
+
+    Costs one serial HEAD per file, and :func:`upload_file` HEADs each again:
+    2N round-trips where it was N. N is unbounded for comment partitions, so
+    profile this loop first when a comment-heavy run drags — the fix is a
+    fixed-width thread pool, not ``max_workers=len(files)``.
     """
     if not getenv("R2_ACCESS_KEY_ID"):
         return
@@ -211,13 +209,11 @@ def preflight_uploads(output_dir: Path, files: list[Path]) -> None:
 
 
 def upload_file(local_path: Path, remote_key: str | None = None) -> None:
-    """Publish a single file to R2 (remote key defaults to the filename).
+    """Publish one file to R2 (the remote key defaults to the filename).
 
-    Before overwriting an existing remote object, checks the current
-    size and refuses to proceed if the new file is much smaller (see
-    :func:`_assert_upload_safe`). This guards against the failure mode
-    where an upstream error produces a near-empty local file that
-    would otherwise silently wipe production data.
+    HEADs the existing object first and refuses to overwrite it with a much
+    smaller one (:func:`_assert_upload_safe`), so an upstream error that
+    produced a near-empty local file cannot wipe production.
     """
     bucket = getenv("R2_BUCKET_NAME", "spicy-regs")
 
@@ -237,14 +233,14 @@ def upload_file(local_path: Path, remote_key: str | None = None) -> None:
     remote_size = _get_remote_size(client, bucket, remote_key)
     _assert_upload_safe(local_size_bytes, remote_size, remote_key)
 
-    # Cache-Control policy. Parquet MUST NOT be edge-cached: DuckDB (both the MCP
-    # server and the browser DuckDB-WASM UI) reads each file via many byte-range
-    # requests, and an edge cache serving inconsistent bytes across those ranges
-    # under concurrent load corrupts the read — observed as `utf-8 codec can't
-    # decode` / ETag-mismatch failures at ~c=10+. (This is why parquet was
-    # `no-cache` originally; a caching experiment reintroduced the corruption and
-    # was reverted.) Non-parquet artifacts (e.g. the UI MiniSearch json.gz, which
-    # is not read by DuckDB) may still be edge-cached. `R2_CACHE_CONTROL` overrides.
+    # Cache-Control policy. Parquet must never be edge-cached: DuckDB (the MCP
+    # server and the browser DuckDB-WASM UI) reads each file through many
+    # byte-range requests, and an edge cache serving inconsistent bytes across
+    # those ranges under concurrent load corrupts the read — `utf-8 codec can't
+    # decode` and ETag mismatches at ~c=10+. Parquet was `no-cache` originally; a
+    # caching experiment brought the corruption back and was reverted. Everything
+    # else (the UI MiniSearch json.gz, which DuckDB never reads) caches safely.
+    # `R2_CACHE_CONTROL` overrides.
     configured_cache_control = getenv("R2_CACHE_CONTROL")
     cache_control = configured_cache_control or (
         "public, no-cache, must-revalidate"
@@ -289,33 +285,32 @@ def upload_directory_to_r2(local_dir: Path, remote_prefix: str | None = None) ->
 
 
 def upload_dataset(output_dir: Path, data_types: list[str]) -> None:
-    """Publish merged base tables in parallel.
-
-    Rollups (feed_summary, agency_stats, ...) are no longer published here — each
-    is built and uploaded by its own decoupled ``run-rollup-*`` pipeline.
-
-    Every upload is awaited and its outcome inspected. This used to be a bare
-    ``executor.map(upload_file, files_to_upload)`` whose return value was
-    discarded — and ``map`` yields a *lazy* iterator, so an exception raised in a
-    worker is only re-raised when the results are consumed. Nothing consumed
-    them, so every publish failure was swallowed and the ETL still exited 0.
-    That masked an 8-week ``dockets`` outage: the shrink guard was correctly
-    refusing a truncated ``dockets.parquet`` on every single run (the Iceberg
-    dockets table was never seeded, so the exported snapshot held ~5k rows
-    instead of ~276k) while the workflow stayed green and the published table sat
-    frozen at 2026-07-02.
+    """Publish the merged base tables in parallel.
 
     Every size guard runs before the first upload starts, so a table this run
     would refuse cannot land after a sibling has already been replaced. The
-    pipeline caller preflights a superset (partitions, index, manifest) first;
-    re-checking here is a few HEAD requests and keeps this function safe for any
-    other caller.
+    pipeline caller preflights a superset (partitions, index, manifest) first,
+    and re-checking here is deliberate rather than an oversight: this function
+    fans out to a thread pool, so its own preflight is what stops one table
+    landing while a sibling is refused. The base tables number two, so it costs
+    two HEAD requests.
 
-    R2 fixed object keys do not provide an atomic multi-object commit. This
-    ordering prevents known guard failures from publishing anything; it does not
-    make the base table uploads atomic against network or service failures. The
-    caller owns publishing ``manifest.parquet`` only after every base and
-    partitioned data file succeeds.
+    Fixed object keys give R2 no atomic multi-object commit. This ordering keeps
+    a known guard failure from publishing anything; the transfers themselves
+    stay exposed to a network or service failure mid-flight. So the caller
+    publishes ``manifest.parquet`` only after every base and partitioned data
+    file has succeeded.
+
+    Every upload is awaited and its outcome inspected. A bare
+    ``executor.map(upload_file, ...)`` whose lazy iterator nobody consumed used
+    to swallow every publish failure while the ETL exited 0, hiding an 8-week
+    ``dockets`` outage: the shrink guard rightly refused a truncated
+    ``dockets.parquet`` on every run (the Iceberg dockets table was never
+    seeded, so the exported snapshot held ~5k rows instead of ~276k) while the
+    workflow stayed green and the published table sat frozen at 2026-07-02.
+
+    Rollups (feed_summary, agency_stats, ...) belong to their own decoupled
+    ``run-rollup-*`` pipelines now.
     """
     base_files = dataset_files(output_dir, data_types)
 
@@ -338,7 +333,7 @@ def upload_dataset(output_dir: Path, data_types: list[str]) -> None:
 
 
 def upload_comment_partitions(output_dir: Path, changed_files: list[Path]) -> None:
-    """Publish changed comment partition files and the comments index to R2."""
+    """Publish the changed comment partitions, then the refreshed comments index."""
     for local_path in changed_files:
         upload_file(local_path, remote_key=_remote_key(output_dir, local_path))
 

--- a/src/spicy_regs/sources/r2.py
+++ b/src/spicy_regs/sources/r2.py
@@ -147,8 +147,44 @@ def _assert_upload_safe(
         )
 
 
-def preflight_uploads(files_to_upload: list[tuple[Path, str]]) -> None:
-    """Run every size guard before a multi-file publication starts.
+def _raise_for_failures(action: str, failures: list[tuple[str, BaseException]], total: int) -> None:
+    """Log every failure, then raise one error naming them all.
+
+    Collecting instead of raising on the first failure keeps one broken file
+    from hiding a second broken file behind it — the whole point of awaiting
+    every outcome (see :func:`upload_dataset`).
+    """
+    if not failures:
+        return
+    for name, error in failures:
+        logger.error("{} failed for {}: {}", action, name, error)
+    names = ", ".join(sorted(name for name, _ in failures))
+    raise RuntimeError(f"{action} failed for {len(failures)} of {total} file(s): {names}") from failures[0][1]
+
+
+def _remote_key(output_dir: Path, local_path: Path) -> str:
+    """The object key a file published from ``output_dir`` lands under.
+
+    One definition so the preflight guards exactly the key the upload writes;
+    two derivations that drifted would silently check the wrong object.
+    """
+    return str(local_path.relative_to(output_dir))
+
+
+def dataset_files(output_dir: Path, data_types: list[str]) -> list[Path]:
+    """The base-table ``{data_type}.parquet`` files that exist under ``output_dir``.
+
+    Shared so a caller can preflight or plan around exactly the set
+    :func:`upload_dataset` will publish, rather than rebuilding it.
+    """
+    return [pf for data_type in data_types if (pf := output_dir / f"{data_type}.parquet").exists()]
+
+
+def preflight_uploads(output_dir: Path, files: list[Path]) -> None:
+    """Run every size guard before a multi-file publication writes its first byte.
+
+    Each file is keyed by its path relative to ``output_dir`` — the same
+    derivation :func:`upload_comment_partitions` uses to publish partitions.
 
     This closes the predictable partial-publication path where one worker can
     replace an object before another worker discovers that its local file would
@@ -161,22 +197,17 @@ def preflight_uploads(files_to_upload: list[tuple[Path, str]]) -> None:
 
     bucket = getenv("R2_BUCKET_NAME", "spicy-regs")
     client = get_r2_client()
-    failures: list[tuple[str, Exception]] = []
+    failures: list[tuple[str, BaseException]] = []
 
-    for local_path, remote_key in files_to_upload:
+    for local_path in files:
+        remote_key = _remote_key(output_dir, local_path)
         try:
             remote_size = _get_remote_size(client, bucket, remote_key)
             _assert_upload_safe(local_path.stat().st_size, remote_size, remote_key)
         except Exception as error:
             failures.append((remote_key, error))
 
-    if failures:
-        for remote_key, error in failures:
-            logger.error("Publication preflight failed for {}: {}", remote_key, error)
-        names = ", ".join(sorted(remote_key for remote_key, _ in failures))
-        raise RuntimeError(
-            f"Publication preflight failed for {len(failures)} of {len(files_to_upload)} file(s): {names}"
-        ) from failures[0][1]
+    _raise_for_failures("Publication preflight", failures, len(files))
 
 
 def upload_file(local_path: Path, remote_key: str | None = None) -> None:
@@ -274,9 +305,11 @@ def upload_dataset(output_dir: Path, data_types: list[str]) -> None:
     instead of ~276k) while the workflow stayed green and the published table sat
     frozen at 2026-07-02.
 
-    The size guard is preflighted for every candidate before any upload starts.
-    Failures are then collected rather than raised on the first transfer, so a
-    broken table can never hide a second broken table behind it.
+    Every size guard runs before the first upload starts, so a table this run
+    would refuse cannot land after a sibling has already been replaced. The
+    pipeline caller preflights a superset (partitions, index, manifest) first;
+    re-checking here is a few HEAD requests and keeps this function safe for any
+    other caller.
 
     R2 fixed object keys do not provide an atomic multi-object commit. This
     ordering prevents known guard failures from publishing anything; it does not
@@ -284,44 +317,30 @@ def upload_dataset(output_dir: Path, data_types: list[str]) -> None:
     caller owns publishing ``manifest.parquet`` only after every base and
     partitioned data file succeeds.
     """
-    base_files = []
-    for data_type in data_types:
-        pf = output_dir / f"{data_type}.parquet"
-        if pf.exists():
-            base_files.append(pf)
-
-    files_to_preflight = [(path, path.name) for path in base_files]
+    base_files = dataset_files(output_dir, data_types)
 
     # ThreadPoolExecutor rejects max_workers=0, so an empty publish set would
     # otherwise raise ValueError rather than being the no-op it should be.
-    if not files_to_preflight:
+    if not base_files:
         logger.warning("upload_dataset: no files to publish in {}", output_dir)
         return
 
-    preflight_uploads(files_to_preflight)
+    preflight_uploads(output_dir, base_files)
 
-    failures: list[tuple[Path, BaseException]] = []
-    if base_files:
-        with ThreadPoolExecutor(max_workers=len(base_files)) as executor:
-            futures = {executor.submit(upload_file, pf): pf for pf in base_files}
-            for future in as_completed(futures):
-                if (error := future.exception()) is not None:
-                    failures.append((futures[future], error))
+    failures: list[tuple[str, BaseException]] = []
+    with ThreadPoolExecutor(max_workers=len(base_files)) as executor:
+        futures = {executor.submit(upload_file, pf): pf for pf in base_files}
+        for future in as_completed(futures):
+            if (error := future.exception()) is not None:
+                failures.append((futures[future].name, error))
 
-    if failures:
-        for path, error in failures:
-            logger.error("Failed to publish {}: {}", path.name, error)
-        names = ", ".join(sorted(path.name for path, _ in failures))
-        raise RuntimeError(
-            f"Failed to publish {len(failures)} of {len(base_files)} base file(s) to R2: {names}"
-        ) from failures[0][1]
+    _raise_for_failures("R2 base table publish", failures, len(base_files))
 
 
 def upload_comment_partitions(output_dir: Path, changed_files: list[Path]) -> None:
     """Publish changed comment partition files and the comments index to R2."""
     for local_path in changed_files:
-        remote_key = str(local_path.relative_to(output_dir))
-        upload_file(local_path, remote_key=remote_key)
+        upload_file(local_path, remote_key=_remote_key(output_dir, local_path))
 
     index_file = output_dir / "comments_index.parquet"
     if index_file.exists():

--- a/tests/test_r2.py
+++ b/tests/test_r2.py
@@ -15,8 +15,8 @@ def test_download_delegates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     assert calls == [("manifest.parquet", tmp_path / "manifest.parquet")]
 
 
-def test_upload_dataset_uploads_existing_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """upload_dataset publishes the existing {type}.parquet files (+ manifest)."""
+def test_upload_dataset_uploads_only_existing_base_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The dataset publisher leaves the manifest to its pipeline caller."""
     (tmp_path / "dockets.parquet").write_bytes(b"d")
     (tmp_path / "documents.parquet").write_bytes(b"x")
     (tmp_path / "manifest.parquet").write_bytes(b"m")
@@ -30,7 +30,6 @@ def test_upload_dataset_uploads_existing_files(tmp_path: Path, monkeypatch: pyte
     assert set(uploaded) == {
         tmp_path / "dockets.parquet",
         tmp_path / "documents.parquet",
-        tmp_path / "manifest.parquet",
     }
 
 
@@ -117,6 +116,35 @@ def test_upload_dataset_raises_when_an_upload_fails(tmp_path: Path, monkeypatch:
 
     with pytest.raises(RuntimeError, match="dockets.parquet"):
         r2.upload_dataset(tmp_path, ["dockets", "documents"])
+
+
+def test_upload_dataset_preflights_all_guards_before_uploading(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A known shrink refusal must stop the whole dataset before the first write."""
+    _upload_env(monkeypatch)
+    (tmp_path / "documents.parquet").write_bytes(b"x" * 100)
+    (tmp_path / "dockets.parquet").write_bytes(b"d")
+    (tmp_path / "manifest.parquet").write_bytes(b"m" * 100)
+
+    monkeypatch.setattr(r2, "get_r2_client", lambda: object())
+    checked: list[str] = []
+
+    def fake_remote_size(client: object, bucket: str, key: str) -> int:
+        checked.append(key)
+        return 100
+
+    monkeypatch.setattr(
+        r2,
+        "_get_remote_size",
+        fake_remote_size,
+    )
+    uploaded: list[Path] = []
+    monkeypatch.setattr(r2, "upload_file", lambda path, remote_key=None: uploaded.append(path))
+
+    with pytest.raises(RuntimeError, match="Publication preflight failed.*dockets.parquet"):
+        r2.upload_dataset(tmp_path, ["documents", "dockets"])
+
+    assert uploaded == []
+    assert checked == ["documents.parquet", "dockets.parquet"]
 
 
 def test_upload_dataset_reports_every_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_r2.py
+++ b/tests/test_r2.py
@@ -49,6 +49,20 @@ def test_upload_comment_partitions_uploads_changed_and_index(tmp_path: Path, mon
     assert (tmp_path / "comments_index.parquet", "comments_index.parquet") in uploaded
 
 
+def test_upload_comment_partitions_refuses_without_an_index(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing index refuses before any partition is written, not after."""
+    changed = tmp_path / "comments" / "agency_code=EPA" / "part-0.parquet"
+    changed.parent.mkdir(parents=True)
+    changed.write_bytes(b"c")
+
+    uploaded: list[Path] = []
+    monkeypatch.setattr(r2, "upload_file", lambda p, remote_key=None: uploaded.append(p))
+
+    with pytest.raises(RuntimeError, match="comments_index.parquet"):
+        r2.upload_comment_partitions(tmp_path, [changed])
+    assert uploaded == []
+
+
 def _upload_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Minimal R2 env so upload_file runs its body (isolate_env strips these)."""
     monkeypatch.setenv("R2_ACCESS_KEY_ID", "k")

--- a/tests/test_r2.py
+++ b/tests/test_r2.py
@@ -99,7 +99,7 @@ def test_upload_file_survives_unreachable_edge(tmp_path: Path, monkeypatch: pyte
 
 
 def test_upload_dataset_raises_when_an_upload_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """A failing publish must surface, not be swallowed by the executor.
+    """A failing publish must surface rather than die inside the executor.
 
     Regression: `executor.map`'s lazy iterator was discarded, so the shrink
     guard's refusal to overwrite dockets.parquet never propagated and the ETL
@@ -123,6 +123,7 @@ def test_upload_dataset_preflights_all_guards_before_uploading(tmp_path: Path, m
     _upload_env(monkeypatch)
     (tmp_path / "documents.parquet").write_bytes(b"x" * 100)
     (tmp_path / "dockets.parquet").write_bytes(b"d")
+    # The manifest is the pipeline's to publish last; upload_dataset ignores it.
     (tmp_path / "manifest.parquet").write_bytes(b"m" * 100)
 
     monkeypatch.setattr(r2, "get_r2_client", lambda: object())

--- a/tests/test_regulations_pipeline.py
+++ b/tests/test_regulations_pipeline.py
@@ -393,8 +393,7 @@ def test_processes_multiple_agencies_in_parallel(tmp_output: Path, monkeypatch: 
 
 
 def test_run_uploads_changed_comment_partitions(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """A run that stages comments must publish the changed partitions + index,
-    then advance the manifest last."""
+    """A comments run publishes the changed partitions and index, then the manifest."""
     store = {
         _comment_key("c1", "EPA-2024-0001"): dumps(
             _comment_payload("c1", "EPA-2024-0001", "2024-01-01T00:00:00Z")
@@ -556,10 +555,11 @@ def test_run_preflight_failure_stops_all_publication(tmp_output: Path, monkeypat
 def test_run_refuses_to_publish_comments_without_a_refreshed_index(
     tmp_output: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A comments run that produced no index must refuse, not skip it silently.
+    """A comments run that produced no index must refuse to publish at all.
 
-    Skipping would publish comment rows and then advance the manifest, retiring
-    the keys while the public index still describes the previous partitions.
+    Skipping the index would publish the comment rows, then advance the
+    manifest — retiring those keys while the public index still describes the
+    previous partitions.
     """
     store = {
         _comment_key("c1", "EPA-2024-0001"): dumps(

--- a/tests/test_regulations_pipeline.py
+++ b/tests/test_regulations_pipeline.py
@@ -394,7 +394,7 @@ def test_processes_multiple_agencies_in_parallel(tmp_output: Path, monkeypatch: 
 
 def test_run_uploads_changed_comment_partitions(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A run that stages comments must publish the changed partitions + index,
-    not just the monolithic dataset."""
+    then advance the manifest last."""
     store = {
         _comment_key("c1", "EPA-2024-0001"): dumps(
             _comment_payload("c1", "EPA-2024-0001", "2024-01-01T00:00:00Z")
@@ -402,16 +402,22 @@ def test_run_uploads_changed_comment_partitions(tmp_output: Path, monkeypatch: p
     }
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
 
-    calls: dict[str, list] = {}
+    events: list[tuple[str, Any]] = []
     monkeypatch.setattr(
         regulations.r2,
-        "upload_dataset",
-        lambda out, types: calls.setdefault("dataset", []).append((out, types)),
+        "preflight_uploads",
+        lambda files: events.append(("preflight", list(files))),
     )
+    monkeypatch.setattr(regulations.r2, "upload_dataset", lambda *args, **kwargs: events.append(("dataset", args)))
     monkeypatch.setattr(
         regulations.r2,
         "upload_comment_partitions",
-        lambda out, changed: calls.setdefault("partitions", []).append((out, list(changed))),
+        lambda out, changed: events.append(("partitions", (out, list(changed)))),
+    )
+    monkeypatch.setattr(
+        regulations.r2,
+        "upload_file",
+        lambda path, remote_key=None: events.append(("file", (path, remote_key))),
     )
 
     RegulationsPipeline(
@@ -422,12 +428,136 @@ def test_run_uploads_changed_comment_partitions(tmp_output: Path, monkeypatch: p
         skip_upload=False,
     ).run()
 
-    assert "partitions" in calls, "changed comment partitions were never uploaded"
-    out, changed = calls["partitions"][0]
+    labels = [label for label, _ in events]
+    assert labels == ["preflight", "partitions", "file"]
+    preflight = dict(events)["preflight"]
+    assert {remote_key for _, remote_key in preflight} >= {
+        "comments_index.parquet",
+        "manifest.parquet",
+    }
+    assert any(remote_key.startswith("comments/") for _, remote_key in preflight)
+    out, changed = dict(events)["partitions"]
     assert out == tmp_output
     assert changed and all(p.suffix == ".parquet" for p in changed)
-    # The dataset upload (manifest etc.) still runs alongside it.
-    assert "dataset" in calls
+    manifest_path, manifest_key = events[-1][1]
+    assert manifest_path == tmp_output / "manifest.parquet"
+    assert manifest_key == "manifest.parquet"
+
+
+def test_run_does_not_advance_manifest_after_comment_upload_failure(
+    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed comment publication must leave the remote retry checkpoint unchanged."""
+    store = {
+        _comment_key("c1", "EPA-2024-0001"): dumps(
+            _comment_payload("c1", "EPA-2024-0001", "2024-01-01T00:00:00Z")
+        ).encode(),
+    }
+    monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
+    monkeypatch.setattr(regulations.r2, "preflight_uploads", lambda files: None)
+    monkeypatch.setattr(regulations.r2, "upload_dataset", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        regulations.r2,
+        "upload_comment_partitions",
+        lambda out, changed: (_ for _ in ()).throw(RuntimeError("comment upload failed")),
+    )
+    uploaded: list[tuple[Path, str | None]] = []
+    monkeypatch.setattr(
+        regulations.r2,
+        "upload_file",
+        lambda path, remote_key=None: uploaded.append((path, remote_key)),
+    )
+
+    with pytest.raises(RuntimeError, match="comment upload failed"):
+        RegulationsPipeline(
+            agency=AGENCY,
+            output_dir=tmp_output,
+            only_comments=True,
+            enrich_text=False,
+            skip_upload=False,
+        ).run()
+
+    assert (tmp_output / "manifest.parquet", "manifest.parquet") not in uploaded
+
+
+def test_run_does_not_advance_manifest_after_base_upload_failure(
+    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed base-table publication must leave the remote retry checkpoint unchanged."""
+    store = {
+        _docket_key("EPA-2024-0001"): dumps(_docket_payload("EPA-2024-0001", "2024-01-01")).encode(),
+    }
+    monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
+    monkeypatch.setattr(regulations.r2, "preflight_uploads", lambda files: None)
+    monkeypatch.setattr(
+        regulations.r2,
+        "upload_dataset",
+        lambda out, types: (_ for _ in ()).throw(RuntimeError("base upload failed")),
+    )
+    uploaded: list[tuple[Path, str | None]] = []
+    monkeypatch.setattr(
+        regulations.r2,
+        "upload_file",
+        lambda path, remote_key=None: uploaded.append((path, remote_key)),
+    )
+
+    with pytest.raises(RuntimeError, match="base upload failed"):
+        RegulationsPipeline(
+            agency=AGENCY,
+            output_dir=tmp_output,
+            skip_comments=True,
+            skip_upload=False,
+        ).run()
+
+    assert (tmp_output / "manifest.parquet", "manifest.parquet") not in uploaded
+
+
+def test_run_preflight_failure_stops_all_publication(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every planned public object must pass its guard before the first write."""
+    store = {
+        _comment_key("c1", "EPA-2024-0001"): dumps(
+            _comment_payload("c1", "EPA-2024-0001", "2024-01-01T00:00:00Z")
+        ).encode(),
+    }
+    monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
+    checked: list[tuple[Path, str]] = []
+
+    def fail_preflight(files: list[tuple[Path, str]]) -> None:
+        checked.extend(files)
+        raise RuntimeError("manifest guard failed")
+
+    monkeypatch.setattr(regulations.r2, "preflight_uploads", fail_preflight)
+    attempted: list[str] = []
+    monkeypatch.setattr(
+        regulations.r2,
+        "upload_dataset",
+        lambda *args, **kwargs: attempted.append("dataset"),
+    )
+    monkeypatch.setattr(
+        regulations.r2,
+        "upload_comment_partitions",
+        lambda *args, **kwargs: attempted.append("comments"),
+    )
+    monkeypatch.setattr(
+        regulations.r2,
+        "upload_file",
+        lambda *args, **kwargs: attempted.append("file"),
+    )
+
+    with pytest.raises(RuntimeError, match="manifest guard failed"):
+        RegulationsPipeline(
+            agency=AGENCY,
+            output_dir=tmp_output,
+            only_comments=True,
+            enrich_text=False,
+            skip_upload=False,
+        ).run()
+
+    assert {remote_key for _, remote_key in checked} >= {
+        "comments_index.parquet",
+        "manifest.parquet",
+    }
+    assert attempted == []
 
 
 def test_run_skips_partition_upload_when_no_comments(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -438,7 +568,11 @@ def test_run_skips_partition_upload_when_no_comments(tmp_output: Path, monkeypat
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
 
     calls: dict[str, list] = {}
-    monkeypatch.setattr(regulations.r2, "upload_dataset", lambda out, types: calls.setdefault("dataset", []).append(1))
+    monkeypatch.setattr(
+        regulations.r2,
+        "upload_dataset",
+        lambda out, types: calls.setdefault("dataset", []).append((out, types)),
+    )
     monkeypatch.setattr(
         regulations.r2,
         "upload_comment_partitions",

--- a/tests/test_regulations_pipeline.py
+++ b/tests/test_regulations_pipeline.py
@@ -406,7 +406,7 @@ def test_run_uploads_changed_comment_partitions(tmp_output: Path, monkeypatch: p
     monkeypatch.setattr(
         regulations.r2,
         "preflight_uploads",
-        lambda files: events.append(("preflight", list(files))),
+        lambda out, files: events.append(("preflight", list(files))),
     )
     monkeypatch.setattr(regulations.r2, "upload_dataset", lambda *args, **kwargs: events.append(("dataset", args)))
     monkeypatch.setattr(
@@ -428,20 +428,15 @@ def test_run_uploads_changed_comment_partitions(tmp_output: Path, monkeypatch: p
         skip_upload=False,
     ).run()
 
-    labels = [label for label, _ in events]
-    assert labels == ["preflight", "partitions", "file"]
-    preflight = dict(events)["preflight"]
-    assert {remote_key for _, remote_key in preflight} >= {
-        "comments_index.parquet",
-        "manifest.parquet",
-    }
-    assert any(remote_key.startswith("comments/") for _, remote_key in preflight)
-    out, changed = dict(events)["partitions"]
+    assert [label for label, _ in events] == ["preflight", "partitions", "file"]
+    preflight = events[0][1]
+    assert tmp_output / "comments_index.parquet" in preflight
+    assert tmp_output / "manifest.parquet" in preflight
+    assert any(p.is_relative_to(tmp_output / "comments") for p in preflight)
+    out, changed = events[1][1]
     assert out == tmp_output
     assert changed and all(p.suffix == ".parquet" for p in changed)
-    manifest_path, manifest_key = events[-1][1]
-    assert manifest_path == tmp_output / "manifest.parquet"
-    assert manifest_key == "manifest.parquet"
+    assert events[2][1] == (tmp_output / "manifest.parquet", "manifest.parquet")
 
 
 def test_run_does_not_advance_manifest_after_comment_upload_failure(
@@ -454,7 +449,7 @@ def test_run_does_not_advance_manifest_after_comment_upload_failure(
         ).encode(),
     }
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
-    monkeypatch.setattr(regulations.r2, "preflight_uploads", lambda files: None)
+    monkeypatch.setattr(regulations.r2, "preflight_uploads", lambda out, files: None)
     monkeypatch.setattr(regulations.r2, "upload_dataset", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         regulations.r2,
@@ -488,7 +483,7 @@ def test_run_does_not_advance_manifest_after_base_upload_failure(
         _docket_key("EPA-2024-0001"): dumps(_docket_payload("EPA-2024-0001", "2024-01-01")).encode(),
     }
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
-    monkeypatch.setattr(regulations.r2, "preflight_uploads", lambda files: None)
+    monkeypatch.setattr(regulations.r2, "preflight_uploads", lambda out, files: None)
     monkeypatch.setattr(
         regulations.r2,
         "upload_dataset",
@@ -520,9 +515,9 @@ def test_run_preflight_failure_stops_all_publication(tmp_output: Path, monkeypat
         ).encode(),
     }
     monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
-    checked: list[tuple[Path, str]] = []
+    checked: list[Path] = []
 
-    def fail_preflight(files: list[tuple[Path, str]]) -> None:
+    def fail_preflight(out: Path, files: list[Path]) -> None:
         checked.extend(files)
         raise RuntimeError("manifest guard failed")
 
@@ -553,11 +548,41 @@ def test_run_preflight_failure_stops_all_publication(tmp_output: Path, monkeypat
             skip_upload=False,
         ).run()
 
-    assert {remote_key for _, remote_key in checked} >= {
-        "comments_index.parquet",
-        "manifest.parquet",
-    }
+    assert tmp_output / "comments_index.parquet" in checked
+    assert tmp_output / "manifest.parquet" in checked
     assert attempted == []
+
+
+def test_run_refuses_to_publish_comments_without_a_refreshed_index(
+    tmp_output: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A comments run that produced no index must refuse, not skip it silently.
+
+    Skipping would publish comment rows and then advance the manifest, retiring
+    the keys while the public index still describes the previous partitions.
+    """
+    store = {
+        _comment_key("c1", "EPA-2024-0001"): dumps(
+            _comment_payload("c1", "EPA-2024-0001", "2024-01-01T00:00:00Z")
+        ).encode(),
+    }
+    monkeypatch.setattr(mirrulations, "s3_resource", lambda: _FakeS3Resource(store))
+    # The catalog MERGE "succeeds" but leaves no comments_index.parquet behind.
+    monkeypatch.setattr(regulations.iceberg, "merge_comments", lambda sd, od, rt: None)
+    uploaded: list[Path] = []
+    monkeypatch.setattr(regulations.r2, "upload_file", lambda path, remote_key=None: uploaded.append(path))
+
+    with pytest.raises(RuntimeError, match="comments_index.parquet"):
+        RegulationsPipeline(
+            agency=AGENCY,
+            output_dir=tmp_output,
+            only_comments=True,
+            use_iceberg=True,
+            enrich_text=False,
+            skip_upload=False,
+        ).run()
+
+    assert uploaded == []
 
 
 def test_run_skips_partition_upload_when_no_comments(tmp_output: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Publishing writes several data files to storage and then a manifest listing what was published. That manifest doubles as the restart checkpoint — anything it lists is skipped on the next run — so writing it early permanently retires work. It was possible for the manifest to land while one of the data files had failed, or before comment data had been uploaded at all, which meant the next run skipped records that were never actually published. This reorders publishing so every planned file is size-checked before anything is written, all the data goes out, and the manifest goes last; any failure now leaves the checkpoint untouched and the next run retries cleanly. Worth flagging for operations: a run that publishes comment data without producing its index now stops with an error instead of quietly skipping it, so a previously-green run can go red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)