### PR TITLE
feat(sources): read U.S. Code source credits

### DIFF
--- a/scripts/build_usc_source_credit_artifact.py
+++ b/scripts/build_usc_source_credit_artifact.py
@@ -1,25 +1,23 @@
 #!/usr/bin/env python
 """Build the pinned U.S. Code source-credit index from the OLRC's USLM XML.
 
-This index gives consumers a second independent statement of the
-act-section-to-U.S.-Code join. The first, the Office of the Law Revision
-Counsel's (OLRC) Table III, is keyed by the enacting public law alone and cannot
-tell apart the dozens of acts one public law may enact. Every section of the
-Code carries a source credit that states the division per section, which is
-exactly what Table III lacks:
+Every section of the Code carries a source credit naming the law that enacted
+it. 26 U.S.C. 6038E carries this one:
 
     26 U.S.C. 6038E  <-  (Added Pub. L. 116-260, div. EE, title I, § 107(d)(1),
                           Dec. 27, 2020, 134 Stat. 3048.)
 
-The builder seals deterministic rows with a digest-pinned receipt,
-repo-relative paths, a secret scan over what is written, and byte-identical
-rebuilds.
+Those credits state the act-section-to-U.S.-Code join a second time, and
+independently. The first statement, the Office of the Law Revision
+Counsel's (OLRC) Table III, is keyed by the enacting public law alone and cannot
+tell apart the dozens of acts one public law may enact. A credit names the
+division per section, which is exactly what Table III lacks.
 
-**It is not a tiebreaker over Table III, and it is not built as one.** The two
-sources have different coverage: measured on release point 119-102, of the 222
-unambiguous triples here whose public law Table III was also fetched for, 176
-have no in-division Table III row at all. 26 U.S.C. 6038E is one of them. A
-disagreement between the sources is a coverage fact about one of them, and this
+**This index is no tiebreaker over Table III, and it is not built as one.** The
+two sources have different coverage: measured on release point 119-102, of the
+222 unambiguous triples here whose public law Table III was also fetched for,
+176 have no in-division Table III row at all, 26 U.S.C. 6038E among them. A
+disagreement between the sources states the coverage of one of them, and this
 artifact never picks a winner.
 
 Outputs, all deterministic and byte-identical across rebuilds from one archive:
@@ -69,8 +67,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 ARTIFACT_SCHEMA_VERSION = "usc-source-credit-artifact-v1"
 
-#: The parser this artifact was produced by. Bump when a parse changes shape, so
-#: a receipt cannot silently describe bytes a different parser would read.
+#: The parser that produced this artifact. Bump it when a parse changes shape,
+#: so a receipt can never describe bytes a different parser would read.
 PARSER_VERSION = "uscode-uslm-parser-v1"
 
 #: How a triple naming more than one U.S. Code section is carried.
@@ -90,8 +88,9 @@ CREDIT_COLUMNS = (
 )
 QUARANTINE_COLUMNS = ("source", "reason", "public_law", "division", "act_section", "raw_value")
 
-#: A build must not seal a secret. The scan is over what is written, not what was
-#: read, so a credential in an environment variable cannot reach the file.
+#: A build must not seal a secret. This runs over what the build writes rather
+#: than over what it read, so a credential reaching a row by any path stops the
+#: seal.
 _SECRET_LIKE = re.compile(r"\b(?:sk-(?:proj-)?[A-Za-z0-9_-]{20,}|api[_-]?key=[^\s&]{8,})\b", re.IGNORECASE)
 
 
@@ -108,10 +107,10 @@ def file_sha256(path: Path) -> str:
 
 
 def _pin_path(path: Path) -> str:
-    """Record a repo-relative path when possible, else the basename.
+    """Record a repo-relative path where one exists, else the basename.
 
-    Keeping absolute scratch paths out of the receipt keeps rebuilds from
-    different working directories byte-identical.
+    An absolute scratch path would differ per working directory and break the
+    byte-identical rebuild the receipt claims.
     """
     resolved = path.resolve()
     try:
@@ -137,6 +136,10 @@ def _scan_for_secrets(rows: list[dict[str, Any]], where: str) -> None:
 
 
 def build(output_dir: Path, *, archive: Path, release_point: str) -> dict:
+    """Scan one release archive into rows, a quarantine file and a sealed receipt.
+
+    Returns the receipt; :func:`main` prints its coverage block.
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
     scan, members = scan_release_zip(archive)
 

--- a/scripts/build_usc_source_credit_artifact.py
+++ b/scripts/build_usc_source_credit_artifact.py
@@ -195,7 +195,7 @@ def build(output_dir: Path, *, archive: Path, release_point: str) -> dict:
             "titles": len(members),
             "source_credits_scanned": scan.credits_scanned,
             "credits_naming_a_division": scan.credits_naming_a_division,
-            "credits_outside_a_section": scan.credits_outside_a_section,
+            "strict_matches_outside_a_section": scan.strict_matches_outside_a_section,
             "strict_matches": scan.strict_matches,
             "triples": len(targets),
             "unambiguous_triples": sum(1 for v in targets.values() if len(v) == 1),

--- a/scripts/build_usc_source_credit_artifact.py
+++ b/scripts/build_usc_source_credit_artifact.py
@@ -37,7 +37,7 @@ Outputs, all deterministic and byte-identical across rebuilds from one archive:
 
 Usage::
 
-    uv run python tools/build_usc_source_credit_artifact.py \\
+    uv run python scripts/build_usc_source_credit_artifact.py \\
         --output output/usc-source-credit-index-2026-08-02 \\
         --archive /tmp/uscall.zip \\
         --release-point 119-102
@@ -57,16 +57,15 @@ from typing import Any
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "src"))
-
-from spicy_regs.sources.uscode_uslm import (  # noqa: E402
+from spicy_regs.sources.uscode_uslm import (
     QUARANTINE_REASONS,
     STRICT_ENACTMENT_RULE,
     USLM_SECTION_DASH_RULE,
     scan_release_zip,
     uslm_release_url,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 ARTIFACT_SCHEMA_VERSION = "usc-source-credit-artifact-v1"
 

--- a/src/spicy_regs/sources/uscode_uslm.py
+++ b/src/spicy_regs/sources/uscode_uslm.py
@@ -181,19 +181,17 @@ class CreditScan:
     """One USLM title's credits, its quarantine, and the four counts it keeps.
 
     ``credits_scanned`` and ``credits_naming_a_division`` count credits.
-    ``strict_matches`` and ``credits_outside_a_section`` count *matches* of
-    :data:`STRICT_ENACTMENT_RULE`, the second only those sitting under no
-    ``<section>``. So ``credits_outside_a_section`` reads 0 on release point
-    119-102, where 549 credits do sit outside a section and none of them
-    matches the strict rule. The name is a key in a sealed receipt; read it as
-    "strict matches outside a section".
+    ``strict_matches`` and ``strict_matches_outside_a_section`` count matches
+    of :data:`STRICT_ENACTMENT_RULE`, the second only those under no
+    ``<section>``. On release point 119-102 that second count is 0: 549
+    credits sit outside a section, and none matches the strict rule.
     """
 
     credits: list[SourceCredit] = field(default_factory=list)
     quarantine: list[QuarantinedCredit] = field(default_factory=list)
     credits_scanned: int = 0
     credits_naming_a_division: int = 0
-    credits_outside_a_section: int = 0
+    strict_matches_outside_a_section: int = 0
     strict_matches: int = 0
 
     def merge(self, other: CreditScan) -> CreditScan:
@@ -202,7 +200,8 @@ class CreditScan:
             quarantine=self.quarantine + other.quarantine,
             credits_scanned=self.credits_scanned + other.credits_scanned,
             credits_naming_a_division=self.credits_naming_a_division + other.credits_naming_a_division,
-            credits_outside_a_section=self.credits_outside_a_section + other.credits_outside_a_section,
+            strict_matches_outside_a_section=self.strict_matches_outside_a_section
+            + other.strict_matches_outside_a_section,
             strict_matches=self.strict_matches + other.strict_matches,
         )
 
@@ -307,7 +306,7 @@ def scan_source_credits(document: bytes | str) -> CreditScan:
         quarantine=quarantine,
         credits_scanned=scanned,
         credits_naming_a_division=naming_a_division,
-        credits_outside_a_section=outside,
+        strict_matches_outside_a_section=outside,
         strict_matches=strict_matches,
     )
 

--- a/src/spicy_regs/sources/uscode_uslm.py
+++ b/src/spicy_regs/sources/uscode_uslm.py
@@ -221,7 +221,10 @@ def iter_source_credits(document: bytes | str) -> Iterator[tuple[str | None, str
     retains every element it has seen, so the peak is the whole title, and title
     42 is 113 MB of it. Measured over a synthetic USLM title of that size:
     775 MB of resident tree without the clear against 6 MB with it, identical
-    output, and 29% quicker for never allocating it.
+    output, and 29% quicker for never allocating it. A second metric over the
+    publisher's own bytes agrees: scanning title 42 of release point 119-102,
+    digest-verified against the sealed receipt, takes whole-process peak RSS
+    from 786 MB to 264 MB and yields byte-identical output.
     """
     payload = document.encode("utf-8") if isinstance(document, str) else document
     stack: list[str | None] = []

