### PR TITLE
feat(ops): watch the Cloudflare purge credential nightly

### DIFF
--- a/.github/workflows/check-rollup-freshness.yml
+++ b/.github/workflows/check-rollup-freshness.yml
@@ -36,6 +36,16 @@ jobs:
       - name: Check published tables
         run: uv run python scripts/check_rollup_freshness.py
 
+      # Runs even when the freshness check failed: a dead purge credential and a
+      # stale table are independent faults, and hiding one behind the other is
+      # how the purge token went twelve days unnoticed in the first place.
+      - name: Check Cloudflare purge credential
+        if: always()
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: uv run python scripts/check_purge_credential.py
+
       - name: Save row-count history
         if: always()
         uses: actions/cache/save@v4

--- a/scripts/check_purge_credential.py
+++ b/scripts/check_purge_credential.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Watchdog for the Cloudflare cache-purge credential.
+
+Purges are best-effort by design: ``purge_urls`` logs a warning and returns, so
+a broken credential never fails a publish that already wrote its data. That is
+correct for the publish and blind for observability. When the purge token
+lapsed on 2026-08-17 every rollup across the repo kept reporting ``success``
+for twelve days while no invalidation happened anywhere — the only trace was a
+warning line buried in each run's log.
+
+This is the check that looks. It runs in the nightly freshness workflow and
+fails it, so a dead or expiring credential surfaces the next morning through
+the notification path the repo already has, instead of waiting for someone to
+read a log.
+
+Missing credentials are a failure, not a skip: an unset token is exactly the
+state where ``purge_urls`` silently no-ops, which is the gap being closed. Pass
+``--allow-unconfigured`` for local runs with no Cloudflare setup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from spicy_regs.sources.cloudflare import verify_token
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--allow-unconfigured",
+        action="store_true",
+        help="treat absent credentials as a skip (local runs), not a failure",
+    )
+    args = parser.parse_args()
+
+    problems = verify_token()
+
+    if problems is None:
+        if args.allow_unconfigured:
+            print("SKIP: CLOUDFLARE_API_TOKEN / CLOUDFLARE_ZONE_ID not set")
+            return 0
+        print("FAIL: CLOUDFLARE_API_TOKEN / CLOUDFLARE_ZONE_ID not set — purges are silently no-oping")
+        return 1
+
+    if problems:
+        print("Cloudflare purge credential problems:")
+        for problem in problems:
+            print(f"- {problem}")
+        print("\nRotate at https://dash.cloudflare.com/profile/api-tokens (template: Purge Cache).")
+        return 1
+
+    print("OK: Cloudflare purge credential is active")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/spicy_regs/sources/cloudflare.py
+++ b/src/spicy_regs/sources/cloudflare.py
@@ -18,7 +18,9 @@ no-ops without R2 credentials, so local runs and tests need no Cloudflare setup.
 
 from __future__ import annotations
 
+from datetime import date, datetime
 from os import getenv
+from typing import Any
 
 import httpx
 from loguru import logger
@@ -65,3 +67,75 @@ def purge_urls(urls: list[str]) -> None:
                 logger.info("Purged {} URL(s) from Cloudflare cache", len(batch))
         except (httpx.HTTPError, ValueError) as exc:
             logger.warning("Cloudflare purge error (upload already succeeded): {}", exc)
+
+
+TOKEN_VERIFY_URL = "https://api.cloudflare.com/client/v4/user/tokens/verify"
+TOKEN_EXPIRY_WARN_DAYS = 14
+
+
+def _parse_expiry(raw: str) -> date | None:
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00")).date()
+    except ValueError:
+        return None
+
+
+def evaluate_token_status(
+    status_code: int,
+    payload: dict[str, Any],
+    today: date,
+    warn_days: int = TOKEN_EXPIRY_WARN_DAYS,
+) -> list[str]:
+    """Problems with a token-verify response; empty list means healthy.
+
+    Pure so the watchdog's judgement is testable without network: every branch
+    here is a state the live API actually returned at some point.
+
+    An imminent expiry counts as a problem rather than a nicety. The token that
+    lapsed on 2026-08-17 was rejected outright the next morning, and a warning
+    fires only if someone is looking — this is the check that is looking.
+    """
+    if status_code != 200 or not payload.get("success", False):
+        errors = payload.get("errors") or []
+        detail = "; ".join(str(err.get("message", err)) for err in errors)
+        return [f"token rejected by Cloudflare ({detail or f'HTTP {status_code}'})"]
+
+    problems: list[str] = []
+    result = payload.get("result") or {}
+    status = result.get("status")
+    if status != "active":
+        problems.append(f"token status is {status!r}, expected 'active'")
+
+    raw_expiry = result.get("expires_on")
+    if raw_expiry:
+        expiry = _parse_expiry(str(raw_expiry))
+        if expiry is None:
+            problems.append(f"could not parse expires_on {raw_expiry!r}")
+        elif expiry < today:
+            problems.append(f"token expired on {expiry} ({(today - expiry).days}d ago)")
+        elif (expiry - today).days <= warn_days:
+            problems.append(f"token expires on {expiry} (in {(expiry - today).days}d) — rotate it now")
+    return problems
+
+
+def verify_token(today: date | None = None, warn_days: int = TOKEN_EXPIRY_WARN_DAYS) -> list[str] | None:
+    """Check the purge credential against Cloudflare. None when unconfigured.
+
+    Returns the caller's decision to make: ``None`` distinguishes "no
+    credentials here" (fine locally, a silent no-op in CI) from "credentials
+    present and healthy" (empty list).
+    """
+    config = _purge_config()
+    if config is None:
+        return None
+    _, token = config
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        resp = httpx.get(TOKEN_VERIFY_URL, headers=headers, timeout=_PURGE_TIMEOUT)
+    except httpx.HTTPError as exc:
+        return [f"could not reach Cloudflare to verify the token: {exc}"]
+    try:
+        payload = resp.json()
+    except ValueError:
+        payload = {}
+    return evaluate_token_status(resp.status_code, payload, today or date.today(), warn_days)

