### PR TITLE
fix(mcp): refuse write statements in query_sql

### DIFF
--- a/mcp-server/INTERNALS.md
+++ b/mcp-server/INTERNALS.md
@@ -48,6 +48,45 @@ on `catalog["namespace"]`.
   sandbox is testable without network. Run it after httpfs loads and before any
   user SQL; `SET lock_configuration=true` is last because it freezes everything.
 
+## The read-only statement guard
+
+`query_sql` hands arbitrary SQL to `cursor.execute()`, so without a gate the
+public endpoint accepts writes. `COPY ... TO`, `ATTACH`, and `EXPORT DATABASE`
+all reach the container filesystem, and on Cloud Run that filesystem is
+in-memory — a large enough `COPY` evicts the instance. The service is
+`--allow-unauthenticated`, so that is an anonymous availability lever.
+
+The obvious fix, `SET disabled_filesystems='LocalFileSystem'`, is the one thing
+that must not be done (see above — httpfs needs the CA bundle). Hence
+`_first_write_statement`, which classifies with DuckDB's own parser via
+`extract_statements` and admits only `SELECT` and `EXPLAIN`.
+
+**Do not swap the parser for a prefix regex.** The parser is what makes leading
+comments (`/* c */ COPY ...`), `COPY` inside a string literal, and stacked
+statements (`SELECT 1; DROP TABLE t`) classify correctly. The stacked case
+matters most: `execute` runs every statement in the string but returns only the
+last result, so a trailing write would otherwise land with nothing in the
+response to show for it.
+
+**The two-entry allowlist is not as narrow as it looks.** DuckDB folds
+`DESCRIBE`, `SHOW`, `SUMMARIZE`, `VALUES`, `TABLE`, and the FROM-first
+shorthand (`FROM comments LIMIT 1`) into `StatementType.SELECT`, so all of them
+still run. `tests/test_mcp_server.py::test_read_forms_pass_the_guard` pins that
+folding; if a DuckDB upgrade splits any of them into its own statement type,
+that test fails rather than clients silently losing a query form.
+
+Matching is on `StatementType.name`, not the enum member, because duckdb's type
+stubs do not declare the members and `ty` gates merges — comparing names keeps
+the check honest without a blanket type-ignore.
+
+This guard does **not** stop local file *reads*: `read_text`, `read_csv`, and
+`read_blob` are `SELECT`s. Nothing sensitive sits on the container filesystem
+today (the R2 catalog token arrives as an env var, `getenv` does not exist in
+DuckDB, and `duckdb_secrets()` redacts the token), so the exposure is latent
+rather than live. It stops being latent the moment a secret is mounted as a
+file — if the catalog token ever moves to a Cloud Run secret *volume*, this
+needs a companion path check.
+
 ## The statement timeout
 
 **DuckDB has no `statement_timeout` parameter.** `SET statement_timeout=...`

--- a/src/spicy_regs/mcp_server.py
+++ b/src/spicy_regs/mcp_server.py
@@ -189,6 +189,39 @@ def _jsonify(value: Any) -> Any:
     return str(value)
 
 
+READ_ONLY_STATEMENT_TYPES = frozenset({"SELECT", "EXPLAIN"})
+
+
+def _first_write_statement(cursor: duckdb.DuckDBPyConnection, sql: str) -> str | None:
+    """Name of the first non-read-only statement in ``sql``, else None.
+
+    The sandbox cannot express "no writes" on its own. ``disabled_filesystems``
+    is the setting that would, but LocalFileSystem has to stay enabled for
+    httpfs to read the CA bundle (see the security-settings notes), so
+    ``COPY ... TO``, ``ATTACH``, and ``EXPORT DATABASE`` could all write to the
+    container filesystem — on Cloud Run an in-memory one, where a large enough
+    write evicts the instance. This is the gate that says no instead.
+
+    Classification comes from DuckDB's own parser rather than a prefix regex,
+    so leading comments, string literals, and stacked statements cannot smuggle
+    a write past it. ``DESCRIBE``/``SHOW``/``SUMMARIZE``/``VALUES``/``TABLE``
+    and the FROM-first shorthand all parse as SELECT, which is why a two-entry
+    allowlist still admits every read form.
+
+    Matching on ``StatementType.name`` rather than the enum member keeps this
+    working against duckdb's incomplete type stubs, which do not declare the
+    members, without a blanket type-ignore over the comparison.
+
+    A ``ParserException`` propagates untouched: malformed SQL should surface
+    DuckDB's own message, which names the offending token.
+    """
+    for statement in cursor.extract_statements(sql):
+        name = statement.type.name
+        if name not in READ_ONLY_STATEMENT_TYPES:
+            return name
+    return None
+
+
 def _apply_security_settings(con: duckdb.DuckDBPyConnection) -> None:
     con.execute("SET preserve_insertion_order=false")
     con.execute("SET autoinstall_known_extensions=false")
