### PR TITLE
fix(congress): unfreeze the bills ingest — sort param was silently ignored

### DIFF
--- a/.github/workflows/_rollup.yml
+++ b/.github/workflows/_rollup.yml
@@ -43,11 +43,16 @@ on:
         required: false
         default: ''
         type: string
+      timeout_minutes:
+        description: 'Job timeout. Raise it for a rollup whose catch-up window is much larger than its steady state.'
+        required: false
+        default: 30
+        type: number
 
 jobs:
   rollup:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout_minutes }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/rollup-congress-bills.yml
+++ b/.github/workflows/rollup-congress-bills.yml
@@ -23,3 +23,7 @@ jobs:
       command: run-rollup-congress-bills
       skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}
       congress_since: ${{ inputs.since || '' }}
+      # A steady-state run is a handful of pages. The catch-up from the 510-day
+      # freeze is ~238k bills / ~950 pages, and a timeout mid-walk publishes
+      # nothing — so it would retry the same walk forever. 60 minutes clears it.
+      timeout_minutes: 60

--- a/src/spicy_regs/sources/congress_bills.py
+++ b/src/spicy_regs/sources/congress_bills.py
@@ -10,8 +10,16 @@ the job of
 :func:`~spicy_regs.transforms.build_congress_bills.build_congress_bills`.
 
 The ``/bill`` list endpoint is paginated by ``offset``/``limit`` (``limit`` caps
-at 250) and sorted ``updateDate+desc`` so the newest activity comes first; an
-incremental run stops as soon as it walks past its ``since`` watermark.
+at 250). An incremental run bounds its window *server-side* with ``fromDateTime``
+and pages until the window is exhausted, newest ``updateDate`` first.
+
+**Do not bound the window client-side by stopping at the first out-of-window
+row.** That is what this reader used to do, and it froze the published table for
+510 days: the ``sort`` parameter was being sent as ``updateDate%2Bdesc``, which
+the API ignores while still answering ``200``, so rows arrived in arbitrary
+order. The second row of the first page was older than the watermark, the walk
+stopped there, and every run "succeeded" having yielded exactly one bill. The
+window is now the server's job; ordering is only a paging-stability concern.
 
 **API key.** Congress.gov requires an api.data.gov key sent as the ``api_key``
 query param. The same key works across regulations.gov, Congress.gov, and
@@ -37,6 +45,19 @@ API_BASE = "https://api.congress.gov/v3"
 # Max the API accepts per page.
 PER_PAGE = 250
 
