### PR TITLE
feat(congress): chunk the bills catch-up so each run publishes

### DIFF
--- a/.github/workflows/_rollup.yml
+++ b/.github/workflows/_rollup.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: ''
         type: string
+      congress_until:
+        description: 'Optional Congress.gov backfill end date (YYYY-MM-DD; still capped to one catch-up window)'
+        required: false
+        default: ''
+        type: string
       fcc_since:
         description: 'Optional FCC ECFS backfill start date (YYYY-MM-DD)'
         required: false
@@ -90,6 +95,7 @@ jobs:
           LDA_SINCE: ${{ inputs.lda_since }}
           LDA_UNTIL: ${{ inputs.lda_until }}
           CONGRESS_SINCE: ${{ inputs.congress_since }}
+          CONGRESS_UNTIL: ${{ inputs.congress_until }}
           FCC_SINCE: ${{ inputs.fcc_since }}
           FCC_PROCEEDINGS: ${{ inputs.fcc_proceedings }}
           # Optional: raises the CourtListener API rate limit. The court_dockets

--- a/.github/workflows/rollup-congress-bills.yml
+++ b/.github/workflows/rollup-congress-bills.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: ''
         type: string
+      until:
+        description: 'Backfill end date (YYYY-MM-DD); blank runs one catch-up window forward from since'
+        required: false
+        default: ''
+        type: string
 jobs:
   run:
     uses: ./.github/workflows/_rollup.yml
@@ -23,13 +28,9 @@ jobs:
       command: run-rollup-congress-bills
       skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}
       congress_since: ${{ inputs.since || '' }}
-      # A steady-state run is a handful of pages. The catch-up from the 510-day
-      # freeze is ~238k bills / ~950 pages, and a timeout mid-walk publishes
-      # nothing — so it would retry the same walk forever.
-      #
-      # 120, not 60: the first catch-up attempt was cancelled at the 60-minute
-      # cap having fetched 190,000 of 238,197. Measured throughput is a steady
-      # ~3,050 bills/min (no deep-offset degradation, no rate limiting), so the
-      # walk needs ~78 minutes plus setup and merge. This is a cap, not a
-      # duration — steady-state runs still finish in seconds.
-      timeout_minutes: 120
+      congress_until: ${{ inputs.until || '' }}
+      # MAX_WINDOW_DAYS caps an incremental run at ~90 days (~14 min at the
+      # measured ~3,050 bills/min), so this headroom is really for the one case
+      # the cap can't bound: a first-ever backfill with no prior table, which
+      # walks the whole ~430k-bill archive at ~140 min.
+      timeout_minutes: 180

--- a/src/spicy_regs/pipelines/rollups/congress_bills.py
+++ b/src/spicy_regs/pipelines/rollups/congress_bills.py
@@ -33,7 +33,11 @@ class CongressBillsRollup(RollupPipeline):
     output: ClassVar[str] = "congress_bills.parquet"
 
     def build(self, output_dir: Path) -> Path:
-        return build_congress_bills(output_dir, since=_date_env("CONGRESS_SINCE"))
+        return build_congress_bills(
+            output_dir,
+            since=_date_env("CONGRESS_SINCE"),
+            until=_date_env("CONGRESS_UNTIL"),
+        )
 
 
 app = make_rollup_app(CongressBillsRollup)

--- a/src/spicy_regs/sources/congress_bills.py
+++ b/src/spicy_regs/sources/congress_bills.py
@@ -11,7 +11,9 @@ the job of
 
 The ``/bill`` list endpoint is paginated by ``offset``/``limit`` (``limit`` caps
 at 250). An incremental run bounds its window *server-side* with ``fromDateTime``
-and pages until the window is exhausted, newest ``updateDate`` first.
+/ ``toDateTime`` and pages until the window is exhausted, newest ``updateDate``
+first. The upper bound is what lets a large catch-up be split into chunks that
+each publish, so progress survives a failure partway through.
 
 **Do not bound the window client-side by stopping at the first out-of-window
 row.** That is what this reader used to do, and it froze the published table for
@@ -51,8 +53,9 @@ PER_PAGE = 250
 # module docstring for what that cost.
 SORT_NEWEST_FIRST = "updateDate desc"
 