--- a/src/spicy_regs/sources/uscode_uslm.py
+++ b/src/spicy_regs/sources/uscode_uslm.py
@@ -1,49 +1,51 @@
 """Read the U.S. Code's own source credits from the OLRC's USLM XML.
 
 Every section of the Code carries a ``<sourceCredit>`` naming the law that
-enacted it and every law that has amended it since:
+enacted it and every law that has amended it since. 26 U.S.C. 6038E carries
+this one:
 
     (Added Pub. L. 116-260, div. EE, title I, § 107(d)(1), Dec. 27, 2020,
      134 Stat. 3048.)
 
-Those credits provide a **second independent statement** of the
-act-section-to-U.S.-Code join also described by the Office of the Law Revision
-Counsel's (OLRC) Table III. They also state something Table III does not: the
-*division* of the enacting public law, per section. Table III is keyed by the
-enacting public law alone, and one public law may enact dozens of acts --
-116-260 enacts 94 -- so a division stated per section is exactly the
-discriminator Table III lacks.
+Read it as ``(116-260, div. EE, § 107) -> 26 U.S.C. 6038E``: an act section on
+the left, the Code section it created on the right. This module pulls that
+arrow out of every credit in the Code.
+
+**A credit names the division; Table III does not.** The Office of the Law
+Revision Counsel (OLRC) publishes the same join as Table III, keyed by the
+enacting public law alone -- and one public law may enact dozens of acts, 94 of
+them in the case of 116-260. The division a credit states per section is
+exactly the discriminator Table III lacks.
 
 **The two sources are complementary, not redundant.** Measured on release point
 119-102 against a pinned Table III comparison: of the 222 unambiguous triples
 this module retains for public laws present in that comparison, **176 have no
-in-division Table III row at all**. 26 U.S.C. 6038E is one of them. A
-disagreement between the sources is a coverage fact, not noise, and neither is
-a tiebreaker over the other.
+in-division Table III row at all**, 26 U.S.C. 6038E among them. A disagreement
+between the two states the coverage of one of them; neither settles the other.
 
-**The rule is a refusal rule, and the mess is why.** A credit lists the
-enactment and every amendment, so an expression that accepts any ``Pub. L. N-M,
-div. X ... § S`` anywhere in a credit pairs a division with a section number
-belonging to a different citation in the same credit. Measured: 13,122 triples,
-of which 2,916 map to more than one U.S. Code section. Reading role by proximity
-to the word "amended" does not fix it -- it credits 26 U.S.C. 7652 to
-(116-260, div. EE, § 107), and that credit never says "amended".
+**The rule refuses, and the mess is why.** A credit lists the enactment and
+every amendment, so an expression accepting any
+``Pub. L. N-M, div. X ... § S`` anywhere in a credit pairs a division with a
+section number belonging to a different citation in the same credit. Measured:
+13,122 triples, 2,916 of them mapping to more than one U.S. Code section.
+Reading the role by proximity to the word "amended" fails too -- it credits
+26 U.S.C. 7652 to (116-260, div. EE, § 107), and that credit never says
+"amended".
 
-:data:`STRICT_ENACTMENT_RULE` requires the citation to sit in an explicit
-enactment construction -- ``Added Pub. L. ...`` or ``as added Pub. L. ...``.
-That collapses the population to 2,202 triples, 1,877 of them naming exactly one
-U.S. Code section, and it removes the 7652 false positive. What it does not
-retain, it does not guess at: 22 U.S.C. 2714a reads ``(Pub. L. 114-94, div. C,
-title XXXII, § 32101, ...)`` with no enactment construction, and this module
-carries no row for it.
+:data:`STRICT_ENACTMENT_RULE` therefore demands an explicit enactment
+construction: ``Added Pub. L. ...`` or ``as added Pub. L. ...``. That collapses
+the population to 2,202 triples, 1,877 of them naming exactly one U.S. Code
+section, and it drops the 7652 false positive. What the rule declines it never
+guesses at: 22 U.S.C. 2714a reads ``(Pub. L. 114-94, div. C, title XXXII,
+§ 32101, ...)`` with no enactment construction, so this module carries no row
+for it.
 
-**Why an XML parse rather than a regular expression over the file.** Unlike the
-Popular Name Tool's flat generated HTML, USLM is well-formed XML whose
-``<section>`` elements nest, and a credit must be attributed to the section that
-*contains* it. A nearest-preceding-tag scan attributes a credit sitting after a
-nested close to the wrong section. The ancestry is the fact being read, so it is
-read structurally. The strict rule itself is an expression over the credit's own
-flattened text, because the construction it looks for is prose.
+**Why parse the XML rather than match over the file.** Unlike the Popular Name
+Tool's flat generated HTML, USLM nests its ``<section>`` elements, and a credit
+belongs to the section that *contains* it. A scan for the nearest preceding tag
+misattributes every credit that follows a nested close, so this module reads
+the ancestry structurally. The strict rule stays an expression over the
+credit's own flattened text, because the construction it looks for is prose.
 """
 
 from __future__ import annotations
@@ -55,31 +57,31 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
-#: The whole Code for one release point, one zip. Measured: 109 MB, ~49 s, 58
-#: titles. There is no per-section endpoint worth 51,548 requests.
+#: One zip carries the whole Code for one release point: 109 MB, 58 titles,
+#: ~49 s to scan. No per-section endpoint is worth 51,548 requests.
 USLM_RELEASE_URL_TEMPLATE = (
     "https://uscode.house.gov/download/releasepoints/us/pl/{congress}/{law}/xml_uscAll@{congress}-{law}.zip"
 )
 
-#: Require an explicit enactment construction. See the module docstring for the
-#: measured alternative and why it is unsafe.
+#: Read a citation only inside ``Added Pub. L. ...`` or ``as added Pub. L. ...``.
+#: The module docstring measures the looser alternative and what it misreads.
 STRICT_ENACTMENT_RULE = "added-or-as-added-pub-law-division-act-section-v1"
 