+# Written with a SPACE, never a literal "+". httpx form-encodes a space to "+"
+# (``sort=updateDate+desc`` — what the API wants) but percent-encodes a literal
+# "+" to "%2B", which the API accepts with a 200 and silently ignores. See the
+# module docstring for what that cost.
+SORT_NEWEST_FIRST = "updateDate desc"
+
+# Server-side window bound. The API wants a full RFC3339 instant.
+_FROM_DATETIME_FMT = "%Y-%m-%dT00:00:00Z"
+
+# Warn when a walk returns materially less than the server said it would; the
+# slack absorbs bills whose updateDate shifts mid-walk.
+_COMPLETENESS_TOLERANCE = 0.9
+
 # Env vars checked in order for the api.data.gov key (one key works across
 # regulations.gov, Congress.gov, and GovInfo).
 API_KEY_ENV_VARS = (
@@ -51,9 +72,11 @@ _TIMEOUT = httpx.Timeout(60.0, connect=30.0)
 _MAX_RETRIES = 5
 _PROGRESS_EVERY = 5_000
 
-# The list endpoint refuses very large offsets; stop paging past this to avoid a
-# runaway loop on an unexpectedly large window. Incremental runs stop far sooner.
-_MAX_OFFSET = 200_000
+# Backstop against a runaway loop, not an expected limit: deep offsets page fine
+# (verified past 238k). Must clear a full-archive backfill — ~430k bills as of
+# 2026-08 — or a first run would silently truncate. Hitting it is logged as an
+# error, never a quiet stop.
+_MAX_OFFSET = 500_000
 
 
 def _resolve_api_key() -> str | None:
@@ -72,9 +95,10 @@ def _resolve_api_key() -> str | None:
 class CongressBillsReader(Reader):
     """Yields raw Congress.gov bill dicts, newest ``updateDate`` first.
 
-    ``since`` lets incremental runs stop once they page past the newest
-    ``updateDate`` already stored; the transform handles merging with the prior
-    table. With no key configured the reader yields nothing.
+    ``since`` becomes the ``fromDateTime`` bound on the request, so the server
+    decides what is in the window and the walk simply runs to exhaustion; the
+    transform handles merging with the prior table. With no key configured the
+    reader yields nothing.
     """
 
     def __init__(
@@ -83,14 +107,13 @@ class CongressBillsReader(Reader):
         since: date | None = None,
         per_page: int = PER_PAGE,
         api_key: str | None = None,
-        verbose: bool = False,
     ) -> None:
         self.since = since
         self.per_page = min(per_page, PER_PAGE)
         self.api_key = api_key or _resolve_api_key()
-        self.verbose = verbose
         self._client: httpx.Client | None = None
         self._seen = 0
+        self._expected: int | None = None
 
     def iter_records(self) -> Iterator[dict]:
         if not self.api_key:
@@ -107,26 +130,38 @@ class CongressBillsReader(Reader):
             self._client = client
             yield from self._paginate()
         logger.info("Congress bills: yielded {:,} bills", self._seen)
+        # A walk that returns far less than the server advertised is the shape
+        # of the 510-day freeze. Say so loudly rather than reporting success.
+        if self._expected is not None and self._seen < self._expected * _COMPLETENESS_TOLERANCE:
+            logger.warning(
+                "Congress bills: yielded {:,} of the {:,} bills the server reported "
+                "for this window — the walk ended early",
+                self._seen,
+                self._expected,
+            )
 
     # -- pagination ----------------------------------------------------------
 
     def _paginate(self) -> Iterator[dict]:
-        """Walk ``offset``/``limit`` pages, stopping at the ``since`` watermark."""
+        """Walk ``offset``/``limit`` pages until the server-bounded window runs out."""
         offset = 0
         while offset < _MAX_OFFSET:
             payload = self._get_page(offset)
             if payload is None:
                 break
+            if self._expected is None:
+                self._expected = _pagination_count(payload)
+                if self._expected is not None:
+                    logger.info(
+                        "Congress bills: server reports {:,} bills in this window",
+                        self._expected,
+                    )
             bills = payload.get("bills") or []
+            # An empty page ends the walk; `fromDateTime` already excluded
+            # everything outside the window, so there is no watermark to check.
             if not bills:
                 break
             for bill in bills:
-                # Bills come newest-updated first; once we cross the watermark
-                # everything after is older, so we can stop early.
-                if self.since is not None and _older_than(bill, self.since):
-                    if self.verbose:
-                        logger.debug("Congress bills: reached watermark {} — stopping", self.since)
-                    return
                 self._seen += 1
                 if self._seen % _PROGRESS_EVERY == 0:
                     logger.info("Congress bills: {:,} bills so far...", self._seen)
@@ -135,15 +170,28 @@ class CongressBillsReader(Reader):
             if len(bills) < self.per_page:
                 break
             offset += self.per_page
+        else:
+            # while/else: reached only when the condition goes false, i.e. the
+            # offset backstop — every ordinary exit above is a `break`.
+            logger.error(
+                "Congress bills: hit the {:,}-row offset backstop with pages still "
+                "coming — the window is too wide for one run; narrow it with --since",
+                _MAX_OFFSET,
+            )
 
     def _get_page(self, offset: int) -> dict | None:
         params: dict[str, object] = {
             "offset": offset,
             "limit": self.per_page,
-            "sort": "updateDate+desc",
+            "sort": SORT_NEWEST_FIRST,
             "format": "json",
             "api_key": self.api_key,
         }
+        # Bound the window server-side. Without this the walk would have to
+        # trust the row order to know when to stop — the exact assumption that
+        # failed silently for 510 days.
+        if self.since is not None:
+            params["fromDateTime"] = self.since.strftime(_FROM_DATETIME_FMT)
         return self._get(f"{API_BASE}/bill", params)
 
     def _get(self, url: str, params: dict | None) -> dict | None:
@@ -168,12 +216,14 @@ class CongressBillsReader(Reader):
         return None
 
 
-def _older_than(bill: dict, since: date) -> bool:
-    """True if the bill's ``updateDate`` is strictly before ``since``."""
-    raw = bill.get("updateDate")
-    if not raw:
-        return False
-    try:
-        return date.fromisoformat(str(raw)[:10]) < since
-    except ValueError:
-        return False
+def _pagination_count(payload: dict) -> int | None:
+    """Total rows the server says match the window, or None if absent/unparseable."""
+    raw = (payload.get("pagination") or {}).get("count")
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+    return None

--- a/src/spicy_regs/transforms/build_congress_bills.py
+++ b/src/spicy_regs/transforms/build_congress_bills.py
@@ -10,8 +10,9 @@ run. Instead we:
 
 1. Best-effort download the prior ``congress_bills.parquet`` from R2.
 2. Fetch only bills updated since its max ``update_date`` (minus a short overlap
-   to catch late-updated bills). Bills come newest-updated first, so the reader
-   stops as soon as it pages past that watermark.
+   to catch late-updated bills). That watermark goes to the API as a
+   ``fromDateTime`` bound, so the server returns the window and the reader pages
+   it to exhaustion.
 3. Dedup the union on ``bill_id``, preferring the freshly fetched row.
 
 With no prior table (first run) step 2 becomes a full backfill.