-# Server-side window bound. The API wants a full RFC3339 instant.
+# Server-side window bounds. The API wants a full RFC3339 instant.
 _FROM_DATETIME_FMT = "%Y-%m-%dT00:00:00Z"
+_TO_DATETIME_FMT = "%Y-%m-%dT00:00:00Z"
 
 # Warn when a walk returns materially less than the server said it would; the
 # slack absorbs bills whose updateDate shifts mid-walk.
@@ -95,20 +98,22 @@ def _resolve_api_key() -> str | None:
 class CongressBillsReader(Reader):
     """Yields raw Congress.gov bill dicts, newest ``updateDate`` first.
 
-    ``since`` becomes the ``fromDateTime`` bound on the request, so the server
-    decides what is in the window and the walk simply runs to exhaustion; the
-    transform handles merging with the prior table. With no key configured the
-    reader yields nothing.
+    ``since``/``until`` become the ``fromDateTime``/``toDateTime`` bounds on the
+    request, so the server decides what is in the window and the walk simply runs
+    to exhaustion; the transform handles merging with the prior table. With no
+    key configured the reader yields nothing.
     """
 
     def __init__(
         self,
         *,
         since: date | None = None,
+        until: date | None = None,
         per_page: int = PER_PAGE,
         api_key: str | None = None,
     ) -> None:
         self.since = since
+        self.until = until
         self.per_page = min(per_page, PER_PAGE)
         self.api_key = api_key or _resolve_api_key()
         self._client: httpx.Client | None = None
@@ -123,8 +128,9 @@ class CongressBillsReader(Reader):
             )
             return
         logger.info(
-            "Congress bills: fetching bills updated since {}",
+            "Congress bills: fetching bills updated {} through {}",
             self.since or "the beginning",
+            self.until or "now",
         )
         with httpx.Client(timeout=_TIMEOUT, headers={"Accept": "application/json"}) as client:
             self._client = client
@@ -192,6 +198,8 @@ class CongressBillsReader(Reader):
         # failed silently for 510 days.
         if self.since is not None:
             params["fromDateTime"] = self.since.strftime(_FROM_DATETIME_FMT)
+        if self.until is not None:
+            params["toDateTime"] = self.until.strftime(_TO_DATETIME_FMT)
         return self._get(f"{API_BASE}/bill", params)
 
     def _get(self, url: str, params: dict | None) -> dict | None:

--- a/src/spicy_regs/transforms/build_congress_bills.py
+++ b/src/spicy_regs/transforms/build_congress_bills.py
@@ -10,12 +10,20 @@ run. Instead we:
 
 1. Best-effort download the prior ``congress_bills.parquet`` from R2.
 2. Fetch only bills updated since its max ``update_date`` (minus a short overlap
-   to catch late-updated bills). That watermark goes to the API as a
-   ``fromDateTime`` bound, so the server returns the window and the reader pages
-   it to exhaustion.
+   to catch late-updated bills), through at most :data:`MAX_WINDOW_DAYS` later.
+   Those bounds go to the API as ``fromDateTime``/``toDateTime``, so the server
+   returns the window and the reader pages it to exhaustion.
 3. Dedup the union on ``bill_id``, preferring the freshly fetched row.
 
 With no prior table (first run) step 2 becomes a full backfill.
+
+**Why the window is capped.** A run publishes nothing until its walk finishes,
+so one unbounded catch-up is all-or-nothing: the first attempt at the 510-day
+freeze fetched 190,000 of 238,197 bills, hit the job timeout, and persisted
+nothing — it would have retried the same doomed walk every night. Capping the
+window makes each run publish and advance the watermark, so a deep backfill
+converges over successive runs instead of never. Chunks can also be driven
+explicitly with ``CONGRESS_SINCE``/``CONGRESS_UNTIL``.
 
 Scope is deliberately **list-level only**: every column comes from the ``/bill``
 list payload, so there are no per-bill detail fetches (no N+1).
@@ -38,6 +46,12 @@ OUTPUT = "congress_bills.parquet"
 # Re-scan this many days before the last stored update_date on each run, so bills
 # updated after our previous run's cutoff are picked up.
 OVERLAP_DAYS = 3
