### PR TITLE
fix(congress): raise the bills catch-up timeout to 120m (measured, was 60)

### DIFF
--- a/.github/workflows/rollup-congress-bills.yml
+++ b/.github/workflows/rollup-congress-bills.yml
@@ -25,5 +25,11 @@ jobs:
       congress_since: ${{ inputs.since || '' }}
       # A steady-state run is a handful of pages. The catch-up from the 510-day
       # freeze is ~238k bills / ~950 pages, and a timeout mid-walk publishes
-      # nothing — so it would retry the same walk forever. 60 minutes clears it.
-      timeout_minutes: 60
+      # nothing — so it would retry the same walk forever.
+      #
+      # 120, not 60: the first catch-up attempt was cancelled at the 60-minute
+      # cap having fetched 190,000 of 238,197. Measured throughput is a steady
+      # ~3,050 bills/min (no deep-offset degradation, no rate limiting), so the
+      # walk needs ~78 minutes plus setup and merge. This is a cap, not a
+      # duration — steady-state runs still finish in seconds.
+      timeout_minutes: 120


### PR DESCRIPTION
## Problem

The catch-up run enabled by #186 ([33333636222](https://github.com/civictechdc/spicy-regs/actions/runs/33333636222)) was **cancelled at the 60-minute cap** having fetched 190,000 of the 238,197 bills in the window. Nothing publishes until the walk completes, so it made no progress — and would have retried the same doomed walk every night.

The `timeout_minutes: 60` I set in #186 was a guess, not a measurement.

## Measurement

Progress timestamps from that run:

| time | bills | rate |
|---|---|---|
| 20:27:26 | 5,000 | — |
| 20:37:00 | 40,000 | 3,650/min |
| 20:49:07 | 80,000 | 3,300/min |
| 21:02:10 | 120,000 | 3,065/min |
| 21:15:24 | 160,000 | 3,030/min |
| 21:25:09 | 190,000 | 3,077/min |

Steady ~3,050 bills/min. **No deep-offset degradation** and **no rate limiting** (the `429` greps were timestamp false positives) — the API is simply slow at ~4.6s per 250-row page. 238,197 bills needs ~78 minutes of fetching, plus ~1.5 min setup and ~2 min merge/upload.

120 leaves headroom. It's a cap, not a duration — once the catch-up lands, steady-state runs are a handful of pages and finish in seconds.

## Also confirmed by that run

The open `%3A` encoding question from #186 is resolved: the run logged `server reports 238,197 bills in this window`, matching the `fromDateTime` window exactly against 429,750 unfiltered. The server-side bound is honoured, and the sort fix works — the walk paged sequentially rather than stopping at one bill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)