--- a/tests/test_congress_bills.py
+++ b/tests/test_congress_bills.py
@@ -1,16 +1,23 @@
 """Hermetic tests for the Congress.gov bill ingest (no network).
 
 Covers the pieces with real logic: the raw-bill → published-schema mapping
-(``_shape`` / ``_bill_id``), the API-key resolution fallback chain, and the
-offset/limit pagination with early stop at the ``since`` watermark.
+(``_shape`` / ``_bill_id``), the API-key resolution fallback chain, the
+offset/limit pagination, and the request params that bound the fetch window.
+
+The params tests are regression cover for the 510-day freeze: ``sort`` has to
+reach the API as ``updateDate+desc`` (a space, which httpx form-encodes to
+``+``) and the window has to be bounded server-side by ``fromDateTime``.
 """
 
 from __future__ import annotations
 
 from datetime import date
 
+import httpx
+
 from spicy_regs.sources.congress_bills import (
     API_KEY_ENV_VARS,
+    SORT_NEWEST_FIRST,
     CongressBillsReader,
     _resolve_api_key,
 )
@@ -119,18 +126,64 @@ def test_paginate_walks_offsets_until_short_page(monkeypatch):
     assert got == [1, 2, 3]
 
 
-def test_paginate_stops_at_since_watermark(monkeypatch):
-    """Bills come newest-updated first; crossing ``since`` stops the walk."""
-    reader = CongressBillsReader(api_key="test", per_page=3, since=date(2024, 3, 4))
+def test_paginate_does_not_stop_on_an_out_of_order_page(monkeypatch):
+    """Row order must not truncate the walk — the server bounds the window.
+
+    This is the 510-day freeze in miniature: with ``sort`` silently ignored the
+    rows arrive shuffled, and the old client-side watermark stop quit after the
+    first row. Every bill on the page has to survive.
+    """
+    reader = CongressBillsReader(api_key="test", per_page=3, since=date(2025, 4, 4))
     pages = {
         0: {
             "bills": [
-                _bill(1, "2024-03-06"),  # newer -> kept
-                _bill(2, "2024-03-04"),  # == watermark -> kept
-                _bill(3, "2024-03-01"),  # older -> stop here
+                _bill(1, "2025-04-07"),
+                _bill(2, "2025-01-02"),  # out of order — must NOT end the walk
+                _bill(3, "2026-03-24"),
             ]
         },
+        3: {"bills": [_bill(4, "2024-02-07")]},  # short page -> stop
     }
     monkeypatch.setattr(reader, "_get_page", lambda offset: pages.get(offset, {"bills": []}))
     got = [b["number"] for b in reader._paginate()]
-    assert got == [1, 2]
+    assert got == [1, 2, 3, 4]
+
+
+# -- request params ----------------------------------------------------------
+
+
+def _params_for(monkeypatch, reader: CongressBillsReader) -> dict:
+    """Capture the query params ``_get_page`` would send."""
+    captured: dict = {}
+
+    def fake_get(url, params):
+        captured.update(params or {})
+        return None
+
+    monkeypatch.setattr(reader, "_get", fake_get)
+    reader._get_page(0)
+    return captured
+
+
+def test_sort_param_survives_url_encoding(monkeypatch):
+    """httpx must encode ``sort`` to ``updateDate+desc``, not ``updateDate%2Bdesc``.
+
+    The API answers 200 to both but only honours the former; the ``%2B`` form
+    returns rows in arbitrary order, which is what froze this table.
+    """
+    params = _params_for(monkeypatch, CongressBillsReader(api_key="test"))
+    assert params["sort"] == SORT_NEWEST_FIRST
+    url = httpx.Request("GET", "https://api.congress.gov/v3/bill", params=params).url
+    assert "sort=updateDate+desc" in str(url)
+    assert "%2B" not in str(url)
+
+
+def test_since_becomes_a_server_side_from_datetime(monkeypatch):
+    reader = CongressBillsReader(api_key="test", since=date(2025, 4, 4))
+    assert _params_for(monkeypatch, reader)["fromDateTime"] == "2025-04-04T00:00:00Z"
+
+
+def test_no_since_sends_no_window_bound(monkeypatch):
+    """A full backfill must not accidentally bound itself."""
+    params = _params_for(monkeypatch, CongressBillsReader(api_key="test"))
+    assert "fromDateTime" not in params