-#: USLM spells a section suffix with an EN DASH (``/us/usc/t16/s824s–1``);
-#: OLRC's Table III and ordinary U.S. Code citations spell it with a hyphen.
-#: Verified on release point 119-102: title 16 alone carries 1,487
-#: en-dash section identifiers and **zero** hyphen ones, so this is a spelling
-#: convention of the source rather than a distinction it draws. Straightening it
-#: is what lets the two OLRC surfaces join at all; the verbatim identifier is
-#: carried alongside so nothing is lost.
+#: USLM spells a section suffix with an EN DASH (``/us/usc/t16/s824s–1``); OLRC's
+#: Table III and ordinary U.S. Code citations spell it with a hyphen. On release
+#: point 119-102, title 16 alone carries 1,487 en-dash section identifiers and
+#: **zero** hyphen ones, so the dash is the source's spelling convention rather
+#: than a distinction it draws. Straightening it is what lets the two OLRC
+#: surfaces join at all, and :attr:`SourceCredit.usc_identifier` keeps the
+#: verbatim spelling, so nothing is lost.
 USLM_SECTION_DASH_RULE = "straighten-uslm-en-dash-to-hyphen-v1"
 
 #: Every way this module declines to read a credit. Codes are data: the artifact
 #: records them per row and the receipt counts them.
 QUARANTINE_REASONS = (
     #: The credit sits under no ``<section>`` at all -- a chapter-level or
-    #: appendix credit. 549 of the release point's 51,548 credits are like this,
-    #: and none of them carries an enactment construction with a division.
+    #: appendix credit. 549 of release point 119-102's 51,548 credits sit there,
+    #: and none of them carries an enactment construction naming a division.
     "credit_outside_usc_section",
     #: The enclosing section's identifier is not ``/us/usc/tN/sX``. The appendix
     #: titles carry ``/us/usc/t18a/pl/91/538/s1`` and its kin.
@@ -101,11 +103,11 @@ _DASH = re.compile(f"[{_DASHES}]")
 
 #: The enactment construction, the public law, its division, and the act section.
 #:
-#: ``lead`` is the whole rule: an empty lead is an amendment (or a re-statement
-#: of the amended act's own citation) and is discarded. Intervening structural
-#: units -- ``title I``, ``subtitle B``, ``ch. 2`` -- are crossed but never
-#: captured, because the act section is the last one and the earlier ones are
-#: not it.
+#: ``lead`` carries the whole rule: an empty lead marks an amendment, or a
+#: restatement of the amended act's own citation, and :func:`scan_source_credits`
+#: discards it. The expression crosses intervening structural units --
+#: ``title I``, ``subtitle B``, ``ch. 2`` -- without capturing them, because the
+#: act section is the one the ``§`` introduces.
 _ENACTMENT = re.compile(
     r"(?P<lead>as\s+added\s+|added\s+|)"
     r"Pub\.\s*L\.\s*(?P<congress>[1-9]\d{0,2})"
@@ -125,8 +127,8 @@ _LEADS = frozenset({"added", "as added"})
 def uslm_release_url(release_point: str) -> str:
     """The whole-Code zip for a release point such as ``"119-102"``.
 
-    A release point of any other shape is refused rather than turned into a URL
-    that would 404, so a build fails on the key rather than on the response.
+    Any other shape raises instead of becoming a URL that would 404, so a build
+    fails on the key rather than on the response.
     """
     match = _RELEASE_POINT.fullmatch(release_point or "")
     if match is None:
@@ -137,8 +139,8 @@ def uslm_release_url(release_point: str) -> str:
 def normalize_usc_section(value: object) -> str:
     """Straighten a USLM section suffix to the spelling everything else uses.
 
-    Implements :data:`USLM_SECTION_DASH_RULE`. Nothing else about the section is
-    touched: this is a dash, not a normalization policy.
+    Implements :data:`USLM_SECTION_DASH_RULE` and touches nothing else about the
+    section: this rewrites a dash, it is not a normalization policy.
     """
     return _DASH.sub("-", str(value or ""))
 
@@ -176,7 +178,16 @@ class QuarantinedCredit:
 
 @dataclass(frozen=True)
 class CreditScan:
-    """What one USLM title said, including what it said nothing usable about."""
+    """One USLM title's credits, its quarantine, and the four counts it keeps.
+
+    ``credits_scanned`` and ``credits_naming_a_division`` count credits.
+    ``strict_matches`` and ``credits_outside_a_section`` count *matches* of
+    :data:`STRICT_ENACTMENT_RULE`, the second only those sitting under no
+    ``<section>``. So ``credits_outside_a_section`` reads 0 on release point
+    119-102, where 549 credits do sit outside a section and none of them
+    matches the strict rule. The name is a key in a sealed receipt; read it as
+    "strict matches outside a section".
+    """
 
     credits: list[SourceCredit] = field(default_factory=list)
     quarantine: list[QuarantinedCredit] = field(default_factory=list)
@@ -199,17 +210,18 @@ class CreditScan:
 def iter_source_credits(document: bytes | str) -> Iterator[tuple[str | None, str]]:
     """Yield ``(enclosing section identifier, credit text)`` for one USLM title.
 
-    The identifier is the nearest **ancestor** ``<section>``'s, which is why this
-    walks the tree: a credit that follows a nested section's close tag has a
-    different nearest-preceding tag than it has ancestor.
+    The identifier is the nearest **ancestor** ``<section>``'s, which is why
+    this walks the tree. A credit that follows a nested section's close tag has
+    the inner section nearest before it and the outer section around it, and
+    only the section around it owns the credit.
 
-    Memory is bounded the same way :mod:`spicy_regs.sources.unified_agenda`
-    bounds it -- the finished record's subtree is dropped as the parse moves on.
+    Clearing each finished ``<section>`` bounds the memory, the same bound
+    :mod:`spicy_regs.sources.unified_agenda` applies for the same reason.
     ``iterparse`` streams the *events*, not the *tree*: without the clear it
-    retains every element it has seen, so the peak is the whole title, and
-    title 42 is 113 MB of it. Measured over a synthetic USLM title of that size:
-    775 MB of resident tree without the clear against 6 MB with it, same output,
-    and 29% quicker for not allocating it.
+    retains every element it has seen, so the peak is the whole title, and title
+    42 is 113 MB of it. Measured over a synthetic USLM title of that size:
+    775 MB of resident tree without the clear against 6 MB with it, identical
+    output, and 29% quicker for never allocating it.
     """
     payload = document.encode("utf-8") if isinstance(document, str) else document
     stack: list[str | None] = []
@@ -229,11 +241,11 @@ def iter_source_credits(document: bytes | str) -> Iterator[tuple[str | None, str
 
 
 def _flatten(element: ElementTree.Element) -> str:
-    """The credit's visible text.
+    """The credit's visible text, with ASCII whitespace collapsed and no more.
 
-    Only ASCII whitespace is collapsed. USLM writes ``§ 107`` with a narrow
-    no-break space, and rewriting it would be editing the source to suit the
-    expression rather than the other way round.
+    USLM writes ``§ 107`` with a narrow no-break space. Rewriting that would
+    edit the source to suit the expression rather than the other way round, so
+    :data:`_ENACTMENT` matches the space where it stands.
     """
     return re.sub(r"[ \t\r\n]+", " ", "".join(element.itertext())).strip()
 

--- a/src/spicy_regs/sources/uscode_uslm.py
+++ b/src/spicy_regs/sources/uscode_uslm.py
@@ -93,8 +93,11 @@ _RELEASE_POINT = re.compile(r"^(?P<congress>[1-9]\d{0,2})-(?P<law>[1-9]\d*)$")
 #: and must not be read as one.
 _USC_SECTION_IDENTIFIER = re.compile(r"^/us/usc/t(?P<title>[1-9]\d*)/s(?P<section>[^/]+)$")
 
-#: Every dash the Statutes at Large, USLM and prose spell a range with.
-_DASH = re.compile(r"[‐‑‒–—―]")
+#: Every dash the Statutes at Large, USLM and prose spell a range with. Spelled
+#: as escapes and shared by both expressions below: the six glyphs are visually
+#: indistinguishable, so a literal class cannot be read for what it contains.
+_DASHES = "\u2010\u2011\u2012\u2013\u2014\u2015"
+_DASH = re.compile(f"[{_DASHES}]")
 
 #: The enactment construction, the public law, its division, and the act section.
 #:
@@ -105,7 +108,9 @@ _DASH = re.compile(r"[‐‑‒–—―]")
 #: not it.
 _ENACTMENT = re.compile(
     r"(?P<lead>as\s+added\s+|added\s+|)"
-    r"Pub\.\s*L\.\s*(?P<congress>[1-9]\d{0,2})[-‐-―](?P<law>[1-9]\d*)"
+    r"Pub\.\s*L\.\s*(?P<congress>[1-9]\d{0,2})"
+    f"[-{_DASHES}]"
+    r"(?P<law>[1-9]\d*)"
     r"\s*,\s*div\.\s*(?P<division>[A-Z]{1,3})\b"
     r"(?:\s*,\s*(?:title|subtitle|part|ch\.|chapter|subch\.|subchapter)[^,§]{0,40})*"
     r"\s*,?\s*§+\s*(?P<section>[1-9]\d*[A-Za-z]?)",
@@ -197,6 +202,14 @@ def iter_source_credits(document: bytes | str) -> Iterator[tuple[str | None, str
     The identifier is the nearest **ancestor** ``<section>``'s, which is why this
     walks the tree: a credit that follows a nested section's close tag has a
     different nearest-preceding tag than it has ancestor.
+
+    Memory is bounded the same way :mod:`spicy_regs.sources.unified_agenda`
+    bounds it -- the finished record's subtree is dropped as the parse moves on.
+    ``iterparse`` streams the *events*, not the *tree*: without the clear it
+    retains every element it has seen, so the peak is the whole title, and
+    title 42 is 113 MB of it. Measured over a synthetic USLM title of that size:
+    775 MB of resident tree without the clear against 6 MB with it, same output,
+    and 29% quicker for not allocating it.
     """
     payload = document.encode("utf-8") if isinstance(document, str) else document
     stack: list[str | None] = []
@@ -208,6 +221,11 @@ def iter_source_credits(document: bytes | str) -> Iterator[tuple[str | None, str
         if tag == "sourceCredit":
             yield next((s for s in reversed(stack) if s), None), _flatten(element)
         stack.pop()
+        if tag == "section":
+            # Every credit this section encloses has already been yielded, and
+            # the identifier the enclosing sections still need is on the stack,
+            # not in the attributes being dropped.
+            element.clear()
 
 
 def _flatten(element: ElementTree.Element) -> str:

--- a/src/spicy_regs/sources/uscode_uslm.py
+++ b/src/spicy_regs/sources/uscode_uslm.py
@@ -1,0 +1,299 @@
+"""Read the U.S. Code's own source credits from the OLRC's USLM XML.
+
+Every section of the Code carries a ``<sourceCredit>`` naming the law that
+enacted it and every law that has amended it since:
+
+    (Added Pub. L. 116-260, div. EE, title I, § 107(d)(1), Dec. 27, 2020,
+     134 Stat. 3048.)
+
+Those credits provide a **second independent statement** of the
+act-section-to-U.S.-Code join also described by the Office of the Law Revision
+Counsel's (OLRC) Table III. They also state something Table III does not: the
+*division* of the enacting public law, per section. Table III is keyed by the
+enacting public law alone, and one public law may enact dozens of acts --
+116-260 enacts 94 -- so a division stated per section is exactly the
+discriminator Table III lacks.
+
+**The two sources are complementary, not redundant.** Measured on release point
+119-102 against a pinned Table III comparison: of the 222 unambiguous triples
+this module retains for public laws present in that comparison, **176 have no
+in-division Table III row at all**. 26 U.S.C. 6038E is one of them. A
+disagreement between the sources is a coverage fact, not noise, and neither is
+a tiebreaker over the other.
+
+**The rule is a refusal rule, and the mess is why.** A credit lists the
+enactment and every amendment, so an expression that accepts any ``Pub. L. N-M,
+div. X ... § S`` anywhere in a credit pairs a division with a section number
+belonging to a different citation in the same credit. Measured: 13,122 triples,
+of which 2,916 map to more than one U.S. Code section. Reading role by proximity
+to the word "amended" does not fix it -- it credits 26 U.S.C. 7652 to
+(116-260, div. EE, § 107), and that credit never says "amended".
+
+:data:`STRICT_ENACTMENT_RULE` requires the citation to sit in an explicit
+enactment construction -- ``Added Pub. L. ...`` or ``as added Pub. L. ...``.
+That collapses the population to 2,202 triples, 1,877 of them naming exactly one
+U.S. Code section, and it removes the 7652 false positive. What it does not
+retain, it does not guess at: 22 U.S.C. 2714a reads ``(Pub. L. 114-94, div. C,
+title XXXII, § 32101, ...)`` with no enactment construction, and this module
+carries no row for it.
+
+**Why an XML parse rather than a regular expression over the file.** Unlike the
+Popular Name Tool's flat generated HTML, USLM is well-formed XML whose
+``<section>`` elements nest, and a credit must be attributed to the section that
+*contains* it. A nearest-preceding-tag scan attributes a credit sitting after a
+nested close to the wrong section. The ancestry is the fact being read, so it is
+read structurally. The strict rule itself is an expression over the credit's own
+flattened text, because the construction it looks for is prose.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import xml.etree.ElementTree as ElementTree
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: The whole Code for one release point, one zip. Measured: 109 MB, ~49 s, 58
+#: titles. There is no per-section endpoint worth 51,548 requests.
+USLM_RELEASE_URL_TEMPLATE = (
+    "https://uscode.house.gov/download/releasepoints/us/pl/{congress}/{law}/xml_uscAll@{congress}-{law}.zip"
+)
+
+#: Require an explicit enactment construction. See the module docstring for the
+#: measured alternative and why it is unsafe.
+STRICT_ENACTMENT_RULE = "added-or-as-added-pub-law-division-act-section-v1"
+
+#: USLM spells a section suffix with an EN DASH (``/us/usc/t16/s824s–1``);
+#: OLRC's Table III and ordinary U.S. Code citations spell it with a hyphen.
+#: Verified on release point 119-102: title 16 alone carries 1,487
+#: en-dash section identifiers and **zero** hyphen ones, so this is a spelling
+#: convention of the source rather than a distinction it draws. Straightening it
+#: is what lets the two OLRC surfaces join at all; the verbatim identifier is
+#: carried alongside so nothing is lost.
+USLM_SECTION_DASH_RULE = "straighten-uslm-en-dash-to-hyphen-v1"
+
+#: Every way this module declines to read a credit. Codes are data: the artifact
+#: records them per row and the receipt counts them.
+QUARANTINE_REASONS = (
+    #: The credit sits under no ``<section>`` at all -- a chapter-level or
+    #: appendix credit. 549 of the release point's 51,548 credits are like this,
+    #: and none of them carries an enactment construction with a division.
+    "credit_outside_usc_section",
+    #: The enclosing section's identifier is not ``/us/usc/tN/sX``. The appendix
+    #: titles carry ``/us/usc/t18a/pl/91/538/s1`` and its kin.
+    "section_identifier_unparsable",
+)
+
+_RELEASE_POINT = re.compile(r"^(?P<congress>[1-9]\d{0,2})-(?P<law>[1-9]\d*)$")
+
+#: A U.S. Code section identifier, and only that shape. A subsection
+#: (``/us/usc/t26/s6038E/a``) or an appendix path is not a section identifier
+#: and must not be read as one.
+_USC_SECTION_IDENTIFIER = re.compile(r"^/us/usc/t(?P<title>[1-9]\d*)/s(?P<section>[^/]+)$")
+
+#: Every dash the Statutes at Large, USLM and prose spell a range with.
+_DASH = re.compile(r"[‐‑‒–—―]")
+
+#: The enactment construction, the public law, its division, and the act section.
+#:
+#: ``lead`` is the whole rule: an empty lead is an amendment (or a re-statement
+#: of the amended act's own citation) and is discarded. Intervening structural
+#: units -- ``title I``, ``subtitle B``, ``ch. 2`` -- are crossed but never
+#: captured, because the act section is the last one and the earlier ones are
+#: not it.
+_ENACTMENT = re.compile(
+    r"(?P<lead>as\s+added\s+|added\s+|)"
+    r"Pub\.\s*L\.\s*(?P<congress>[1-9]\d{0,2})[-‐-―](?P<law>[1-9]\d*)"
+    r"\s*,\s*div\.\s*(?P<division>[A-Z]{1,3})\b"
+    r"(?:\s*,\s*(?:title|subtitle|part|ch\.|chapter|subch\.|subchapter)[^,§]{0,40})*"
+    r"\s*,?\s*§+\s*(?P<section>[1-9]\d*[A-Za-z]?)",
+    re.IGNORECASE,
+)
+
+_STATUTES_AT_LARGE = re.compile(r"(?P<volume>[1-9]\d{0,2})\s+Stat\.\s+(?P<page>[1-9]\d{0,4})")
+
+_LEADS = frozenset({"added", "as added"})
+
+
+def uslm_release_url(release_point: str) -> str:
+    """The whole-Code zip for a release point such as ``"119-102"``.
+
+    A release point of any other shape is refused rather than turned into a URL
+    that would 404, so a build fails on the key rather than on the response.
+    """
+    match = _RELEASE_POINT.fullmatch(release_point or "")
+    if match is None:
+        raise ValueError(f"invalid U.S. Code release point: {release_point!r}")
+    return USLM_RELEASE_URL_TEMPLATE.format(congress=match.group("congress"), law=match.group("law"))
+
+
+def normalize_usc_section(value: object) -> str:
+    """Straighten a USLM section suffix to the spelling everything else uses.
+
+    Implements :data:`USLM_SECTION_DASH_RULE`. Nothing else about the section is
+    touched: this is a dash, not a normalization policy.
+    """
+    return _DASH.sub("-", str(value or ""))
+
+
+@dataclass(frozen=True)
+class SourceCredit:
+    """One U.S. Code section, and the act section that added it."""
+
+    public_law: str
+    division: str
+    act_section: str
+    usc_title: str
+    usc_section: str
+    #: The USLM identifier verbatim, en dash and all, so the row stays auditable
+    #: against the bytes it was read from.
+    usc_identifier: str
+    statutes_at_large_volume: str | None = None
+    statutes_at_large_page: str | None = None
+
+
+@dataclass(frozen=True)
+class QuarantinedCredit:
+    """A credit that matched the strict rule and could not be attributed."""
+
+    reason: str
+    public_law: str
+    division: str
+    act_section: str
+    raw_value: str
+
+    def __post_init__(self) -> None:
+        if self.reason not in QUARANTINE_REASONS:
+            raise ValueError(f"undeclared quarantine reason: {self.reason!r}")
+
+
+@dataclass(frozen=True)
+class CreditScan:
+    """What one USLM title said, including what it said nothing usable about."""
+
+    credits: list[SourceCredit] = field(default_factory=list)
+    quarantine: list[QuarantinedCredit] = field(default_factory=list)
+    credits_scanned: int = 0
+    credits_naming_a_division: int = 0
+    credits_outside_a_section: int = 0
+    strict_matches: int = 0
+
+    def merge(self, other: CreditScan) -> CreditScan:
+        return CreditScan(
+            credits=self.credits + other.credits,
+            quarantine=self.quarantine + other.quarantine,
+            credits_scanned=self.credits_scanned + other.credits_scanned,
+            credits_naming_a_division=self.credits_naming_a_division + other.credits_naming_a_division,
+            credits_outside_a_section=self.credits_outside_a_section + other.credits_outside_a_section,
+            strict_matches=self.strict_matches + other.strict_matches,
+        )
+
+
+def iter_source_credits(document: bytes | str) -> Iterator[tuple[str | None, str]]:
+    """Yield ``(enclosing section identifier, credit text)`` for one USLM title.
+
+    The identifier is the nearest **ancestor** ``<section>``'s, which is why this
+    walks the tree: a credit that follows a nested section's close tag has a
+    different nearest-preceding tag than it has ancestor.
+    """
+    payload = document.encode("utf-8") if isinstance(document, str) else document
+    stack: list[str | None] = []
+    for event, element in ElementTree.iterparse(io.BytesIO(payload), events=("start", "end")):
+        tag = element.tag.rsplit("}", 1)[-1]
+        if event == "start":
+            stack.append(element.get("identifier") if tag == "section" else None)
+            continue
+        if tag == "sourceCredit":
+            yield next((s for s in reversed(stack) if s), None), _flatten(element)
+        stack.pop()
+
+
+def _flatten(element: ElementTree.Element) -> str:
+    """The credit's visible text.
+
+    Only ASCII whitespace is collapsed. USLM writes ``§ 107`` with a narrow
+    no-break space, and rewriting it would be editing the source to suit the
+    expression rather than the other way round.
+    """
+    return re.sub(r"[ \t\r\n]+", " ", "".join(element.itertext())).strip()
+
+
+def scan_source_credits(document: bytes | str) -> CreditScan:
+    """Apply :data:`STRICT_ENACTMENT_RULE` to one USLM title's source credits."""
+    credits: list[SourceCredit] = []
+    quarantine: list[QuarantinedCredit] = []
+    scanned = naming_a_division = outside = strict_matches = 0
+
+    for identifier, text in iter_source_credits(document):
+        scanned += 1
+        if "div." in text:
+            naming_a_division += 1
+        matches = list(_ENACTMENT.finditer(text))
+        for position, match in enumerate(matches):
+            if (match.group("lead") or "").strip().lower() not in _LEADS:
+                continue
+            strict_matches += 1
+            public_law = f"{match.group('congress')}-{match.group('law')}"
+            division, act_section = match.group("division"), match.group("section")
+            section = _USC_SECTION_IDENTIFIER.fullmatch(identifier or "")
+            if section is None:
+                if identifier is None:
+                    outside += 1
+                quarantine.append(
+                    QuarantinedCredit(
+                        reason="credit_outside_usc_section" if identifier is None else "section_identifier_unparsable",
+                        public_law=public_law,
+                        division=division,
+                        act_section=act_section,
+                        raw_value=identifier or "",
+                    )
+                )
+                continue
+            # The page belongs to the citation it follows, so the search window
+            # ends where the next citation begins. A credit listing several
+            # enactments states several pages and they are not interchangeable.
+            end = matches[position + 1].start() if position + 1 < len(matches) else len(text)
+            page = _STATUTES_AT_LARGE.search(text, match.end(), end)
+            credits.append(
+                SourceCredit(
+                    public_law=public_law,
+                    division=division,
+                    act_section=act_section,
+                    usc_title=section.group("title"),
+                    usc_section=normalize_usc_section(section.group("section")),
+                    usc_identifier=identifier or "",
+                    statutes_at_large_volume=page.group("volume") if page else None,
+                    statutes_at_large_page=page.group("page") if page else None,
+                )
+            )
+
+    return CreditScan(
+        credits=credits,
+        quarantine=quarantine,
+        credits_scanned=scanned,
+        credits_naming_a_division=naming_a_division,
+        credits_outside_a_section=outside,
+        strict_matches=strict_matches,
+    )
+
+
+def scan_release_zip(archive: Path) -> tuple[CreditScan, list[tuple[str, str]]]:
+    """Scan every title in a whole-Code release zip.
+
+    Returns the merged scan and one ``(member, sha256)`` pair per title, sorted,
+    so a receipt pins the bytes each count was read from rather than only the
+    zip they arrived in.
+    """
+    import hashlib
+    import zipfile
+
+    scan = CreditScan()
+    members: list[tuple[str, str]] = []
+    with zipfile.ZipFile(archive) as bundle:
+        for name in sorted(n for n in bundle.namelist() if n.endswith(".xml")):
+            payload = bundle.read(name)
+            members.append((name, f"sha256:{hashlib.sha256(payload).hexdigest()}"))
+            scan = scan.merge(scan_source_credits(payload))
+    return scan, members

--- a/tests/test_build_usc_source_credit_artifact.py
+++ b/tests/test_build_usc_source_credit_artifact.py
@@ -1,0 +1,153 @@
+"""The sealed U.S. Code source-credit artifact, built from a synthetic release zip.
+
+The builder's whole claim is that one archive yields one set of bytes: the
+receipt names digests, so a build that is not reproducible is a receipt that
+lies. These tests exercise that claim, and the two refusals the build carries --
+a triple naming several sections is marked rather than dropped, and a
+secret-shaped value stops the seal.
+
+The parquet is written with pyarrow and read back with polars, so the read-back
+cannot agree with the writer merely by sharing its assumptions.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from scripts.build_usc_source_credit_artifact import build
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+USLM = "http://xml.house.gov/schemas/uslm/1.0"
+
+
+def _title(identifier: str, body: str) -> bytes:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<uscDoc xmlns="{USLM}" identifier="{identifier}"><main>{body}</main></uscDoc>""".encode()
+
+
+def _section(identifier: str, credit: str) -> str:
+    return f"""<section identifier="{identifier}"><num>§ x.</num>
+<sourceCredit>{credit}</sourceCredit></section>"""
+
+
+_ADDED_107 = (
+    '(Added <ref href="/us/pl/116/260/dEE/tI/s107">Pub. L. 116–260, div. EE, title I, § 107(d)(1)</ref>, '
+    '<ref href="/us/stat/134/3048">134 Stat. 3048</ref>.)'
+)
+_ADDED_303 = (
+    '(Added <ref href="/us/pl/117/328/dT/tIII/s303">Pub. L. 117–328, div. T, title III, § 303</ref>, '
+    '<ref href="/us/stat/136/5339">136 Stat. 5339</ref>.)'
+)
+
+
+def _archive(tmp_path: Path, name: str, members: dict[str, bytes]) -> Path:
+    path = tmp_path / name
+    with zipfile.ZipFile(path, "w") as bundle:
+        for member, payload in sorted(members.items()):
+            bundle.writestr(member, payload)
+    return path
+
+
+@pytest.fixture
+def archive(tmp_path: Path) -> Path:
+    """Two titles: one act section naming two sections, one naming one, one appendix."""
+    return _archive(
+        tmp_path,
+        "uscall.zip",
+        {
+            "usc26.xml": _title(
+                "/us/usc/t26",
+                _section("/us/usc/t26/s6038E", _ADDED_107) + _section("/us/usc/t26/s6038F", _ADDED_107),
+            ),
+            "usc16.xml": _title(
+                "/us/usc/t16",
+                _section("/us/usc/t16/s824s–1", _ADDED_303) + _section("/us/usc/t18a/pl/91/538/s1", _ADDED_303),
+            ),
+        },
+    )
+
+
+def test_a_triple_naming_two_sections_is_kept_and_marked_not_dropped(tmp_path: Path, archive: Path):
+    """ "The source said two things" is a different fact from "it said nothing"."""
+    receipt = build(tmp_path / "out", archive=archive, release_point="119-102")
+
+    rows = pl.read_parquet(tmp_path / "out" / "usc-source-credits.parquet").sort("usc_section")
+    assert rows["usc_section"].to_list() == ["6038E", "6038F", "824s-1"]
+    # 107 named two sections and is refused at resolution; 303 named one and is not.
+    assert rows["refusal"].to_list() == ["multi_target", "multi_target", None]
+    assert rows["target_count"].to_list() == ["2", "2", "1"]
+    # The en dash is straightened in usc_section and kept verbatim alongside it.
+    assert rows["usc_identifier"].to_list()[2] == "/us/usc/t16/s824s–1"
+    assert receipt["coverage"]["multi_target_triples"] == 1
+    assert receipt["coverage"]["unambiguous_triples"] == 1
+
+
+def test_a_section_identifier_the_usc_shape_cannot_spell_reaches_the_quarantine_file(tmp_path: Path, archive: Path):
+    receipt = build(tmp_path / "out", archive=archive, release_point="119-102")
+
+    quarantine = pl.read_parquet(tmp_path / "out" / "quarantine.parquet")
+    assert quarantine["raw_value"].to_list() == ["/us/usc/t18a/pl/91/538/s1"]
+    assert quarantine["reason"].to_list() == ["section_identifier_unparsable"]
+    assert receipt["coverage"]["quarantine_reasons"] == {"section_identifier_unparsable": 1}
+
+
+def test_two_builds_of_one_archive_write_the_same_bytes(tmp_path: Path, archive: Path):
+    """The receipt names digests, so a non-reproducible build is a receipt that lies.
+
+    The second build runs in a fresh interpreter under a different
+    ``PYTHONHASHSEED``. Rebuilding in this one would compare the process against
+    itself and could not see set or dict iteration order reaching the bytes.
+    """
+    build(tmp_path / "a", archive=archive, release_point="119-102")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.build_usc_source_credit_artifact",
+            "--output",
+            str(tmp_path / "b"),
+            "--archive",
+            str(archive),
+            "--release-point",
+            "119-102",
+        ],
+        cwd=REPO_ROOT,
+        env={**os.environ, "PYTHONHASHSEED": "1"},
+        check=True,
+        capture_output=True,
+    )
+
+    for name in ("usc-source-credits.parquet", "quarantine.parquet", "receipt.json"):
+        assert (tmp_path / "a" / name).read_bytes() == (tmp_path / "b" / name).read_bytes()
+
+
+def test_the_receipt_pins_the_bytes_of_every_title_and_the_rules_applied(tmp_path: Path, archive: Path):
+    receipt = build(tmp_path / "out", archive=archive, release_point="119-102")
+
+    # Per-title digests, not only the archive's: the counts were read from these.
+    assert [t["member"] for t in receipt["inputs"]["titles"]] == ["usc16.xml", "usc26.xml"]
+    assert all(t["digest"].startswith("sha256:") for t in receipt["inputs"]["titles"])
+    assert receipt["inputs"]["release_url"].endswith("xml_uscAll@119-102.zip")
+    assert receipt["rules"]["strict_enactment_rule"] == "added-or-as-added-pub-law-division-act-section-v1"
+    assert receipt["rules"]["section_dash_rule"] == "straighten-uslm-en-dash-to-hyphen-v1"
+    assert receipt["rules"]["multi_target_policy"] == "retain-and-mark-refusal-multi_target-v1"
+
+
+def test_a_secret_shaped_value_stops_the_seal(tmp_path: Path):
+    """A credential must not reach a sealed file, whatever path carried it there."""
+    leaky = _archive(
+        tmp_path,
+        "leaky.zip",
+        {"usc26.xml": _title("/us/usc/t26", _section("/us/usc/t18a/api_key=deadbeef1234", _ADDED_107))},
+    )
+
+    with pytest.raises(SystemExit, match="refusing to seal"):
+        build(tmp_path / "out", archive=leaky, release_point="119-102")

--- a/tests/test_build_usc_source_credit_artifact.py
+++ b/tests/test_build_usc_source_credit_artifact.py
@@ -2,12 +2,12 @@
 
 The builder's whole claim is that one archive yields one set of bytes: the
 receipt names digests, so a build that is not reproducible is a receipt that
-lies. These tests exercise that claim, and the two refusals the build carries --
+lies. These tests exercise that claim and the two refusals the build carries --
 a triple naming several sections is marked rather than dropped, and a
 secret-shaped value stops the seal.
 
-The parquet is written with pyarrow and read back with polars, so the read-back
-cannot agree with the writer merely by sharing its assumptions.
+pyarrow writes the parquet and polars reads it back, so the read-back cannot
+agree with the writer merely by sharing its assumptions.
 """
 
 from __future__ import annotations
@@ -58,7 +58,7 @@ def _archive(tmp_path: Path, name: str, members: dict[str, bytes]) -> Path:
 
 @pytest.fixture
 def archive(tmp_path: Path) -> Path:
-    """Two titles: one act section naming two sections, one naming one, one appendix."""
+    """Two titles: act section 107 names two Code sections, 303 names one, plus one appendix identifier."""
     return _archive(
         tmp_path,
         "uscall.zip",
@@ -81,7 +81,7 @@ def test_a_triple_naming_two_sections_is_kept_and_marked_not_dropped(tmp_path: P
 
     rows = pl.read_parquet(tmp_path / "out" / "usc-source-credits.parquet").sort("usc_section")
     assert rows["usc_section"].to_list() == ["6038E", "6038F", "824s-1"]
-    # 107 named two sections and is refused at resolution; 303 named one and is not.
+    # 107 named two sections, so both its rows carry the refusal; 303 named one.
     assert rows["refusal"].to_list() == ["multi_target", "multi_target", None]
     assert rows["target_count"].to_list() == ["2", "2", "1"]
     # The en dash is straightened in usc_section and kept verbatim alongside it.

--- a/tests/test_sources_uscode_uslm.py
+++ b/tests/test_sources_uscode_uslm.py
@@ -1,14 +1,14 @@
 """The U.S. Code's own source credits, read as a pure parser over USLM bytes.
 
 Every fixture below is real markup, copied from the release point the artifact
-pins. The parser is asserted against those bytes rather than against a live
-request, so the shapes this module claims to read are pinned by the test.
+pins, so these tests assert against the bytes the parser will meet rather than
+against a live request.
 
-The rule under test is a **refusal** rule. A source credit lists the enactment
-*and* every later amendment, so a match that does not require an enactment
-construction pairs a division with a section number from a different citation in
-the same credit. The measured example is in this file: 26 U.S.C. 7652's credit
-names ``div. EE ... § 107``, and 7652 was not added by it.
+The rule under test **refuses**. A source credit lists the enactment *and*
+every later amendment, so a match that does not demand an enactment
+construction pairs a division with a section number from a different citation
+in the same credit. ``AMENDED_ONLY`` below is the measured case: 26 U.S.C.
+7652's credit names ``div. EE ... § 107``, and 7652 was not added by it.
 """
 
 from __future__ import annotations
@@ -40,17 +40,18 @@ ADDED = _document(
 )
 
 # 29 U.S.C. 1153, verbatim. The construction is "as added Pub. L. ..." and the
-# credit ALSO names Pub. L. 93-406, which enacted the section it was added to.
+# credit ALSO names Pub. L. 93-406, which created the act the section was added
+# to.
 AS_ADDED = _document(
     """<section identifier="/us/usc/t29/s1153"><num value="1153">§ 1153.</num>
 <sourceCredit>(<ref href="/us/pl/93/406/tI/s523">Pub. L. 93–406, title I, § 523</ref>, as added <ref href="/us/pl/117/328/dT/tIII/s303/a">Pub. L. 117–328, div. T, title III, § 303(a)</ref>, <date date="2022-12-29">Dec. 29, 2022</date>, <ref href="/us/stat/136/5339">136 Stat. 5339</ref>.)</sourceCredit>
 </section>"""
 )
 
-# 26 U.S.C. 7652, abbreviated but verbatim in the part that matters. The credit
-# names (116-260, div. EE, sec. 107) as an AMENDMENT, at 134 Stat. 3046 -- the
-# enactment of 6038E is at 3048. A loose rule credits 7652 to that triple. This
-# is the measured false positive the strict rule exists to remove.
+# 26 U.S.C. 7652, abbreviated but verbatim where it matters. This credit names
+# (116-260, div. EE, § 107) as an AMENDMENT at 134 Stat. 3046, while that act
+# section's enactment of 6038E sits at 3048. A loose rule credits 7652 to the
+# triple anyway: the measured false positive the strict rule exists to remove.
 AMENDED_ONLY = _document(
     """<section identifier="/us/usc/t26/s7652"><num value="7652">§ 7652.</num>
 <sourceCredit>(<date date="1954-08-16">Aug. 16, 1954</date>, ch. 736, 68A Stat. 907; <ref href="/us/pl/115/123/dD/tII/s41102/a/1">Pub. L. 115–123, div. D, title II, § 41102(a)(1), (b)(1)</ref>, Feb. 9, 2018, 132 Stat. 155; <ref href="/us/pl/116/260/dEE/tI/s107/a/2">Pub. L. 116–260, div. EE, title I, § 107(a)(2)</ref>, <date date="2020-12-27">Dec. 27, 2020</date>, <ref href="/us/stat/134/3046">134 Stat. 3046</ref>.)</sourceCredit>
@@ -82,8 +83,8 @@ def test_an_added_construction_yields_the_triple_and_its_page():
 def test_an_as_added_construction_credits_the_adding_law_not_the_amended_one():
     """ "Pub. L. 93-406 ... as added Pub. L. 117-328, div. T, sec. 303(a)".
 
-    The section was added BY 117-328 TO the act 93-406 created. Only the adding
-    law is an enactment of this section, and only it names a division.
+    117-328 added the section to the act 93-406 created. Only the adding law
+    enacted this section, and only it names a division.
     """
     scan = scan_source_credits(AS_ADDED)
 
@@ -98,9 +99,8 @@ def test_a_credit_that_only_amends_yields_nothing():
 
     26 U.S.C. 7652's credit names (116-260, div. EE, sec. 107) at 134 Stat.
     3046. A loose expression reads that as an enactment and credits 7652 to the
-    triple that actually enacted 26 U.S.C. 6038E at 3048. Reading the role by
-    proximity to the word "amended" does not fix it -- this credit never uses
-    the word.
+    triple that enacted 26 U.S.C. 6038E at 3048. Reading the role by proximity
+    to the word "amended" fails here too: this credit never uses the word.
     """
     scan = scan_source_credits(AMENDED_ONLY)
 
@@ -155,10 +155,11 @@ def test_a_section_identifier_the_usc_shape_cannot_spell_is_quarantined():
 def test_a_credit_naming_no_division_is_not_read_at_all():
     """The index is keyed by division. A credit without one cannot key into it.
 
-    This is a coverage bound, stated rather than hidden: 22 U.S.C. 2714a reads
-    "(Pub. L. 114-94, div. C, title XXXII, sec. 32101, ...)" with no enactment
-    construction, and 21 U.S.C. 350a-1 likewise -- both are real classifications
-    this index does not carry.
+    Real classifications fall outside this index, and the bound is stated here
+    rather than hidden. The credit below names no division. 22 U.S.C. 2714a
+    reads "(Pub. L. 114-94, div. C, title XXXII, sec. 32101, ...)" and
+    21 U.S.C. 350a-1 likewise: a division, and no enactment construction around
+    it.
     """
     document = _document(
         """<section identifier="/us/usc/t26/s1"><num value="1">§ 1.</num>

--- a/tests/test_sources_uscode_uslm.py
+++ b/tests/test_sources_uscode_uslm.py
@@ -134,7 +134,7 @@ def test_a_credit_outside_any_usc_section_is_quarantined_not_dropped():
     (quarantined,) = scan.quarantine
     assert quarantined.reason == "credit_outside_usc_section"
     assert (quarantined.public_law, quarantined.division, quarantined.act_section) == ("116-260", "EE", "107")
-    assert scan.credits_outside_a_section == 1
+    assert scan.strict_matches_outside_a_section == 1
 
 
 def test_a_section_identifier_the_usc_shape_cannot_spell_is_quarantined():

--- a/tests/test_sources_uscode_uslm.py
+++ b/tests/test_sources_uscode_uslm.py
@@ -119,7 +119,6 @@ def test_the_en_dash_in_a_uslm_section_identifier_is_straightened():
     # the bytes it was read from.
     assert credit.usc_identifier == "/us/usc/t16/s824s–1"
     assert normalize_usc_section("824s–1") == "824s-1"
-    assert USLM_SECTION_DASH_RULE == "straighten-uslm-en-dash-to-hyphen-v1"
 
 
 def test_a_credit_outside_any_usc_section_is_quarantined_not_dropped():
@@ -185,16 +184,38 @@ def test_the_page_belongs_to_the_citation_it_follows():
     assert {(c.act_section, c.statutes_at_large_page) for c in scan.credits} == {("107", "3048"), ("303", "5339")}
 
 
-def test_the_strict_rule_is_a_named_constant():
+def test_a_credit_after_a_nested_section_belongs_to_the_section_containing_it():
+    """The module's stated reason for walking the tree rather than scanning it.
+
+    The outer section's credit follows the inner section's close tag, so its
+    nearest *preceding* section identifier is the inner one while its nearest
+    *ancestor* is the outer one. Only the ancestor is the fact.
+    """
+    document = _document(
+        """<section identifier="/us/usc/t26/s100"><num value="100">§ 100.</num>
+<section identifier="/us/usc/t26/s100A"><num value="100A">§ 100A.</num>
+<sourceCredit>(Added <ref href="/us/pl/117/328/dT/tIII/s303">Pub. L. 117–328, div. T, title III, § 303</ref>, <ref href="/us/stat/136/5339">136 Stat. 5339</ref>.)</sourceCredit>
+</section>
+<sourceCredit>(Added <ref href="/us/pl/116/260/dEE/tI/s107">Pub. L. 116–260, div. EE, title I, § 107</ref>, <ref href="/us/stat/134/3048">134 Stat. 3048</ref>.)</sourceCredit>
+</section>"""
+    )
+    scan = scan_source_credits(document)
+
+    assert {(c.act_section, c.usc_section) for c in scan.credits} == {("303", "100A"), ("107", "100")}
+    assert scan.quarantine == []
+
+
+def test_the_pinned_rules_are_named_constants():
+    """Both ids are written into the artifact receipt; a silent bump is the risk."""
     assert STRICT_ENACTMENT_RULE == "added-or-as-added-pub-law-division-act-section-v1"
+    assert USLM_SECTION_DASH_RULE == "straighten-uslm-en-dash-to-hyphen-v1"
 
 
-@pytest.mark.parametrize(
-    ("congress", "law", "expected"),
-    [(119, 102, "https://uscode.house.gov/download/releasepoints/us/pl/119/102/xml_uscAll@119-102.zip")],
-)
-def test_the_release_point_url_is_derived_from_the_release_point(congress, law, expected):
-    assert uslm_release_url(f"{congress}-{law}") == expected
+def test_the_release_point_url_is_derived_from_the_release_point():
+    assert (
+        uslm_release_url("119-102")
+        == "https://uscode.house.gov/download/releasepoints/us/pl/119/102/xml_uscAll@119-102.zip"
+    )
 
 
 def test_a_release_point_of_the_wrong_shape_is_refused():

--- a/tests/test_sources_uscode_uslm.py
+++ b/tests/test_sources_uscode_uslm.py
@@ -1,0 +1,202 @@
+"""The U.S. Code's own source credits, read as a pure parser over USLM bytes.
+
+Every fixture below is real markup, copied from the release point the artifact
+pins. The parser is asserted against those bytes rather than against a live
+request, so the shapes this module claims to read are pinned by the test.
+
+The rule under test is a **refusal** rule. A source credit lists the enactment
+*and* every later amendment, so a match that does not require an enactment
+construction pairs a division with a section number from a different citation in
+the same credit. The measured example is in this file: 26 U.S.C. 7652's credit
+names ``div. EE ... § 107``, and 7652 was not added by it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from spicy_regs.sources.uscode_uslm import (
+    STRICT_ENACTMENT_RULE,
+    USLM_SECTION_DASH_RULE,
+    normalize_usc_section,
+    scan_source_credits,
+    uslm_release_url,
+)
+
+USLM = "http://xml.house.gov/schemas/uslm/1.0"
+
+
+def _document(body: str) -> bytes:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<uscDoc xmlns="{USLM}" identifier="/us/usc/t26"><main>{body}</main></uscDoc>""".encode()
+
+
+# 26 U.S.C. 6038E, verbatim. The enactment construction is "(Added Pub. L. ...".
+ADDED = _document(
+    """<section identifier="/us/usc/t26/s6038E"><num value="6038E">§ 6038E.</num>
+<heading>Information</heading><content><p>text</p></content>
+<sourceCredit>(Added <ref href="/us/pl/116/260/dEE/tI/s107/d/1">Pub. L. 116–260, div. EE, title I, § 107(d)(1)</ref>, <date date="2020-12-27">Dec. 27, 2020</date>, <ref href="/us/stat/134/3048">134 Stat. 3048</ref>.)</sourceCredit>
+</section>"""
+)
+
+# 29 U.S.C. 1153, verbatim. The construction is "as added Pub. L. ..." and the
+# credit ALSO names Pub. L. 93-406, which enacted the section it was added to.
+AS_ADDED = _document(
+    """<section identifier="/us/usc/t29/s1153"><num value="1153">§ 1153.</num>
+<sourceCredit>(<ref href="/us/pl/93/406/tI/s523">Pub. L. 93–406, title I, § 523</ref>, as added <ref href="/us/pl/117/328/dT/tIII/s303/a">Pub. L. 117–328, div. T, title III, § 303(a)</ref>, <date date="2022-12-29">Dec. 29, 2022</date>, <ref href="/us/stat/136/5339">136 Stat. 5339</ref>.)</sourceCredit>
+</section>"""
+)
+
+# 26 U.S.C. 7652, abbreviated but verbatim in the part that matters. The credit
+# names (116-260, div. EE, sec. 107) as an AMENDMENT, at 134 Stat. 3046 -- the
+# enactment of 6038E is at 3048. A loose rule credits 7652 to that triple. This
+# is the measured false positive the strict rule exists to remove.
+AMENDED_ONLY = _document(
+    """<section identifier="/us/usc/t26/s7652"><num value="7652">§ 7652.</num>
+<sourceCredit>(<date date="1954-08-16">Aug. 16, 1954</date>, ch. 736, 68A Stat. 907; <ref href="/us/pl/115/123/dD/tII/s41102/a/1">Pub. L. 115–123, div. D, title II, § 41102(a)(1), (b)(1)</ref>, Feb. 9, 2018, 132 Stat. 155; <ref href="/us/pl/116/260/dEE/tI/s107/a/2">Pub. L. 116–260, div. EE, title I, § 107(a)(2)</ref>, <date date="2020-12-27">Dec. 27, 2020</date>, <ref href="/us/stat/134/3046">134 Stat. 3046</ref>.)</sourceCredit>
+</section>"""
+)
+
+# USLM spells a section suffix with an EN DASH; Table III spells it with a
+# hyphen. Straightening it is the only way the two sources join at all.
+EN_DASH = _document(
+    """<section identifier="/us/usc/t16/s824s–1"><num value="824s–1">§ 824s–1.</num>
+<sourceCredit>(Added <ref href="/us/pl/117/58/dD/tI/s40123">Pub. L. 117–58, div. D, title I, § 40123(a)</ref>, <date date="2021-11-15">Nov. 15, 2021</date>, <ref href="/us/stat/135/946">135 Stat. 946</ref>.)</sourceCredit>
+</section>"""
+)
+
+
+def test_an_added_construction_yields_the_triple_and_its_page():
+    scan = scan_source_credits(ADDED)
+
+    (credit,) = scan.credits
+    assert (credit.public_law, credit.division, credit.act_section) == ("116-260", "EE", "107")
+    assert (credit.usc_title, credit.usc_section) == ("26", "6038E")
+    assert credit.usc_identifier == "/us/usc/t26/s6038E"
+    assert (credit.statutes_at_large_volume, credit.statutes_at_large_page) == ("134", "3048")
+    assert scan.credits_scanned == 1
+    assert scan.credits_naming_a_division == 1
+    assert scan.quarantine == []
+
+
+def test_an_as_added_construction_credits_the_adding_law_not_the_amended_one():
+    """ "Pub. L. 93-406 ... as added Pub. L. 117-328, div. T, sec. 303(a)".
+
+    The section was added BY 117-328 TO the act 93-406 created. Only the adding
+    law is an enactment of this section, and only it names a division.
+    """
+    scan = scan_source_credits(AS_ADDED)
+
+    (credit,) = scan.credits
+    assert (credit.public_law, credit.division, credit.act_section) == ("117-328", "T", "303")
+    assert (credit.usc_title, credit.usc_section) == ("29", "1153")
+    assert (credit.statutes_at_large_volume, credit.statutes_at_large_page) == ("136", "5339")
+
+
+def test_a_credit_that_only_amends_yields_nothing():
+    """The measured false positive, kept as a regression.
+
+    26 U.S.C. 7652's credit names (116-260, div. EE, sec. 107) at 134 Stat.
+    3046. A loose expression reads that as an enactment and credits 7652 to the
+    triple that actually enacted 26 U.S.C. 6038E at 3048. Reading the role by
+    proximity to the word "amended" does not fix it -- this credit never uses
+    the word.
+    """
+    scan = scan_source_credits(AMENDED_ONLY)
+
+    assert scan.credits == []
+    assert scan.credits_scanned == 1
+    assert scan.credits_naming_a_division == 1, "the credit does name a division; the rule declines it anyway"
+
+
+def test_the_en_dash_in_a_uslm_section_identifier_is_straightened():
+    """USLM writes ``824s-1`` with an en dash and Table III writes a hyphen."""
+    scan = scan_source_credits(EN_DASH)
+
+    (credit,) = scan.credits
+    assert credit.usc_section == "824s-1"
+    # The verbatim identifier is kept, so the artifact stays auditable against
+    # the bytes it was read from.
+    assert credit.usc_identifier == "/us/usc/t16/s824s–1"
+    assert normalize_usc_section("824s–1") == "824s-1"
+    assert USLM_SECTION_DASH_RULE == "straighten-uslm-en-dash-to-hyphen-v1"
+
+
+def test_a_credit_outside_any_usc_section_is_quarantined_not_dropped():
+    """A credit the parser cannot attribute must be visible, never silent."""
+    document = _document(
+        """<level identifier="/us/usc/t26/ch61"><heading>x</heading>
+<sourceCredit>(Added <ref href="/us/pl/116/260/dEE/tI/s107">Pub. L. 116–260, div. EE, title I, § 107</ref>, <ref href="/us/stat/134/3048">134 Stat. 3048</ref>.)</sourceCredit>
+</level>"""
+    )
+    scan = scan_source_credits(document)
+
+    assert scan.credits == []
+    (quarantined,) = scan.quarantine
+    assert quarantined.reason == "credit_outside_usc_section"
+    assert (quarantined.public_law, quarantined.division, quarantined.act_section) == ("116-260", "EE", "107")
+    assert scan.credits_outside_a_section == 1
+
+
+def test_a_section_identifier_the_usc_shape_cannot_spell_is_quarantined():
+    """The appendix titles carry ``/us/usc/t18a/pl/91/538/s1`` and its kin."""
+    document = _document(
+        """<section identifier="/us/usc/t18a/pl/91/538/s1"><num value="1">§ 1.</num>
+<sourceCredit>(Added <ref href="/us/pl/116/260/dEE/tI/s107">Pub. L. 116–260, div. EE, title I, § 107</ref>, <ref href="/us/stat/134/3048">134 Stat. 3048</ref>.)</sourceCredit>
+</section>"""
+    )
+    scan = scan_source_credits(document)
+
+    assert scan.credits == []
+    (quarantined,) = scan.quarantine
+    assert quarantined.reason == "section_identifier_unparsable"
+    assert quarantined.raw_value == "/us/usc/t18a/pl/91/538/s1"
+
+
+def test_a_credit_naming_no_division_is_not_read_at_all():
+    """The index is keyed by division. A credit without one cannot key into it.
+
+    This is a coverage bound, stated rather than hidden: 22 U.S.C. 2714a reads
+    "(Pub. L. 114-94, div. C, title XXXII, sec. 32101, ...)" with no enactment
+    construction, and 21 U.S.C. 350a-1 likewise -- both are real classifications
+    this index does not carry.
+    """
+    document = _document(
+        """<section identifier="/us/usc/t26/s1"><num value="1">§ 1.</num>
+<sourceCredit>(Added <ref href="/us/pl/115/97/tI/s11001">Pub. L. 115–97, title I, § 11001(a)</ref>, <ref href="/us/stat/131/2054">131 Stat. 2054</ref>.)</sourceCredit>
+</section>"""
+    )
+    scan = scan_source_credits(document)
+
+    assert scan.credits == []
+    assert scan.quarantine == []
+    assert scan.credits_naming_a_division == 0
+
+
+def test_the_page_belongs_to_the_citation_it_follows():
+    """Two enactment citations in one credit each keep their own page."""
+    document = _document(
+        """<section identifier="/us/usc/t42/s1"><num value="1">§ 1.</num>
+<sourceCredit>(Added <ref href="/us/pl/116/260/dEE/tI/s107">Pub. L. 116–260, div. EE, title I, § 107</ref>, <ref href="/us/stat/134/3048">134 Stat. 3048</ref>; added <ref href="/us/pl/117/328/dT/tIII/s303">Pub. L. 117–328, div. T, title III, § 303</ref>, <ref href="/us/stat/136/5339">136 Stat. 5339</ref>.)</sourceCredit>
+</section>"""
+    )
+    scan = scan_source_credits(document)
+
+    assert {(c.act_section, c.statutes_at_large_page) for c in scan.credits} == {("107", "3048"), ("303", "5339")}
+
+
+def test_the_strict_rule_is_a_named_constant():
+    assert STRICT_ENACTMENT_RULE == "added-or-as-added-pub-law-division-act-section-v1"
+
+
+@pytest.mark.parametrize(
+    ("congress", "law", "expected"),
+    [(119, 102, "https://uscode.house.gov/download/releasepoints/us/pl/119/102/xml_uscAll@119-102.zip")],
+)
+def test_the_release_point_url_is_derived_from_the_release_point(congress, law, expected):
+    assert uslm_release_url(f"{congress}-{law}") == expected
+
+
+def test_a_release_point_of_the_wrong_shape_is_refused():
+    with pytest.raises(ValueError):
+        uslm_release_url("119.102")

--- a/tools/build_usc_source_credit_artifact.py
+++ b/tools/build_usc_source_credit_artifact.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python
+"""Build the pinned U.S. Code source-credit index from the OLRC's USLM XML.
+
+This index gives consumers a second independent statement of the
+act-section-to-U.S.-Code join. The first, the Office of the Law Revision
+Counsel's (OLRC) Table III, is keyed by the enacting public law alone and cannot
+tell apart the dozens of acts one public law may enact. Every section of the
+Code carries a source credit that states the division per section, which is
+exactly what Table III lacks:
+
+    26 U.S.C. 6038E  <-  (Added Pub. L. 116-260, div. EE, title I, § 107(d)(1),
+                          Dec. 27, 2020, 134 Stat. 3048.)
+
+The builder seals deterministic rows with a digest-pinned receipt,
+repo-relative paths, a secret scan over what is written, and byte-identical
+rebuilds.
+
+**It is not a tiebreaker over Table III, and it is not built as one.** The two
+sources have different coverage: measured on release point 119-102, of the 222
+unambiguous triples here whose public law Table III was also fetched for, 176
+have no in-division Table III row at all. 26 U.S.C. 6038E is one of them. A
+disagreement between the sources is a coverage fact about one of them, and this
+artifact never picks a winner.
+
+Outputs, all deterministic and byte-identical across rebuilds from one archive:
+
+* ``usc-source-credits.parquet`` -- one row per retained credit:
+  ``(public law, division, act section) -> U.S. Code section``, carrying the
+  Statutes at Large volume and page and the verbatim USLM identifier. A triple
+  naming several sections is **kept and marked** ``refusal='multi_target'``,
+  because "the source said two things" is a different fact from "the source said
+  nothing".
+* ``quarantine.parquet`` -- every credit the strict rule matched and the build
+  could not attribute, with a reason.
+* ``receipt.json`` -- the archive and per-title input digests, every count, and
+  the pinned rules with their derivations.
+
+Usage::
+
+    uv run python tools/build_usc_source_credit_artifact.py \\
+        --output output/usc-source-credit-index-2026-08-02 \\
+        --archive /tmp/uscall.zip \\
+        --release-point 119-102
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from spicy_regs.sources.uscode_uslm import (  # noqa: E402
+    QUARANTINE_REASONS,
+    STRICT_ENACTMENT_RULE,
+    USLM_SECTION_DASH_RULE,
+    scan_release_zip,
+    uslm_release_url,
+)
+
+ARTIFACT_SCHEMA_VERSION = "usc-source-credit-artifact-v1"
+
+#: The parser this artifact was produced by. Bump when a parse changes shape, so
+#: a receipt cannot silently describe bytes a different parser would read.
+PARSER_VERSION = "uscode-uslm-parser-v1"
+
+#: How a triple naming more than one U.S. Code section is carried.
+MULTI_TARGET_POLICY = "retain-and-mark-refusal-multi_target-v1"
+
+CREDIT_COLUMNS = (
+    "public_law",
+    "division",
+    "act_section",
+    "usc_title",
+    "usc_section",
+    "usc_identifier",
+    "statutes_at_large_volume",
+    "statutes_at_large_page",
+    "target_count",
+    "refusal",
+)
+QUARANTINE_COLUMNS = ("source", "reason", "public_law", "division", "act_section", "raw_value")
+
+#: A build must not seal a secret. The scan is over what is written, not what was
+#: read, so a credential in an environment variable cannot reach the file.
+_SECRET_LIKE = re.compile(r"\b(?:sk-(?:proj-)?[A-Za-z0-9_-]{20,}|api[_-]?key=[^\s&]{8,})\b", re.IGNORECASE)
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(block)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _pin_path(path: Path) -> str:
+    """Record a repo-relative path when possible, else the basename.
+
+    Keeping absolute scratch paths out of the receipt keeps rebuilds from
+    different working directories byte-identical.
+    """
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT))
+    except ValueError:
+        return resolved.name
+
+
+def _write_parquet(path: Path, columns: tuple[str, ...], rows: list[dict[str, Any]]) -> None:
+    """Write VARCHAR columns in a fixed order, sorted, so bytes are stable."""
+    ordered = sorted(rows, key=lambda row: tuple("" if row.get(c) is None else str(row[c]) for c in columns))
+    table = pa.table(
+        {c: pa.array([None if r.get(c) is None else str(r[c]) for r in ordered], pa.string()) for c in columns}
+    )
+    pq.write_table(table, path, compression="zstd", sorting_columns=None)
+
+
+def _scan_for_secrets(rows: list[dict[str, Any]], where: str) -> None:
+    for row in rows:
+        for key, value in row.items():
+            if value is not None and _SECRET_LIKE.search(str(value)):
+                raise SystemExit(f"refusing to seal a secret-like value in {where}.{key}")
+
+
+def build(output_dir: Path, *, archive: Path, release_point: str) -> dict:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    scan, members = scan_release_zip(archive)
+
+    targets: dict[tuple[str, str, str], set[tuple[str, str]]] = defaultdict(set)
+    for credit in scan.credits:
+        targets[(credit.public_law, credit.division, credit.act_section)].add((credit.usc_title, credit.usc_section))
+
+    credit_rows: list[dict[str, Any]] = []
+    for credit in scan.credits:
+        key = (credit.public_law, credit.division, credit.act_section)
+        count = len(targets[key])
+        credit_rows.append(
+            {
+                "public_law": credit.public_law,
+                "division": credit.division,
+                "act_section": credit.act_section,
+                "usc_title": credit.usc_title,
+                "usc_section": credit.usc_section,
+                "usc_identifier": credit.usc_identifier,
+                "statutes_at_large_volume": credit.statutes_at_large_volume,
+                "statutes_at_large_page": credit.statutes_at_large_page,
+                "target_count": str(count),
+                # Kept and marked, never dropped: "the source said two things"
+                # is a different fact from "the source said nothing".
+                "refusal": "multi_target" if count > 1 else None,
+            }
+        )
+
+    quarantine_rows = [
+        {
+            "source": "uslm_source_credit",
+            "reason": entry.reason,
+            "public_law": entry.public_law,
+            "division": entry.division,
+            "act_section": entry.act_section,
+            "raw_value": entry.raw_value or None,
+        }
+        for entry in scan.quarantine
+    ]
+
+    _scan_for_secrets(credit_rows, "usc-source-credits")
+    _scan_for_secrets(quarantine_rows, "quarantine")
+
+    credits_path = output_dir / "usc-source-credits.parquet"
+    quarantine_path = output_dir / "quarantine.parquet"
+    _write_parquet(credits_path, CREDIT_COLUMNS, credit_rows)
+    _write_parquet(quarantine_path, QUARANTINE_COLUMNS, quarantine_rows)
+
+    receipt = {
+        "schema_version": ARTIFACT_SCHEMA_VERSION,
+        "parser_version": PARSER_VERSION,
+        "coverage": {
+            "titles": len(members),
+            "source_credits_scanned": scan.credits_scanned,
+            "credits_naming_a_division": scan.credits_naming_a_division,
+            "credits_outside_a_section": scan.credits_outside_a_section,
+            "strict_matches": scan.strict_matches,
+            "triples": len(targets),
+            "unambiguous_triples": sum(1 for v in targets.values() if len(v) == 1),
+            "multi_target_triples": sum(1 for v in targets.values() if len(v) > 1),
+            "distinct_public_law_division_pairs": len({(k[0], k[1]) for k in targets}),
+            "rows": len(credit_rows),
+            "rows_refusing": sum(1 for r in credit_rows if r["refusal"]),
+            "rows_without_a_statutes_at_large_page": sum(1 for r in credit_rows if not r["statutes_at_large_page"]),
+            "quarantine_rows": len(quarantine_rows),
+            "quarantine_reasons": dict(sorted(Counter(r["reason"] for r in quarantine_rows).items())),
+        },
+        "inputs": {
+            "release_point": release_point,
+            "release_url": uslm_release_url(release_point),
+            "archive": _pin_path(archive),
+            "archive_digest": file_sha256(archive),
+            "archive_bytes": archive.stat().st_size,
+            # The archive digest says which bundle; the member digests say which
+            # bytes each count was read from.
+            "titles": [{"member": member, "digest": digest} for member, digest in members],
+        },
+        "rules": {
+            "strict_enactment_rule": STRICT_ENACTMENT_RULE,
+            "strict_enactment_rule_derivation": (
+                "A source credit lists the original enactment AND every later amendment, so an "
+                "expression accepting any 'Pub. L. N-M, div. X ... section S' anywhere in a credit "
+                "pairs a division with a section number belonging to a different citation in the "
+                "same credit -- measured, 13,122 triples of which 2,916 name more than one U.S. "
+                "Code section. Reading the role by proximity to the word 'amended' does not fix "
+                "it: it credits 26 U.S.C. 7652 to (116-260, div. EE, sec. 107), which enacted "
+                "26 U.S.C. 6038E, and 7652's credit never uses the word 'amended' at all -- it "
+                "names the same act section at 134 Stat. 3046 where the enactment sits at 3048. "
+                "Requiring an explicit enactment construction ('Added Pub. L. ...' or 'as added "
+                "Pub. L. ...') removes that false positive. What it does not retain it does not "
+                "guess at: 22 U.S.C. 2714a reads '(Pub. L. 114-94, div. C, title XXXII, sec. "
+                "32101, ...)' with no such construction and this index carries no row for it."
+            ),
+            "section_dash_rule": USLM_SECTION_DASH_RULE,
+            "section_dash_rule_derivation": (
+                "USLM spells a section suffix with an EN DASH ('/us/usc/t16/s824s-1' with U+2013) "
+                "while Table III and ordinary U.S. Code citations spell it with a "
+                "hyphen. Verified on this release point: title 16 alone carries 1,487 en-dash "
+                "section identifiers and zero hyphen ones, so it is a spelling convention of the "
+                "source rather than a distinction it draws. The verbatim identifier is carried in "
+                "usc_identifier, so straightening loses nothing."
+            ),
+            "multi_target_policy": MULTI_TARGET_POLICY,
+            "multi_target_policy_derivation": (
+                "A triple naming several U.S. Code sections is kept, marked refusal='multi_target' "
+                "on every one of its rows, and refused at resolution time. Dropping it would tell "
+                "a consumer the source was silent when it was plural, and those are different "
+                "facts that call for different fixes."
+            ),
+            "quarantine_reasons": list(QUARANTINE_REASONS),
+        },
+        "outputs": {
+            _pin_path(path): {"digest": file_sha256(path), "rows": pq.ParquetFile(path).metadata.num_rows}
+            for path in (credits_path, quarantine_path)
+        },
+    }
+    receipt_text = canonical_json(receipt)
+    if _SECRET_LIKE.search(receipt_text):
+        raise SystemExit("refusing to seal a secret-like value in receipt.json")
+    (output_dir / "receipt.json").write_text(receipt_text, encoding="utf-8")
+    return receipt
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=(__doc__ or "").splitlines()[0])
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--archive", type=Path, required=True, help="the whole-Code USLM zip")
+    parser.add_argument("--release-point", required=True, help='the release point the archive is, e.g. "119-102"')
+    args = parser.parse_args(argv)
+    if not args.archive.exists():
+        print(
+            f"missing archive {args.archive}; fetch {uslm_release_url(args.release_point)} (~109 MB)",
+            file=sys.stderr,
+        )
+        return 2
+    receipt = build(args.output, archive=args.archive, release_point=args.release_point)
+    print(canonical_json(receipt["coverage"]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Every section of the U.S. Code carries a "source credit" line recording which act and section created it. This adds the ability to read those credits, giving us a direct mapping from legislation to the codified law it produced — more precise than the public alternative, which is keyed only to the enacting public law and so cannot tell apart the several acts a single law may contain. It ships as a reader plus an offline builder that produces a sealed, reproducible dataset recording digests of every input it read, and it refuses rather than guesses where a citation is ambiguous. Nothing in the running pipeline consumes it yet; this lands the capability ahead of the consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)