+
+# Largest span one run will fetch. Sized off measured throughput (~3,050
+# bills/min against this API) and the ~467 bills/day average across the 510-day
+# freeze: ~90 days is ~42k bills, roughly 14 minutes — comfortably inside the
+# job timeout even if a stretch runs several times denser than average.
+MAX_WINDOW_DAYS = 90
 
 # The published schema: 10 columns, all VARCHAR, in a fixed order. ``bill_id`` is
 # the primary / dedup key.
@@ -94,6 +108,15 @@ def _shape(doc: dict) -> dict:
     }
 
 
+def _bounded_until(since: date | None, until: date | None, *, today: date | None = None) -> date | None:
+    """Return a deterministic end date no more than one catch-up window ahead."""
+    if since is None:
+        return until
+    if until is not None and until < since:
+        raise ValueError(f"Congress until date {until} precedes since date {since}")
+    return min(until or today or date.today(), since + timedelta(days=MAX_WINDOW_DAYS))
+
+
 def _prior_max_update_date(prior_file: Path) -> date | None:
     """Largest ``update_date`` in the prior table, or None if empty/absent."""
     if not prior_file.exists():
@@ -109,7 +132,7 @@ def _prior_max_update_date(prior_file: Path) -> date | None:
         return None
 
 
-def build_congress_bills(output_dir: Path, *, since: date | None = None) -> Path:
+def build_congress_bills(output_dir: Path, *, since: date | None = None, until: date | None = None) -> Path:
     """Build ``congress_bills.parquet`` (incremental merge with the prior table)."""
     import duckdb
 
@@ -127,10 +150,15 @@ def build_congress_bills(output_dir: Path, *, since: date | None = None) -> Path
     if since is None:
         prior_max = _prior_max_update_date(prior_file) if have_prior else None
         since = (prior_max - timedelta(days=OVERLAP_DAYS)) if prior_max else None
-    logger.info("Congress bills: fetching bills updated since {}", since or "the beginning")
+    until = _bounded_until(since, until)
+    logger.info(
+        "Congress bills: fetching bills updated {} through {}",
+        since or "the beginning",
+        until or "now",
+    )
 
     # 3. Fetch + shape into a "new rows" parquet.
-    reader = CongressBillsReader(since=since)
+    reader = CongressBillsReader(since=since, until=until)
     rows = [_shape(doc) for doc in reader.iter_records()]
     new_file = output_dir / "_congress_new.parquet"
     table = pa.Table.from_pylist(rows, schema=_SCHEMA) if rows else _SCHEMA.empty_table()