--- a/tests/test_cloudflare.py
+++ b/tests/test_cloudflare.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import date
+
 import httpx
 import pytest
 
@@ -92,3 +94,99 @@ def test_purge_swallows_transport_error(monkeypatch: pytest.MonkeyPatch) -> None
 
     monkeypatch.setattr(httpx, "post", _raise)
     cloudflare.purge_urls(["https://data.spicy-regs.dev/x.parquet"])  # must not raise
+
+
+# --- purge-credential watchdog (evaluate_token_status / verify_token) --------
+
+
+ACTIVE = {"success": True, "result": {"id": "t1", "status": "active"}}
+TODAY = date(2026, 9, 1)
+
+
+def test_healthy_token_has_no_problems() -> None:
+    assert cloudflare.evaluate_token_status(200, ACTIVE, TODAY) == []
+
+
+def test_401_is_reported_with_cloudflare_message() -> None:
+    """The exact shape the live API returned once the token lapsed."""
+    payload = {"success": False, "errors": [{"code": 10000, "message": "Authentication error"}]}
+    problems = cloudflare.evaluate_token_status(401, payload, TODAY)
+    assert len(problems) == 1
+    assert "Authentication error" in problems[0]
+
+
+def test_non_200_without_error_body_still_reports() -> None:
+    problems = cloudflare.evaluate_token_status(500, {}, TODAY)
+    assert problems == ["token rejected by Cloudflare (HTTP 500)"]
+
+
+def test_inactive_status_is_a_problem() -> None:
+    payload = {"success": True, "result": {"status": "disabled"}}
+    assert "disabled" in cloudflare.evaluate_token_status(200, payload, TODAY)[0]
+
+
+def test_expired_token_is_a_problem() -> None:
+    payload = {"success": True, "result": {"status": "active", "expires_on": "2026-08-17T00:00:00Z"}}
+    problems = cloudflare.evaluate_token_status(200, payload, TODAY)
+    assert "expired on 2026-08-17" in problems[0]
+    assert "15d ago" in problems[0]
+
+
+def test_imminent_expiry_is_a_problem_before_it_bites() -> None:
+    """The whole point: catch it while the token still works."""
+    payload = {"success": True, "result": {"status": "active", "expires_on": "2026-09-08T00:00:00Z"}}
+    problems = cloudflare.evaluate_token_status(200, payload, TODAY)
+    assert "expires on 2026-09-08" in problems[0]
+    assert "in 7d" in problems[0]
+
+
+def test_distant_expiry_is_fine() -> None:
+    payload = {"success": True, "result": {"status": "active", "expires_on": "2027-09-01T00:00:00Z"}}
+    assert cloudflare.evaluate_token_status(200, payload, TODAY) == []
+
+
+def test_unparseable_expiry_is_surfaced_not_swallowed() -> None:
+    payload = {"success": True, "result": {"status": "active", "expires_on": "whenever"}}
+    assert "could not parse" in cloudflare.evaluate_token_status(200, payload, TODAY)[0]
+
+
+def test_verify_token_returns_none_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """None is 'unconfigured', distinct from [] meaning 'configured and healthy'."""
+    monkeypatch.delenv("CLOUDFLARE_API_TOKEN", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_ZONE_ID", raising=False)
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: pytest.fail("should not call"))
+    assert cloudflare.verify_token() is None
+
+
+def test_verify_token_sends_bearer_and_reads_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    _creds(monkeypatch)
+    seen: dict = {}
+
+    def _get(url, headers=None, timeout=None):
+        seen["url"] = url
+        seen["headers"] = headers
+        return httpx.Response(200, json=ACTIVE)
+
+    monkeypatch.setattr(httpx, "get", _get)
+    assert cloudflare.verify_token(today=TODAY) == []
+    assert seen["url"] == cloudflare.TOKEN_VERIFY_URL
+    assert seen["headers"]["Authorization"] == "Bearer tok-123"
+
+
+def test_verify_token_reports_transport_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _creds(monkeypatch)
+
+    def _boom(*a, **k):
+        raise httpx.ConnectError("no route")
+
+    monkeypatch.setattr(httpx, "get", _boom)
+    problems = cloudflare.verify_token(today=TODAY)
+    assert problems is not None and "could not reach Cloudflare" in problems[0]
+
+
+def test_verify_token_survives_a_non_json_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An HTML error page from a proxy must report, not raise."""
+    _creds(monkeypatch)
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: httpx.Response(502, text="<html>bad gateway"))
+    problems = cloudflare.verify_token(today=TODAY)
+    assert problems is not None and "HTTP 502" in problems[0]


### PR DESCRIPTION
## Problem

`CLOUDFLARE_API_TOKEN` expired on **2026-08-17**. Every rollup in the repo
401'd on purge for the next twelve days while still reporting `success`. It was
found by accident on 2026-09-01 while reading an unrelated `congress_bills` run.

```
WARNING | Cloudflare purge failed (401): {"errors":[{"code":10000,"message":"Authentication error"}]}
```

Reconstructed from `rollup-gao-reports` logs:

| date | purge |
|---|---|
| Aug 10–14 | not called (feature not yet live) |
| **Aug 15, 16** | **`Purged N URL(s)`** |
| Aug 17 → Sep 1 | `401`, every run, every rollup |

Confirmed the same failure on `federal_register`, `lobbying_filings`,
`fcc_filings`, and `gao_reports` — it was repo-wide, not one workflow.

**No data was affected.** The corpus edge-cache rule is `enabled = false` in
`deploy/terraform/main.tf` — deliberately, since edge-caching parquet corrupts
DuckDB's concurrent byte-range reads. With no cache in front of the corpus a
purge has nothing to invalidate, so the dead credential was inert.

The risk was latent rather than live. That rule is kept in Terraform precisely
so it can be re-enabled ("narrow the expression … and flip enabled back on"),
and its own description asserts `purge-on-publish invalidates`. Whoever
re-enabled it would have inherited a stale-data bug whose invalidation
mechanism had been broken for weeks, with every job still green.

## What this does not change

`purge_urls` still logs and returns. A purge failure must never fail a publish
that already wrote its data, and the origin `max-age` is a self-healing
backstop — that design is correct and stays exactly as it is.

The gap was never the swallowing. It was that **nothing else was looking.**

## Solution

`scripts/check_purge_credential.py`, run nightly as a step in
`check-rollup-freshness.yml` — the repo's existing watchdog, whose failures
already reach someone.

It fails when the token is rejected, not `active`, absent, or **within 14 days
of expiry**. Three deliberate choices:

- **Verify the credential, don't scrape logs.** It calls Cloudflare's
  `/user/tokens/verify` directly. Log-grepping across N rollup workflows would
  be fragile and always retrospective.
- **Warn 14 days ahead.** The August token was rejected outright the morning
  after it lapsed. Reading `expires_on` means the *next* expiry surfaces before
  it bites — the check that would actually have prevented this, rather than
  merely reported it sooner.
- **Absent credentials fail, not skip.** An unset token is exactly the state
  where `purge_urls` silently no-ops, so treating it as a skip would rebuild the
  original blind spot. `--allow-unconfigured` keeps local runs working.

The step is `if: always()`, so a stale table and a dead credential report
independently — hiding one behind the other is how this went unnoticed.

## Testing

12 new tests. `evaluate_token_status` is pure, so every branch is exercised
without network, including the exact 401 body the live API returned:

```python
{"success": False, "errors": [{"code": 10000, "message": "Authentication error"}]}
```

plus inactive status, expired, imminent-expiry, distant-expiry, unparseable
`expires_on`, transport error, and a non-JSON body from a proxy (502 HTML, which
must report rather than raise).

`580 passed`; `ruff check`, `ruff format --check`, `ty check` all clean.

Verified against the real credential by dispatching the workflow on this branch
(see comment below).

## Follow-up

The token was rotated on 2026-09-01 and a purge succeeded (`Purged 1 URL(s)`,
run `33454659342`), so this lands against a healthy credential. A rotation
runbook now exists outside the repo; worth considering whether a short version
belongs in `deploy/` too, since there is currently nothing here describing the
token's required scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)