### PR TITLE
fix(unified-agenda): reject impossible dates

### DIFF
--- a/src/spicy_regs/transforms/build_unified_agenda.py
+++ b/src/spicy_regs/transforms/build_unified_agenda.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import date
 from pathlib import Path
 
 import pyarrow as pa
@@ -75,7 +76,13 @@ _MDY = re.compile(r"^(\d{1,2})/(\d{1,2})/(\d{4})$")
 
 
 def _iso_dates(timetable: list) -> list[str]:
-    """Return the timetable's parseable action dates as sorted ISO ``YYYY-MM-DD``."""
+    """Return the timetable's real action dates as sorted ISO ``YYYY-MM-DD``.
+
+    Fail-closed on the calendar: a value that names no day that ever existed
+    (``02/30/2024``, ``13/01/2024``) is dropped like any other unparseable
+    date rather than repaired into a *different* real date. ``00`` remains
+    reginfo's month-only marker and resolves to the first of that month.
+    """
     dates: set[str] = set()
     for entry in timetable:
         raw = (entry or {}).get("date")
@@ -84,11 +91,12 @@ def _iso_dates(timetable: list) -> list[str]:
         m = _MDY.match(raw.strip())
         if not m:
             continue
-        month, day, year = int(m.group(1)), int(m.group(2)), m.group(3)
-        if not 1 <= month <= 12:
+        month, day, year = int(m.group(1)), int(m.group(2)), int(m.group(3))
+        try:
+            action = date(year, month, day or 1)
+        except ValueError:
             continue
-        day = min(max(day, 1), 31)  # clamp; ``00`` (month-only) becomes the 1st
-        dates.add(f"{year}-{month:02d}-{day:02d}")
+        dates.add(action.isoformat())
     return sorted(dates)
 
 

--- a/src/spicy_regs/transforms/build_unified_agenda.py
+++ b/src/spicy_regs/transforms/build_unified_agenda.py
@@ -78,10 +78,8 @@ _MDY = re.compile(r"^(\d{1,2})/(\d{1,2})/(\d{4})$")
 def _iso_dates(timetable: list) -> list[str]:
     """Return the timetable's real action dates as sorted ISO ``YYYY-MM-DD``.
 
-    Fail-closed on the calendar: a value that names no day that ever existed
-    (``02/30/2024``, ``13/01/2024``) is dropped like any other unparseable
-    date rather than repaired into a *different* real date. ``00`` remains
-    reginfo's month-only marker and resolves to the first of that month.
+    A date the calendar rejects (``02/30/2024``) is dropped, never clamped into a
+    *different* real date; ``00`` stays reginfo's month-only marker for the 1st.
     """
     dates: set[str] = set()
     for entry in timetable:
@@ -93,10 +91,10 @@ def _iso_dates(timetable: list) -> list[str]:
             continue
         month, day, year = int(m.group(1)), int(m.group(2)), int(m.group(3))
         try:
-            action = date(year, month, day or 1)
+            action_date = date(year, month, day or 1)
         except ValueError:
             continue
-        dates.add(action.isoformat())
+        dates.add(action_date.isoformat())
     return sorted(dates)
 
 

--- a/src/spicy_regs/transforms/build_unified_agenda.py
+++ b/src/spicy_regs/transforms/build_unified_agenda.py
@@ -70,8 +70,10 @@ def _s(value: object) -> str | None:
     return str(value)
 
 
-# reginfo timetable dates are ``MM/DD/YYYY`` (day may be ``00`` for month-only);
-# anything else (e.g. ``To Be Determined``) is not a real date and is skipped.
+# reginfo timetable dates are ``MM/DD/YYYY``; anything else (``To Be Determined``)
+# never matches. ``strptime`` cannot replace this regex: ``%d`` rejects reginfo's
+# ``00`` day at the format level, so the swap would silently drop the 2,922
+# month-only dates in the published table.
 _MDY = re.compile(r"^(\d{1,2})/(\d{1,2})/(\d{4})$")
 
 

--- a/src/spicy_regs/transforms/build_unified_agenda.py
+++ b/src/spicy_regs/transforms/build_unified_agenda.py
@@ -95,6 +95,9 @@ def _iso_dates(timetable: list) -> list[str]:
         try:
             action_date = date(year, month, day or 1)
         except ValueError:
+            # Warn only here. The regex miss above fires 538 times per edition on
+            # reginfo's own "To Be Determined" and would bury this.
+            logger.warning("Unified Agenda: dropped impossible timetable date {!r}", raw.strip())
             continue
         dates.add(action_date.isoformat())
     return sorted(dates)

--- a/tests/test_unified_agenda.py
+++ b/tests/test_unified_agenda.py
@@ -178,9 +178,9 @@ def test_shape_handles_missing_and_unparseable_dates():
         ("06/00/2024", ["2024-06-01"]),  # reginfo's month-only marker
         ("02/30/2024", []),  # never existed — dropped, not moved to the 29th
         ("02/29/2023", []),  # not a leap year
-        ("06/32/2024", []),  # was clamped to the 31st
-        ("13/01/2024", []),
-        ("00/15/2024", []),
+        ("06/32/2024", []),  # the old clamp made this 2024-06-31
+        ("13/01/2024", []),  # ``date()`` now owns the month range; the hand check is gone
+        ("00/15/2024", []),  # the ``00`` marker is the day's alone — month 0 stays invalid
         ("To Be Determined", []),
     ],
 )
@@ -198,7 +198,7 @@ def test_shape_drops_impossible_dates_without_fabricating_a_neighbour():
     # The impossible date is absent, so the real one becomes the first action.
     assert row["first_action_date"] == "2024-07-04"
     assert row["next_action_date"] is None