--- a/tests/test_congress_bills.py
+++ b/tests/test_congress_bills.py
@@ -11,9 +11,10 @@ reach the API as ``updateDate+desc`` (a space, which httpx form-encodes to
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 
 import httpx
+import pytest
 
 from spicy_regs.sources.congress_bills import (
     API_KEY_ENV_VARS,
@@ -21,7 +22,13 @@ from spicy_regs.sources.congress_bills import (
     CongressBillsReader,
     _resolve_api_key,
 )
-from spicy_regs.transforms.build_congress_bills import COLUMNS, _bill_id, _shape
+from spicy_regs.transforms.build_congress_bills import (
+    COLUMNS,
+    MAX_WINDOW_DAYS,
+    _bill_id,
+    _bounded_until,
+    _shape,
+)
 
 _RAW_BILL = {
     "congress": 118,
@@ -187,3 +194,57 @@ def test_no_since_sends_no_window_bound(monkeypatch):
     """A full backfill must not accidentally bound itself."""
     params = _params_for(monkeypatch, CongressBillsReader(api_key="test"))
     assert "fromDateTime" not in params
+
+
+def test_since_and_until_become_server_side_bounds(monkeypatch):
+    reader = CongressBillsReader(api_key="test", since=date(2025, 4, 4), until=date(2025, 7, 3))
+    params = _params_for(monkeypatch, reader)
+    assert params["fromDateTime"] == "2025-04-04T00:00:00Z"
+    assert params["toDateTime"] == "2025-07-03T00:00:00Z"
+
+
+def test_no_until_sends_no_upper_bound(monkeypatch):
+    params = _params_for(monkeypatch, CongressBillsReader(api_key="test", since=date(2025, 4, 4)))
+    assert "toDateTime" not in params
+
+
+# -- catch-up windowing ------------------------------------------------------
+
+
+def test_window_is_capped_so_a_deep_backfill_converges():
+    """An unbounded catch-up publishes nothing and retries forever; cap it.
+
+    The 510-day freeze needed 238k bills in one walk. That run hit the job
+    timeout at 190k and persisted nothing. Capping the window makes each run
+    publish and advance the watermark.
+    """
+    since = date(2025, 4, 4)
+    until = _bounded_until(since, None, today=date(2026, 8, 30))
+    assert until == since + timedelta(days=MAX_WINDOW_DAYS)
+
+
+def test_explicit_until_is_still_capped():
+    since = date(2025, 4, 4)
+    # An operator asking for the whole 510-day span still gets one window.
+    assert _bounded_until(since, date(2026, 8, 30)) == since + timedelta(days=MAX_WINDOW_DAYS)
+
+
+def test_short_explicit_window_is_left_alone():
+    since, until = date(2026, 8, 1), date(2026, 8, 10)
+    assert _bounded_until(since, until) == until
+
+
+def test_caught_up_run_stops_at_today():
+    """Steady state: the cap must not push the window past now."""
+    since, today = date(2026, 8, 27), date(2026, 8, 30)
+    assert _bounded_until(since, None, today=today) == today
+
+
+def test_backwards_window_is_rejected():
+    with pytest.raises(ValueError, match="precedes"):
+        _bounded_until(date(2026, 8, 10), date(2026, 8, 1))
+
+
+def test_full_backfill_has_no_upper_bound():
+    """No prior table means no watermark to window from."""
+    assert _bounded_until(None, None) is None


### PR DESCRIPTION
## Problem

A run publishes nothing until its walk finishes, which makes a deep catch-up **all-or-nothing**. The first attempt at the 510-day freeze ([33333636222](https://github.com/civictechdc/spicy-regs/actions/runs/33333636222)) fetched 190,000 of 238,197 bills, hit the job timeout, and persisted nothing — it would have retried the same doomed walk every night, never converging. #187 raised the ceiling, but that only buys room; it doesn't fix the shape.

## Solution

Cap the fetch window at `MAX_WINDOW_DAYS` (90) and add a `toDateTime` upper bound — mirroring the `since`/`until` + `_bounded_until` pattern `build_lobbying_filings` already uses, so this is an existing idiom in the repo rather than a new one.

Each run now fetches at most one window, publishes, and advances the watermark. A deep backfill converges over successive runs instead of never:

```
run 1: 2025-04-04 -> 2025-07-03   publish, watermark now ~2025-07-03
run 2: 2025-06-30 -> 2025-09-28   publish, ...
...                               ~6 runs to close a 510-day gap
```

Verified `toDateTime` is honoured server-side: 676 rows for a bounded 9-day window, all dates inside it.

**Window size is measured, not guessed** — the mistake I made sizing the timeout in #186. Observed throughput is ~3,050 bills/min against this API, and the freeze averaged ~467 bills/day, so a 90-day window is ~42k bills / ~14 min. Comfortable even if a stretch runs several times denser than average.

**Explicit chunking too:** `CONGRESS_SINCE`/`CONGRESS_UNTIL` are wired through as the `until` workflow input alongside the existing `since`, so an operator can drive specific chunks (e.g. newest-first, to restore the freshness signal before backfilling the archive).

**Steady state is unaffected:** the watermark is days old, so `min(today, since + 90)` is today and the cap never binds.

**Timeout 120 -> 180**, now covering only the one case the cap can't bound: a first-ever backfill with no prior table, which walks the whole ~430k archive at ~140 min.

## Test plan

- `uv run pytest` — **567 passed**. `ruff` and `ty` clean.
- New tests cover the windowing contract: an unbounded catch-up gets capped, an over-wide explicit `until` still gets capped, a short explicit window is left alone, a caught-up run stops at today (no future window), a backwards window raises, and a full backfill stays unbounded.
- Reader tests assert `since`/`until` become `fromDateTime`/`toDateTime`, and that no `until` sends no upper bound.

## Note

The in-flight unbounded catch-up ([33348410126](https://github.com/civictechdc/spicy-regs/actions/runs/33348410126), started 01:42 UTC under #187's 120-min cap) is still running and may well complete the backfill on its own. This PR is worth merging either way — if that run succeeds it's future-proofing; if it fails, nightly runs now self-heal over ~6 nights with no manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)