### PR DESCRIPTION
## Problem

`congress_bills` has been frozen at `update_date = 2025-04-07` for **510 days**. `check-rollup-freshness.yml` has been red the entire time — it was the reviewer note on #176 ("a monitor that always fails monitors nothing"). Every nightly rollup run reported success in ~25s:

```
Congress bills: fetching bills updated since 2025-04-04
Congress bills: yielded 1 bills
Congress bills: 192,141 rows
```

**Root cause.** The reader sent `sort` as the literal string `"updateDate+desc"` in an httpx `params` dict. httpx percent-encodes a literal `+` to `%2B`, so the API received `sort=updateDate%2Bdesc` — which it **accepts with a 200 and silently ignores**, returning rows in arbitrary order.

Verified against the live API. With the broken encoding, page 1 is:

```
2025-04-07, 2025-01-02, 2026-03-24, 2024-02-07, 2025-02-04
```

That first row is exactly the stuck watermark. `_paginate` stopped at the first row older than `since` — row 2 — so every run yielded one bill, the watermark never advanced, and the next run asked the identical question. With a space instead (`sort=updateDate+desc` on the wire), the same request returns `2026-08-29` five times.

This also means the backfill was never completed: the table holds 192,141 rows against a 429,750-bill archive.

## Solution

**1. Fix the encoding.** The sort value is written with a space, which httpx form-encodes to `+`.

**2. Bound the window server-side** with `fromDateTime`, and page to exhaustion. This is the structural part — correctness no longer depends on row order at all. Confirmed the API honours it (549 rows for a 5-day window vs. 429,750 unfiltered) and that deep offsets page cleanly past 238k.

**3. Drop the client-side early stop** (`_older_than`), the mechanism that turned a silently-ignored parameter into a frozen table.

**4. Make the next failure loud**, since this one was silent:
- The server reports a `count` for the window; a walk returning under 90% of it logs a warning instead of reporting success.
- The offset backstop logs an error rather than quietly truncating. Raised `_MAX_OFFSET` 200k → 500k, since a full backfill is ~430k bills and the old cap would have truncated one.

**5. `timeout_minutes` input on `_rollup.yml`** (default 30, unchanged for every other rollup); congress-bills sets 60. The catch-up walk is ~950 pages, and a timeout mid-walk publishes nothing — it would retry the same walk forever.

## Test plan

- `uv run pytest` — **559 passed**. `ruff` and `ty` clean; pre-commit hooks pass.
- Tests replace the watermark early-stop coverage with the actual failure mode: an out-of-order page must **not** truncate the walk. Plus params tests asserting `%2B` never reaches the built URL, that `since` becomes a `fromDateTime` bound, and that a full backfill sends no bound.
- Both new failure paths exercised and confirmed firing (offset backstop error, sub-90% shortfall warning).
- Request URL captured through a mock transport:
  ```
  https://api.congress.gov/v3/bill?offset=0&limit=3&sort=updateDate+desc&format=json&api_key=$KEY&fromDateTime=2025-04-04T00%3A00%3A00Z
  ```

## Reviewer notes

**The first run after merge is a large catch-up:** ~238k bills / ~950 pages, taking the table from 192,141 to roughly the full 429,750-row archive. That's growth, so `_assert_upload_safe` won't block it. Steady state afterwards is a handful of pages. If it does time out, `workflow_dispatch` accepts a `since` to chunk it.

**One item still verifying:** httpx encodes the colons in `fromDateTime` as `%3A`; my live checks used literal colons (I exhausted the `DEMO_KEY` rate limit). I expect it to pass — `%3A` decodes to `:`, the same value, unlike `%2B`, which decodes to a *different character* than `+` means in a query string. Worst case if it were rejected, the walk still returns correct newest-first data, just unbounded. Will confirm and update this note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