-    # The raw timetable is still carried through verbatim.
+    # ``timetable_json`` still carries the raw date verbatim.
     assert json.loads(row["timetable_json"])[0]["date"] == "02/30/2024"
 
 

--- a/tests/test_unified_agenda.py
+++ b/tests/test_unified_agenda.py
@@ -178,7 +178,6 @@ def test_shape_handles_missing_and_unparseable_dates():
         ("06/00/2024", ["2024-06-01"]),  # reginfo's month-only marker
         ("02/30/2024", []),  # never existed — dropped, not moved to the 29th
         ("02/29/2023", []),  # not a leap year
-        ("04/31/2024", []),
         ("06/32/2024", []),  # was clamped to the 31st
         ("13/01/2024", []),
         ("00/15/2024", []),
@@ -190,7 +189,7 @@ def test_iso_dates_rejects_impossible_calendar_dates(raw, expected):
 
 
 def test_shape_drops_impossible_dates_without_fabricating_a_neighbour():
-    doc = dict(_read_fixture("202510")[0])
+    doc = _read_fixture("202510")[0]
     doc["timetable"] = [
         {"action": "NPRM", "date": "02/30/2024"},
         {"action": "Final Rule", "date": "07/04/2024"},

--- a/tests/test_unified_agenda.py
+++ b/tests/test_unified_agenda.py
@@ -13,9 +13,11 @@ from __future__ import annotations
 import json
 from unittest.mock import patch
 
+import pytest
+
 from spicy_regs.sources import unified_agenda
 from spicy_regs.sources.unified_agenda import UnifiedAgendaReader
-from spicy_regs.transforms.build_unified_agenda import COLUMNS, _shape
+from spicy_regs.transforms.build_unified_agenda import COLUMNS, _iso_dates, _shape
 
 # A two-record slice of the real export, matching the observed tag structure:
 # <REGINFO_RIN_DATA> root, repeated <RIN_INFO> records, nested AGENCY / CFR_LIST /
@@ -166,6 +168,39 @@ def test_shape_handles_missing_and_unparseable_dates():
     # Absent fields are null.
     assert row["abstract"] is None
     assert row["priority_category"] is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("06/15/2024", ["2024-06-15"]),
+        ("02/29/2024", ["2024-02-29"]),  # a real leap day survives
+        ("06/00/2024", ["2024-06-01"]),  # reginfo's month-only marker
+        ("02/30/2024", []),  # never existed — dropped, not moved to the 29th
+        ("02/29/2023", []),  # not a leap year
+        ("04/31/2024", []),
+        ("06/32/2024", []),  # was clamped to the 31st
+        ("13/01/2024", []),
+        ("00/15/2024", []),
+        ("To Be Determined", []),
+    ],
+)
+def test_iso_dates_rejects_impossible_calendar_dates(raw, expected):
+    assert _iso_dates([{"action": "NPRM", "date": raw}]) == expected
+
+
+def test_shape_drops_impossible_dates_without_fabricating_a_neighbour():
+    doc = dict(_read_fixture("202510")[0])
+    doc["timetable"] = [
+        {"action": "NPRM", "date": "02/30/2024"},
+        {"action": "Final Rule", "date": "07/04/2024"},
+    ]
+    row = _shape(doc)
+    # The impossible date is absent, so the real one becomes the first action.
+    assert row["first_action_date"] == "2024-07-04"
+    assert row["next_action_date"] is None
+    # The raw timetable is still carried through verbatim.
+    assert json.loads(row["timetable_json"])[0]["date"] == "02/30/2024"
 
 
 def test_download_rejects_non_xml_body(monkeypatch):

--- a/tests/test_unified_agenda.py
+++ b/tests/test_unified_agenda.py
@@ -14,6 +14,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from loguru import logger
 
 from spicy_regs.sources import unified_agenda
 from spicy_regs.sources.unified_agenda import UnifiedAgendaReader
@@ -186,6 +187,29 @@ def test_shape_handles_missing_and_unparseable_dates():
 )
 def test_iso_dates_rejects_impossible_calendar_dates(raw, expected):
     assert _iso_dates([{"action": "NPRM", "date": raw}]) == expected
+
+
+def _warnings_from(timetable: list) -> list[str]:
+    """Collect WARNING records emitted while ``_iso_dates`` runs."""
+    messages: list[str] = []
+    sink = logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        assert _iso_dates(timetable) == []
+    finally:
+        logger.remove(sink)
+    return messages
+
+
+def test_an_impossible_date_says_so_in_the_run_log():
+    """Dropping is otherwise silent, so an edition that starts emitting impossible
+    dates would shrink the published table with nothing in the log to explain it."""
+    assert any("02/30/2024" in m for m in _warnings_from([{"date": "02/30/2024"}]))
+
+
+def test_an_unparseable_date_stays_quiet():
+    """``To Be Determined`` is reginfo's own placeholder and appears 538 times in a
+    single published edition; warning on it would bury the impossible-date case."""
+    assert _warnings_from([{"date": "To Be Determined"}]) == []
 
 
 def test_shape_drops_impossible_dates_without_fabricating_a_neighbour():


### PR DESCRIPTION
Dates in the Unified Agenda arrive as MM/DD/YYYY and were being forced into range rather than checked against a calendar, so a value like 02/30/2024 was published unchanged — a date that does not exist. Anything downstream reading those columns either errors or silently reinterprets them. This validates the date and drops it if it isn't real, rather than nudging it to a nearby date that looks plausible but isn't what the source said; the raw value stays available in the untouched timetable column, and the publisher's month-only convention is preserved. No rows in the currently published data change — this prevents the next bad value rather than repairing an existing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)