@@ -365,8 +398,11 @@ def _register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool()
     def query_sql(sql: str, max_rows: int = 25) -> dict[str, Any]:
-        """Run a SQL query against the Spicy Regs R2 tables and return up to max_rows rows.
+        """Run a read-only SQL query against the Spicy Regs R2 tables and return up to max_rows rows.
 
+        Only SELECT and EXPLAIN run; DESCRIBE, SHOW, SUMMARIZE, VALUES and the
+        FROM-first shorthand are accepted as SELECT. Statements that write
+        (COPY TO, ATTACH, CREATE, INSERT, DROP, EXPORT, SET, ...) are refused.
         The connection is in-memory and read-only against R2. One view exists per
         table listed by list_sources. Always include a LIMIT in exploratory
         queries; results past max_rows are dropped.
@@ -375,6 +411,10 @@ def _register_tools(mcp: FastMCP) -> None:
             return {"error": "max_rows must be between 1 and 500"}
 
         cursor = _get_connection().cursor()
+        write_statement = _first_write_statement(cursor, sql)
+        if write_statement is not None:
+            return {"error": f"query_sql is read-only; refusing {write_statement} statement"}
+
         with _statement_timeout(cursor):
             cursor.execute(sql)
             columns = [desc[0] for desc in cursor.description] if cursor.description else []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -201,6 +201,108 @@ def test_sandbox_locks_configuration():
         con.execute("SET allow_unsigned_extensions=true")
 
 
+# --- read-only statement guard ----------------------------------------------
+
+
+READ_FORMS = [
+    "SELECT 1",
+    "WITH a AS (SELECT 1) SELECT * FROM a",
+    "FROM range(3)",
+    "DESCRIBE SELECT 1",
+    "EXPLAIN SELECT 1",
+    "SHOW ALL TABLES",
+    "SUMMARIZE SELECT 1",
+    "VALUES (1), (2)",
+    "/* lead */ SELECT 1",
+    "SELECT 1 -- COPY (SELECT 1) TO '/tmp/x.csv'",
+    "SELECT 'COPY (SELECT 1) TO /tmp/x.csv' AS s",
+]
+
+WRITE_FORMS = [
+    ("COPY (SELECT 1) TO '/tmp/probe.csv'", "COPY"),
+    ("ATTACH '/tmp/probe.db' AS z", "ATTACH"),
+    ("EXPORT DATABASE '/tmp/probe'", "EXPORT"),
+    ("CREATE TABLE t (i INTEGER)", "CREATE"),
+    ("CREATE VIEW v AS SELECT 1", "CREATE"),
+    ("DROP TABLE IF EXISTS t", "DROP"),
+    ("INSERT INTO t VALUES (1)", "INSERT"),
+    ("UPDATE t SET i = 1", "UPDATE"),
+    ("DELETE FROM t", "DELETE"),
+    ("SET memory_limit='1GB'", "SET"),
+    ("LOAD httpfs", "LOAD"),
+    ("CALL pragma_version()", "CALL"),
+    ("PREPARE p AS SELECT 1", "PREPARE"),
+    ("BEGIN TRANSACTION", "TRANSACTION"),
+]
+
+
+@pytest.mark.parametrize("sql", READ_FORMS)
+def test_read_forms_pass_the_guard(sql):
+    """Every read shape a client might send must survive the allowlist.
+
+    The allowlist is only {SELECT, EXPLAIN} because DuckDB's parser folds
+    DESCRIBE/SHOW/SUMMARIZE/VALUES and the FROM-first shorthand into SELECT.
+    If that ever stops holding, these are the cases that break.
+    """
+    con = _sandboxed_connection()
+    assert mcp_server._first_write_statement(con, sql) is None
+
+
+@pytest.mark.parametrize("sql,expected", WRITE_FORMS)
+def test_write_forms_are_named_and_rejected(sql, expected):
+    con = _sandboxed_connection()
+    assert mcp_server._first_write_statement(con, sql) == expected
+
+
+def test_guard_catches_a_write_stacked_behind_a_select():
+    """A trailing write must not ride in on a leading SELECT.
+
+    ``execute`` runs every statement in the string but returns only the last
+    result, so a stacked write would otherwise land silently.
+    """
+    con = _sandboxed_connection()
+    assert mcp_server._first_write_statement(con, "SELECT 1; DROP TABLE t") == "DROP"
+
+
+def test_guard_ignores_empty_sql():
+    con = _sandboxed_connection()
+    assert mcp_server._first_write_statement(con, "   ") is None
+
+
+def test_guard_lets_parser_errors_through():
+    """Malformed SQL keeps surfacing DuckDB's message, which names the token."""
+    con = _sandboxed_connection()
+    with pytest.raises(duckdb.ParserException):
+        mcp_server._first_write_statement(con, "SELECT ((")
+
+
+def test_query_sql_refuses_a_write_without_executing_it(monkeypatch, tmp_path):
+    """End-to-end: the tool returns an error and the COPY never lands on disk."""
+    module = mcp_server
+    module._reset_connection_cache()
+    _make_local_connection(monkeypatch, module)
+    server = module.build_server()
+    target = tmp_path / "written.csv"
+
+    result = asyncio.run(server.call_tool("query_sql", {"sql": f"COPY (SELECT 1) TO '{target}'", "max_rows": 1}))
+
+    assert not target.exists()
+    assert "read-only" in str(result)
+    module._reset_connection_cache()
+
+
+def test_query_sql_still_runs_a_select(monkeypatch):
+    module = mcp_server
+    module._reset_connection_cache()
+    _make_local_connection(monkeypatch, module)
+    server = module.build_server()
+
+    result = asyncio.run(server.call_tool("query_sql", {"sql": "SELECT docket_count FROM agency_stats", "max_rows": 1}))
+
+    assert "read-only" not in str(result)
+    module._reset_connection_cache()
+
+
 def test_comments_catalog_view_dedups_on_read():
     """The catalog-backed ``comments`` view keeps one row per comment_id.
 


### PR DESCRIPTION
## Problem

`query_sql` handed arbitrary SQL straight to `cursor.execute()` with no
statement-type check. The Cloud Run service is `--allow-unauthenticated`, so
anyone could send writes: `COPY ... TO`, `ATTACH`, and `EXPORT DATABASE` all
reach the container filesystem.

On Cloud Run that filesystem is in-memory, and `deploy.sh` sets
`SPICY_REGS_TEMP_DIR=/tmp` against `MEMORY=16Gi` with `MEM_LIMIT=12GB` — so
DuckDB's budget and anything written to `/tmp` draw on the same allocation.
A large enough `COPY (SELECT * FROM comments) TO '/tmp/x.csv'` evicts the
instance. That is an anonymous availability lever, and it also makes the
"public, stateless, and read-only" premise in `INTERNALS.md` — the stated
rationale for disabling DNS rebinding protection — untrue as written.

Verified by reproducing `_apply_security_settings` exactly and running the
statements; `COPY ... TO` and `ATTACH` both succeeded.

## Solution

Gate on statement type before executing, admitting only `SELECT` and `EXPLAIN`.

The obvious fix — `SET disabled_filesystems='LocalFileSystem'` — is the one
thing that must not be done: httpfs reads the system CA bundle off the local
filesystem on every TLS handshake, so disabling it breaks every R2 read. That
constraint is already documented and test-pinned, so the gate lives above
DuckDB instead of inside it.

**Classification uses DuckDB's own parser** (`extract_statements`), not a prefix
regex. The parser is what makes these land correctly:

| input | classified |
|---|---|
| `/* c */ COPY (SELECT 1) TO '/tmp/x'` | `COPY` — rejected |
| `SELECT 'COPY (SELECT 1) TO /tmp/x' AS s` | `SELECT` — allowed |
| `SELECT 1; DROP TABLE t` | `DROP` — rejected |

The stacked case matters most: `execute` runs every statement in the string but
returns only the last result, so a trailing write would otherwise land with
nothing in the response to show for it.

**The two-entry allowlist is wider than it looks.** DuckDB folds `DESCRIBE`,
`SHOW`, `SUMMARIZE`, `VALUES`, `TABLE`, and the FROM-first shorthand
(`FROM comments LIMIT 1`) into `StatementType.SELECT`, so every read form still
runs. `test_read_forms_pass_the_guard` pins that folding — if a DuckDB upgrade
splits any of them into its own type, the test fails rather than clients
silently losing a query form.

Matching is on `StatementType.name` rather than the enum member: duckdb's type
stubs don't declare the members and `ty` gates merges, so comparing names avoids
a blanket type-ignore over the comparison.

The `query_sql` docstring is updated too — it's reflected into every client's
tool list, so the read-only contract should be visible there.

## Scope — what this does not fix

This does **not** stop local file *reads*: `read_text`, `read_csv`, and
`read_blob` are `SELECT`s and still pass. That is deliberate scope, and the
exposure is latent rather than live:

- the R2 catalog token arrives as an env var, never a file
- `getenv` does not exist in the deployed DuckDB (v1.5.5, confirmed against
  `duckdb_functions()`)
- `duckdb_secrets()` renders it as `token=redacted`
- `/proc/self/environ` reads back 0 bytes, since DuckDB sizes reads from
  `stat` and procfs reports size 0

So there is no SQL path to the token today. It stops being latent the moment a
secret is mounted as a file — if the catalog token ever moves to a Cloud Run
secret *volume*, this needs a companion path check. Noted in `INTERNALS.md`.

## Testing

- 17 new tests: 11 read forms that must pass, 14 write forms that must be
  rejected by name, plus stacked-write, empty-SQL, parser-error passthrough, and
  two end-to-end `call_tool` cases (one asserting the `COPY` target never
  appears on disk).
- `597 passed` full suite; the network integration test against live R2 passes,
  so the guard doesn't disturb real reads.
- `ruff check`, `ruff format --check`, and `ty check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)