### PR TITLE
docs: one disposition record for the archived research program

### DIFF
--- a/docs/disposition.md
+++ b/docs/disposition.md
@@ -174,53 +174,119 @@ they must trust.
 
 Rulespec's own spec (`spec/rulespec-releases.md` §7, 2026-08-04) recorded
 these duties as parked with no owner and assigned the decision to the platform
-owner. Decided 2026-09-04 as a split; ruled complete 2026-09-05. The split below is
-from the call graph of `rkaf_projection.py` at `8d9e7a2`, which corrects the
-first draft's count: `project_document` was listed as deterministic, but it
-calls the model layer, so it belongs to the orchestration.
+owner. Decided 2026-09-04 as a split; ruled complete 2026-09-05. The split is from
+the call graph of `rkaf_projection.py` at `8d9e7a2`, which corrects the first
+draft's count: `project_document` was listed as deterministic, but it calls the
+model layer, so it belongs to the orchestration. Both receiving lanes reproduced
+every count below by AST on 2026-09-05 and added the seams recorded here.
 
 - **The deterministic layer** — 21 functions, 1,307 lines of
-  `rkaf_projection.py`, plus its 13 data classes (221 lines): `assemble`
-  (476), `verify_candidate_rows` (191), `_federal_register_facts` (204),
-  `_unified_agenda_facts` (91), `verify_fragment`, `load_artifact`, and the
-  IRI and fragment helpers under them. It becomes
+  `rkaf_projection.py`, plus 12 of its 13 data classes (209 lines;
+  `NormalizedVocabulary` serves only the model path and stays). Roots:
+  `assemble` (476), `verify_candidate_rows` (191), `_federal_register_facts`
+  (204), `_unified_agenda_facts` (91), `verify_fragment`, `load_artifact`, and
+  the IRI and fragment helpers under them. It becomes
   `rulespec/packages/rulespec-projection`, beside `rulespec-artifacts`, the
   only package there today: the format owner ships the reference producer next
-  to its verifier and fifteen conformance bundles. Priced against rulespec's
-  closure (`rulespec-artifacts`, `pyshacl`, `rdflib`, `rdfcanon`): the layer's
-  own functions import nothing outside the standard library. What they reach
-  through spicy-regs modules: `ontology.citations` (1,025 lines, standard
-  library only), `ontology.attestations` (544, same), four helpers from
-  `ontology.common` (`canonical_json`, `stable_id`, `text_digest`,
-  `RunContext`; that module imports pyarrow and loguru at the top, so the four
-  are copied, or replaced by `rulespec_artifacts.canonical_json_bytes` and
-  `sha256_digest`, and the module is not), and `resolve_exact_evidence_offsets`
-  from `ontology.llm` (35 lines, no imports). `SourceArtifact` from
-  `docpipeline/source.py` becomes the input contract, filled from DocSpec's
-  DocumentRelease 2.0; IRIs come from RefSpec's `iri_minting`. Zero new
-  dependencies.
+  to its verifier and fifteen conformance bundles. Priced against rulespec at
+  `a519d06` (`rulespec-artifacts`, `pyshacl`, `rdflib`, `rdfcanon`): zero new
+  dependencies. The functions themselves import nothing outside the standard
+  library. What they reach is copied at the name, not the module, because the
+  host modules import pyarrow and loguru at the top:
+  - `ontology.citations`: ten parser and IRI functions. The module is 1,025
+    lines of standard library and can move whole.
+  - `ontology.attestations`: `attestation_row` and `ATTESTOR_KIND_AI_MODEL`,
+    which close over about 100 lines, plus `OntologyInvariantError` from
+    `invariants`. Not the 544-line module.
+  - `ontology.common`: `canonical_json`, `stable_id`, `text_digest`,
+    `RunContext`; or `rulespec_artifacts.canonical_json_bytes` and
+    `sha256_digest` for the first two.
+  - `ontology.llm`: `resolve_exact_evidence_offsets` with its
+    `EvidenceOffsetResolution` dataclass, 50 lines, no imports.
+
+  Two seams stay with the caller as a Protocol or an injected mapping:
+  `PublishedTables`, whose cache fills through `read_parquet_rows` (the one
+  pyarrow path in the set), and `_source_table_for_profile`, which reads
+  `SOURCE_PROFILES`. `SourceArtifact`, a 34-line dataclass, becomes the input
+  contract, filled from DocSpec's DocumentRelease 2.0, with `AccessScope` and
+  docling's default size limit inlined; IRIs come from RefSpec's `iri_minting`.
+
 - **The orchestration** — the 13 functions only the model path uses, 1,150
   lines of `rkaf_projection.py` (`_run_model_layer_with_vocabulary` 355, the
   two vocabulary loaders 552, `project_document` 71), plus the six provider
   adapters (6,932 lines), `extraction` (954), `runtime` (1,792), `tag_task`
-  (961), `relation_task` (2,102), `executor` (536), and `corpora/` (16
-  modules, 23,798 lines). Its home is **spicy-docs**, ruled 2026-09-05: it
-  sits beside the source-native releases it reads and the table publisher it
-  feeds, so one install runs the whole path. It depends on
-  `rulespec-projection` for the 13 functions both layers share (878 lines).
-  Priced against spicy-docs at `86e8416` (`rulespec-artifacts`, `boto3`,
-  `httpx`, `jsonschema`, `loguru`, `polars`, `tqdm`; `pyarrow` as the
+  (961), `relation_task` (2,102), and `executor` (536). Its home is
+  **spicy-docs**, ruled 2026-09-05: it sits beside the source-native releases
+  it reads and the table publisher it feeds, so one install runs the whole
+  path. It depends on `rulespec-projection` for the 13 functions both layers
+  share (878 lines).
+
+  *The constraint that shapes it.* spicy-docs' read and verify path is
+  contractually thin. DocSpec installs the spicy-docs wheel with `--no-deps`
+  (`tests/test_source_catalog_installed_wheel.py:911` at `20fcb24`) and imports
+  five of its modules, and spicy-docs' `tests/test_reader_closure.py` at
+  `86e8416` fails if `polars`, `httpx`, `boto3`, `botocore`, `loguru`, or
+  `tqdm` sit in `sys.modules` after importing `source_native` and
+  `source_native_profiles`. That guard is the enforcement for this port. It
+  gains the seven model names (`anthropic`, `openai`, `sentence_transformers`,
+  `torch`, `docling`, `tiktoken`, `transformers`), and since DocSpec imports
+  five modules on that path and all five are clean today, it should name all
+  five. Import direction, after spicysearch's `AGENTS.md` table
+  (`f97b904:100`):
+
+  | From | Read/verify | Acquisition/publish | Orchestration | Experiments |
+  |---|---|---|---|---|
+  | Read/verify | Yes | No | No | No |
+  | Acquisition/publish | Yes | Yes | No | No |
+  | Orchestration | Yes | Yes | Yes | No |
+  | Experiments | Yes | Yes | Yes | Yes |
+  | Tests | Yes | Yes | Yes | Yes |
+
+  Model output is nondeterministic by construction and spicy-docs' releases are
+  byte-reproducible; the table keeps them apart in the direction that matters.
+
+  *Dependencies*, priced against spicy-docs at `86e8416` (`rulespec-artifacts`,
+  `boto3`, `httpx`, `jsonschema`, `loguru`, `polars`, `tqdm`; `pyarrow` as the
   `public-table` extra). Present: `jsonschema`, `loguru`, `pyarrow`. Absent at
   runtime: `anthropic`, `openai`, `tiktoken` (the model adapters);
   `sentence_transformers` and `torch` (the embedding adapter); `docling` (the
-  layout adapter, imported lazily); `refspec` (the vocabulary loader);
-  `rdflib` (through `candidate_release`); `numpy` and `scikit-learn` (through
-  `ontology.concepts`, lazily). Each adapter's dependency belongs in an extra
-  named for it, the way `public-table` carries pyarrow. `corpora/` adds
-  `transformers`, `scipy`, `ir_measures`, `pypdf`, `python-dotenv`, `duckdb`:
-  an `experiments` extra. Test-only and absent: `docling_core`, `python-docx`,
-  `openpyxl`, `python-pptx` (the real-Docling test); `refspec` and `duckdb`
-  (the projection test).
+  layout adapter, imported lazily); `refspec` (the vocabulary loader); `rdflib`
+  (through `candidate_release`); `numpy` and `scikit-learn` (through
+  `ontology.concepts`, lazily). One extra per adapter, copying all four
+  properties of `public-table`: the extra, the reason in the module docstring,
+  a lazy CLI import that reports the missing dependency instead of crashing,
+  and presence in the dev group so the default suite tests it. The embedding
+  extra's note states its size: `pyarrow` is one wheel, `torch` is gigabytes.
+  Test-only and absent: `docling_core`, `python-docx`, `openpyxl`,
+  `python-pptx` (the real-Docling test); `refspec` and `duckdb` (the projection
+  test). spicy-docs has no model or adapter code at `86e8416`, so nothing
+  collides.
+
+  *Seams.* The cost is the first-party closure, 20 modules and 19,209 lines
+  before adapters, not the packages. Each module below is touched at a few
+  names, and a module touched at a few names is a contract to define, not code
+  to move:
+
+  | module | lines | names the orchestration uses |
+  |---|---|---|
+  | `docpipeline/source.py` | 3,593 | 5: `SourceArtifact`, `build_source_artifact`, `profile_for_table`, `SOURCE_PROFILES`, `iter_source_records` |
+  | `ontology/concepts.py` | 1,407 | 4 |
+  | `docpipeline/segments.py` | 1,163 | 3 |
+  | `ontology/llm.py` | 1,036 | 7: the prompt constants, the tag schema, the resolver |
+  | `candidate_release.py` | 705 | 2 |
+  | `document_release_v3.py` | 678 | 6: digest and key helpers |
+  | `ontology/common.py` | 226 | 6: `canonical_json` alone from ten call sites |
+  | `connected_concepts`, `ontology/segmentation`, `concept_dimensions` | 856 | 7 |
+
+- **`corpora/`** — 16 modules, 23,798 lines of experiment scripts, over half
+  the producer by volume. Experiments may import everything and nothing imports
+  them, so they sequence last and defer at no cost. All 15 scripts were last
+  touched 2026-08-28; 13 of them are registered as 13 console-script
+  entries at `8d9e7a2`, and `mirrulations_document_corpus` is neither
+  registered nor cited by the evidence. They move per module, when the evidence
+  that cites one needs re-running, under an `experiments` extra
+  (`transformers`, `scipy`, `ir_measures`, `pypdf`, `python-dotenv`,
+  `duckdb`). None moves in the same change as the adapters.
 
 ## Ships to spicy-docs
 

--- a/docs/disposition.md
+++ b/docs/disposition.md
@@ -1,9 +1,8 @@
-# Disposition of the archived spicy-regs work
+# Disposition of the July–August research program
 
-Written 2026-09-04. One record of where every piece of the July–August 2026
-research program now lives, what replaced it, and what still needs a home. It
-replaces three earlier documents that disagreed with each other and with the
-code; see *Supersedes*.
+Written 2026-09-04. One record of what the program built, what each piece gives
+a user of the platform, and where each piece now lives. Decisions were taken
+2026-09-04 by the platform owner; this document records them.
 
 Every claim below was checked against a pinned commit, not read from a
 document. The pins:
@@ -19,164 +18,306 @@ document. The pins:
 | RefSpec | `main` | `da4fe055` |
 | rulespec | `main` | `a87d839` |
 
-## Where the work is
+## What the program was
 
-Two branches carry all the content. They forked from `origin/main` at
-`01ecbef` (2026-08-19) and were cut one day apart from the same program.
-Neither removes anything from upstream; the nine files they "lack" are what
-upstream added after the fork (`org_committee_links`, `seed_dockets_catalog`,
-`check_purge_credential`).
+Between 2026-07-23 and 2026-08-29 a document-AI research program ran on this
+repository: read federal documents, segment them, tag what they are about,
+extract how rules relate, and publish the result in a portable graph format
+that other products can consume. It measured everything it did — 202 evidence
+files, 20 design specs, 14 notebooks — and it left behind about 270,000 lines
+across two branches.
+
+Users of the platform ask four kinds of question this program answers:
+
+- *Follow one rule* — from the Unified Agenda through its docket, CFR parts,
+  RIN, comment periods, and final rule, across the four identifier systems the
+  government uses for it.
+- *What is this document about* — in words no 1995 thesaurus anticipated.
+- *Which cases touch this rule* — court opinions cite statutes, not CFR parts,
+  and nothing joined them.
+- *Is this all of them* — whether a result set is complete or the platform
+  never fetched the rest.
+
+The sections below say which piece answers which question and where it ships.
+
+## Where the work lives
+
+Two branches carry the content. They forked from `origin/main` at `01ecbef`
+(2026-08-19) and were cut one day apart from the same program. Neither removes
+anything from upstream; the nine files they lack are what upstream added after
+the fork.
 
 | branch | commit | date | vs `origin/main` | holds |
 |---|---|---|---|---|
+| `integrate/payload-prereqs` | `8d9e7a2` | 2026-08-28 | +649 files | the shared core plus source-native, courts, bills, the table publisher |
 | `archive/landing-final` | `9a79569` | 2026-08-29 | +609 files | the shared core plus `source_catalog/`, `universes/` |
-| `integrate/payload-prereqs` | `8d9e7a2` | 2026-08-28 | +649 files | the shared core plus source-native, courts, bills, `public_table` |
 
-Both are on `github.com/mikewolfd/spicy-regs` (a fork; remote `fork`), with
-four older snapshots whose tip trees are copies of one or the other:
+Both are on `github.com/mikewolfd/spicy-regs` (a fork; remote `fork`) with
+four earlier snapshots whose tip trees are copies of one or the other:
 `archive/landing-main-pre-reorg` `31a4bfe`, `archive/integrate-payload-prereqs-pre-reorg`
 `a6ab98a`, `archive/pre-strip-2026-08-26` `57d46bf`, `backup/pre-marker-fix`
-`bc8f534`, `feat/rkaf-boundary-freeze` `a8938b4`. Nothing is single-disk.
+`bc8f534`, `feat/rkaf-boundary-freeze` `a8938b4`. Everything has a remote.
 
-Fifteen `src/` files exist on both branches with different content. Only two
-matter after the dispositions below — `sources/supreme_court_opinions.py` and
-`transforms/build_supreme_court_opinions.py` — and only when the courts PR is
-cut. The rest belong to buckets that drop.
+Fifteen `src/` files exist on both branches with different content. Two matter:
+`sources/supreme_court_opinions.py` and `transforms/build_supreme_court_opinions.py`,
+when the courts PR is cut. The rest belong to pieces that ship from one branch
+only.
 
-Neither branch has PRs #181, #182, or #183. Both carry the pre-fix
-`uscode_uslm.py` (no memory bound) and `integrate` carries the pre-fix
-`source_domains.py` (fabricated publisher URL). Landing `integrate` wholesale
-would reintroduce both.
+Neither branch has PRs #181, #182, or #183. Both carry the earlier
+`uscode_uslm.py` and `integrate` carries the earlier `source_domains.py`; the
+corrected versions are on their own branches, and the PRs below cut from
+`integrate` by file, never wholesale.
 
-## Dispositions
+## Ships to spicy-regs
 
-**Drop** means: the code stays on the fork, nothing is ported, and the check
-in the last column is the reason. **PR** means cut a branch from
-`integrate/payload-prereqs` onto `origin/main` and treat it like #181 — rebase,
-gate through `uv run`, validate against real data, one-paragraph description.
-**Port** means the work belongs in another repo and goes through that repo's
-own intake.
+Each of these becomes one PR cut from `integrate/payload-prereqs` (or
+`archive/landing-final` where noted) onto `origin/main`, with the same
+treatment as #181: rebase, gate through `uv run`, validate against real data,
+one-paragraph description. In this order.
 
-### A. Already re-homed — drop
+### 1. The rulemaking join surface
 
-| bucket | branch | files | replaced by | check |
-|---|---|---|---|---|
-| `source_native*.py`, `schemas/source_native_release/1.0/` | integrate | 22 | spicy-docs `src/spicy_docs/source_native.py` and siblings, shipped `70a5b16` 2026-08-29 | integrate's copy is byte-identical to `ff8d202`, the extraction point; zero commits touched it since |
-| `sources/uscode_uslm.py`, `uscode_olrc.py` | both | 2 | RefSpec `tools/build_usc_source_credits.py` (`5b8f4d8b`), `registry/act_resolution.py` | both copies got the `element.clear()` memory bound independently: spicy-regs `5ecfd5a`, RefSpec `93d244a3` |
-| `ontology/citations.py` | both | 1 | RefSpec `registry/iri_minting.py` (`582461fe`) — seven minters, 1,570 test lines | one minter did not travel; see D |
-| `ontology/act_index.py` | both | 1 | RefSpec `registry/act_resolution.py`, which names it as provenance | — |
-| `transforms/build_authority_edges.py` | both | 1 | RefSpec `registry/unified_agenda_parquet.py` | — |
-| `document_release.py` (M1) | both | 1 | DocSpec `tests/fixtures/document_release_v2{,_docspec}/` (`bdab0b8`, 2026-08-30) — 49 sealed cases, FR-2026-03227 included | — |
-| `document_release_v3*.py` (6) and `fixtures/releases/` (56) | both | 77 | DocSpec DocumentRelease 2.0: `src/docspec/schemas/document_release/2.0/`, `adapters/document_release_verify.py`, ADR `docs/decisions/0001-document-release-2-0.md`, three mint receipts | the two directories are one bucket; earlier counts listed them twice |
-| `docpipeline/source.py`, `segments.py` | both | 2 | DocSpec `processing/bounded_segmentation.py`, `retention_floors.py` (`be3c865`, `9bcc9ba`, 2026-08-30) | DocSpec addresses UTF-8 bytes; spicy-regs addressed codepoints. Region ids do not compare equal across the two. |
-| `sources/source_domains.py` | integrate | 1 | archived on `feat/source-domain-drift-gate-revived` `f8e9e35` (PR #192, closed) | the archived copy has the corrected publisher URL; integrate's does not |
-| `enrichment/accepted_output.py` | landing-final | 1 | nothing | imports `refspec.accepted_output`, which RefSpec no longer provides (`9a79569` commit message says so) |
-| `enrichment/managed_release.py` | landing-final | 1 | RefSpec `src/refspec/managed_release.py` (2,638 lines) — this was a consumer wrapper over it | — |
+`transforms/build_rule_targets.py`, `build_proceedings.py`,
+`build_regulatory_agenda.py`, `build_comment_periods.py`, with `published.py`
+and `pipelines/materialized.py` that serve their tables. On both branches.
 
-### B. Unowned — PR to spicy-regs
+**What a user gets.** Today the platform pairs a proposed rule with its final
+rule (`rulemaking_lifecycles`) and links Federal Register documents to dockets
+(`fr_docket_links`). It cannot follow one rule end to end, because a rule is a
+RIN on reginfo, a docket on regulations.gov, a set of CFR parts in the Code, and
+a document number in the Register, and nothing joins the four. These transforms
+build that spine — docket ↔ CFR ↔ RIN — then promote each rulemaking to a
+first-class proceeding with its actions, link agenda items to those actions,
+and materialize every comment period including reopenings. A user follows one
+rule from agenda to final under every name the government gives it.
 
-Absent from DocSpec, spicysearch, and spicy-docs at the pinned commits. Each
-was grepped in all three.
+This is the product the platform was built to be.
 
-| bucket | files | lines | why it matters | what downstream has instead |
-|---|---|---|---|---|
-| `sources/document_populations.py`, `sample-data/document-populations/` | 2 + 7 captures | 468 | the coverage denominator. Its docstring: "you cannot state what a run missed without a publisher-issued enumeration to miss it against." Digest-pinned captures of CBO, FCC ECFS, GovInfo PREMIS; refuses a bot-challenge body rather than yield an empty population. **No consumer anywhere.** | nothing |
-| `public_table.py`, `public_table_profiles.py`, `publication.py` | 3 | 1,230 | the Parquet/DuckDB/Iceberg **producer**. The 2026-08-27 sweep ruled the public-view path "not safe to abandon." | spicy-docs has a **consumer** (`spicy_regs_public_tables_source_native.py`) whose supply-precedence ruling assumes these tables keep existing. No producer. |
-| courts: `sources/courtlistener_bulk.py`, `transforms/build_court_opinion_{bodies,clusters}.py`, `court_scope.py`, `pipelines/court_opinion_{bodies,clusters}.py`, `sources/supreme_court_opinions.py`, `transforms/build_supreme_court_opinions.py`, `pipelines/supreme_court_opinions.py`, `transforms/pdf_text_pymupdf.py` | 10 | ~2,000 | rollup pipelines that emit parquet. A real run exists: `output/court-data-2026-08-22/`, 5.7 GB. | spicysearch consumes pinned court parquet and tags it (`derived_topic_passes/postings.py`); no fetcher, no PyMuPDF dependency. spicy-docs took `courtlistener_bulk.py` as a reader (`9c75f0b`) and built nothing on it. DocSpec: zero hits. |
-| `sources/bill_subjects.py`, `transforms/enrich_bill_subjects.py`, `pipelines/bill_subjects.py` | 3 | 722 | wired with a cron entry point and workflow | nothing |
+### 2. Courts
 
-When cutting the courts PR, diff `sources/supreme_court_opinions.py` and
-`transforms/build_supreme_court_opinions.py` between `8d9e7a2` and `9a79569`
-first; they differ.
+`sources/courtlistener_bulk.py`, `transforms/build_court_opinion_bodies.py`
+(356 lines), `build_court_opinion_clusters.py` (410), `court_scope.py` (348),
+`pipelines/court_opinion_{bodies,clusters}.py`, `sources/supreme_court_opinions.py`,
+`transforms/build_supreme_court_opinions.py`, `pipelines/supreme_court_opinions.py`,
+`transforms/pdf_text_pymupdf.py` (171). Ten files, about 2,000 lines, on
+`integrate`. A real run exists: `output/court-data-2026-08-22/`, 5.7 GB.
 
-### C. Refused on the record — drop
+**What a user gets.** Court opinions cite statutes, not CFR parts, so a user
+asking "which cases touch this rule" gets nothing today. These pipelines bring
+CourtListener's bulk dumps and the Supreme Court's own opinion PDFs into the
+same tables as everything else — opinion text, cluster identity, and the court
+that decided (which the cluster dump omits) — so the U.S.C. bridge can join
+litigation to rulemaking. spicysearch already tags court opinions it is handed
+as pinned parquet; this is what produces that parquet.
 
-| bucket | files | lines | who refused, where |
-|---|---|---|---|
-| `docpipeline/{extraction,runtime,tag_task,relation_task,executor}.py`, `docpipeline/adapters/` (Anthropic, OpenAI, OpenAI-compatible, Codex CLI, Docling, sentence-transformers) | 11 | — | rulespec `spec/rulespec-releases.md:340-361` §7 parks approval, selection, and baseline-validation execution with no owner and rejects the inference that the Extrapolator inherits them. `docs/decisions.md:170-175` (ADR 2026-08-02): "no producer of an `ExtrapolationRelease` outside the fixture path … do not implement." |
-| `docpipeline/retrieval.py` | 1 | 5,479 | spicysearch reimplemented it as three lanes plus one optional (`src/spicysearch/search_application.py`, `POST /v1/search`). The interface the manifest named, `search_documents` / `SearchResultSet`, has zero hits in spicysearch source. |
-| `ontology/concepts.py`, `concept_dimensions.py`, `transforms/build_concept{s,_assignments,_events}.py` | 5 | — | RefSpec REF-053 (2026-08-31): "Open-vocabulary concept lifecycle stays unported — no owner, no consumer, no check." |
-| `candidate_release.py` | 1 | — | reads `ATLAS_FORMAT = "refspec-vocabulary-atlas-nquads-1.0"` (line 24). RefSpec retired Atlas 1.0 and 2.0 at `5c6d889a`, 2026-08-09. No producer of that format exists. |
-| `docpipeline/rkaf_projection.py` | 1 | 3,124 | rulespec's refusal above. Also: `from refspec import` at line 2334 violates spicysearch `docs/decisions/0001-four-product-boundary.md:56-57`; its `RulespecCoreRelease` pin `urn:rulespec:core:5ac6ba59…` was re-keyed by rulespec `8bce779` on 2026-08-11. The largest single module in this group. |
-| `feat/rkaf-boundary-freeze` fixture schemas | 26 | — | a superseded v3 fixture layout; nothing references them by name; `9a79569`'s 645 tests pass without them |
+Ships whole. The 21 tables on `origin/main` each keep their fetch beside their
+transform; courts follows the same shape.
 
-### D. Genuine gaps — port
+### 3. Bill subjects
 
-| bucket | lines | to | why |
-|---|---|---|---|
-| `ontology/rulespec_release.py` | 178 | RefSpec | an executable publish gate that recomputes the L0 contract digest from the tagged rulespec archive and refuses on mismatch. RefSpec's pin is verified only against its own `RULESPEC_DEPENDENCY_SHA256`; `profiles/rulespec-dependency.json` says `releaseAvailability: localUnpublished`; `vendor/README.md` calls rc18 a provisional pin from an unmerged branch. |
-| `canonical_usc_chapter_iri` and its lowercase-suffix rule (`citations.py:404-418`) | ~15 | RefSpec `iri_minting.py` | the one URN producer of eight that the port left behind |
-| `ontology/attestations.py` | — | RefSpec, when REF-058 reopens | RefSpec considered and deferred `rkaf:Attestation` alignment. Hold on the fork until then. |
+`sources/bill_subjects.py`, `transforms/enrich_bill_subjects.py`,
+`pipelines/bill_subjects.py`. 722 lines on `integrate`, already wired with a
+cron entry point and workflow.
 
-### E. No owner, no refusal — decision pending
+**What a user gets.** Every bill carries a CRS policy area and legislative
+subjects that Congress.gov assigns. With them in the tables, a user filters
+bills by topic and relates bills to rules by subject — the first link between
+the legislative and regulatory halves of the corpus that does not go through a
+statute citation.
 
-Nothing downstream took these and nothing on the record rules them out. The
-call is between dropping them with the evidence preserved on the fork, or
-holding them as gaps to fill.
+Ships whole, same reasoning as courts.
 
-| bucket | files | note |
+### 4. The table publisher
+
+`public_table.py`, `public_table_profiles.py`, `publication.py`. 1,230 lines
+on `integrate`.
+
+**What a user gets.** Everything a user touches — the Parquet files at
+`data.spicy-regs.dev`, the MCP server, the app — is a table something built.
+Today that something is 21 hand-written scrapers. This is the path that builds
+the same tables from verified, digest-pinned source-native releases instead: an
+admitted release goes in, faithful Parquet/DuckDB/Iceberg views come out, and
+the provenance of every row is the release it came from. spicy-docs' supply
+rule already treats these tables as its first rung of acquisition and captures
+them; this is what makes them.
+
+### 5. The document-AI producer
+
+`docpipeline/rkaf_projection.py` (3,124 lines), `docpipeline/{extraction,runtime,tag_task,relation_task,executor}.py`,
+`docpipeline/adapters/` (Anthropic, OpenAI, OpenAI-compatible, Codex CLI,
+Docling, sentence-transformers), and `corpora/` (16 modules) with
+`evaluation_boundary.py` as their test bench. On both branches.
+
+**What a user gets.** Two things no product provides today.
+
+*What is this document about.* Search knows the Federal Register Thesaurus
+(last revised 1995) and RefSpec's curated vocabularies. A document about a
+topic no curator anticipated is invisible to a topic query. This pipeline reads
+the document with a model, tags what it is about in open language, and extracts
+how it relates to other rules — with identity minted deterministically and
+every claim bound to an exact span of source text the model cannot alter.
+
+*A format other products can read.* The result is written as Rulespec RKAF
+JSON-LD. Seven production modules across rulespec, RefSpec, and spicysearch
+already read that format; this module is the only thing that writes it from a
+real document. Without a producer, the platform's portable, validated graph is
+a schema with no instances.
+
+`corpora/` ships with it: six console scripts run the segmentation and
+relation-extraction experiments whose numbers appear in the evidence, and
+`evaluation_boundary.py` freezes the train/holdout split so every accuracy
+claim can be re-run. A quality number a user can check is worth more than one
+they must trust.
+
+Rulespec's own spec (`spec/rulespec-releases.md` §7, 2026-08-04) recorded
+these duties as parked with no owner and assigned the decision to the platform
+owner. Decided 2026-09-04: spicy-regs owns them. One line changes on the way
+in — `rkaf_projection.py:2334` imports `refspec` directly; it takes a vendored
+wheel instead, the pattern spicysearch uses.
+
+## Ships to spicy-docs
+
+### Publisher-issued document populations
+
+`sources/document_populations.py` (468 lines) and seven digest-pinned captures
+under `sample-data/document-populations/` — CBO's cost-estimate feed, FCC ECFS
+filing pages, GovInfo PREMIS records. On `integrate`.
+
+**What a user gets.** When a query returns 412 CBO cost estimates, the user
+cannot tell today whether that is all of them. This captures what the publisher
+itself says exists, so the platform answers "412 of 415" and can distinguish
+"there are no more" from "we never fetched the rest." The parsers refuse a
+bot-challenge page rather than report an empty population, so a blocked fetch
+never reads as a complete one.
+
+spicy-docs is the acquisition product — "spicy-docs gets; it does not
+interpret" — and already carries `source_domains.py`, the documented-vs-observed
+drift gate. Populations are the same kind of thing: acquisition metadata. It
+goes through spicy-docs' own intake, commit-never-push.
+
+## Ships to RefSpec
+
+### The rulespec publish gate
+
+`ontology/rulespec_release.py` (178 lines). On both branches.
+
+**What a user gets.** Confidence that what RefSpec publishes was checked
+against the rulespec release it claims to depend on. Today RefSpec verifies its
+pin against its own recorded digest — proof the note did not change, not proof
+the note is true — and its `profiles/rulespec-dependency.json` says
+`localUnpublished`. This gate recomputes the L0 contract digest from the tagged
+rulespec archive and refuses to publish on mismatch.
+
+Committed to RefSpec, not pushed, once the current merge settles.
+
+### One missing minter
+
+`canonical_usc_chapter_iri` and its lowercase-suffix rule
+(`ontology/citations.py:404-418`). The 2026-08-31 port of the citation grammar
+into RefSpec's `iri_minting.py` carried seven of eight producers; this is the
+eighth.
+
+**What a user gets.** `26 U.S.C. chapter 13A` and `chapter 13a` resolve to the
+same place.
+
+Goes to whoever is editing `iri_minting.py`; it lives inside that file.
+
+## Already delivered elsewhere
+
+Users have these today through the product that maintains them. The
+spicy-regs copies stay on the fork as the record of where each started.
+
+| piece | where users get it now | what they get |
 |---|---|---|
-| `ontology/ann_index.py`, `candidate_channels.py` | 2 | RefSpec's ledger books them as spicysearch's. spicysearch has zero hits for usearch, hnsw, faiss, annoy, or `candidate_channels`. The older manifest's "inventoried-not-moved" was right. |
-| `corpora/` | 16 | six console scripts point into it. No document addresses it. |
-| `ontology/{ledger,invariants,receipt,relation_findings,evaluation,common,adapters,subjects,segmentation,checkpoint,llm,codex_cli}.py` | 12 | RefSpec ported one of five functions from `invariants.py` (`2b4960e1`). `ledger.py` is out of RefSpec's scope by REF-022. The rest are unaddressed. |
-| `evaluation_boundary.py`, `rulespec_testbed.py`, `evaluate_tag_quality.py`, `source_profiles.py`, `source_profile_artifacts*.py`, `published.py`, `document_file_pipeline.py`, `pipelines/{materialized,ontology_dataset}.py` | 10 | `published.py` reads the ontology tables at `data.spicy-regs.dev/materialized/ontology/latest.json`, which has returned 404 since at least 2026-08-27. The `materialize-ontology` workflow is not on `origin/main`. |
-| `transforms/{build_comment_periods,build_proceedings,build_regulatory_agenda,build_rule_targets}.py` | 4 | RefSpec's ledger assigns `build_rule_targets` to DocSpec's scope; DocSpec has nothing. |
-| `universes/` | 3 JSON | 600 lines of the archived `PLAN.md` describe them |
-| `docs/superpowers/specs/` (20), `docs/evidence/` (202), 12 of 14 notebooks | 234 | provenance for the decisions above. Stays on the fork either way. |
+| `source_native*.py`, `schemas/source_native_release/1.0/` (22 files) | spicy-docs `src/spicy_docs/source_native.py` and siblings, from `70a5b16` 2026-08-29; integrate's copy is the byte-identical ancestor at `ff8d202` | faithful, digest-pinned captures from the Federal Register, regulations.gov, GAO product pages, and CourtListener — GAO capture the original never had |
+| `sources/uscode_uslm.py`, `uscode_olrc.py` | RefSpec `tools/build_usc_source_credits.py` (`5b8f4d8b`), `registry/act_resolution.py` | from an act section to the U.S. Code section it created, with the division that public Table III lacks. Both copies gained the memory bound the same day: spicy-regs `5ecfd5a`, RefSpec `93d244a3` |
+| `ontology/citations.py` | RefSpec `registry/iri_minting.py` (`582461fe`) — seven minters, 1,570 test lines, contract-tested across four compiled forms | every CFR, U.S.C., RIN, Federal Register, and docket identifier resolves to one stable IRI |
+| `ontology/act_index.py` | RefSpec `registry/act_resolution.py`, which names it as its provenance | "section 107 of the X Act" resolves through two OLRC sources |
+| `transforms/build_authority_edges.py` | RefSpec `registry/unified_agenda_parquet.py` | Unified Agenda legal-authority strings become edges a user can traverse |
+| `document_release.py`, `document_release_v3*.py`, `fixtures/releases/` (77 files) | DocSpec DocumentRelease 2.0 — schemas, verifier, 49 sealed fixture cases, three mint receipts (8,284 documents, 220,582 segments) | sealed document releases with bodies and segments, minted and verified |
+| `docpipeline/source.py`, `segments.py` | DocSpec `processing/bounded_segmentation.py`, `retention_floors.py` (2026-08-30) | bounded, retention-checked segmentation. DocSpec addresses UTF-8 bytes where spicy-regs addressed codepoints; ids from the two do not compare equal |
+| `sources/source_domains.py` | `feat/source-domain-drift-gate-revived` `f8e9e35` (PR #192, ready to reopen) | a check that the values in `document_type`, `rule_stage`, `rin_status` still match what GSA and reginfo document — it already found that every `rin_status` row uses a spelling the publisher's schema does not |
+| `enrichment/accepted_output.py`, `managed_release.py` | RefSpec `src/refspec/managed_release.py` (2,638 lines) | candidate lookup against curated, sealed vocabulary releases |
+| `docpipeline/retrieval.py` (5,479 lines) | spicysearch `search_application.py`, `POST /v1/search` — lexical, semantic, and concept lanes in production | search over the corpus, served |
+| `candidate_release.py` | RefSpec managed releases | the same lookup against a format RefSpec maintains, rather than the Atlas 1.0 format retired 2026-08-09 |
+| `source_catalog/` (10 files, 7,239 lines; `archive/landing-final` only) | DocSpec `src/docspec/domain/source_catalog.py`, `schemas/source_catalog/1.0/` — about 1,800 live lines | the catalog of what exists, what was requested, and what was admitted |
 
-### F. `source_catalog/` — drop the code, keep the namespace
+One thing outlives the `source_catalog/` code: DocSpec pins
+`urn:spicy-regs:source-catalog-release:v1:` in 83 files. That prefix is
+DocSpec's contract. spicy-regs never reuses it.
 
-Ten files, 7,239 lines, on `archive/landing-final` only. DocSpec owns it:
-`src/docspec/domain/source_catalog.py`, `schemas/source_catalog/1.0/`, about
-1,800 live lines. The commit that added it (`4e9d192`) says "This is superseded
-work. DocSpec owns SourceCatalog."
+## Preserved on the fork
 
-But DocSpec pins `urn:spicy-regs:source-catalog-release:v1:` in **83 files**
-(`adapters/document_release_verify.py:138`, with a sealed
-`catalog-pin-mismatch` refusal case). That URN prefix is DocSpec's contract
-now. Never reuse it in spicy-regs for anything else.
+These wait for a reader. Each names what would bring it back.
+
+**The open-vocabulary concept lifecycle** — `ontology/concepts.py`,
+`concept_dimensions.py`, `transforms/build_concept{s,_assignments,_events}.py`,
+with `ann_index.py` and `candidate_channels.py` as its serving layer. A SKOS
+registry that grows from the corpus: mint a term from what documents say,
+promote it on multi-source evidence, deprecate it, merge within one facet.
+What a user would get: a vocabulary that tracks what agencies write rather than
+what a curator listed. Why it waits: RefSpec is closed-world by design and
+spicysearch is closed-vocabulary by design, so no product reads a minted term
+today (RefSpec REF-053, 2026-08-31). It returns when one does, and REF-053
+asks that the quota and single-facet merge rules already paid for be weighed
+then.
+
+**The rest of `ontology/`** — `ledger`, `invariants`, `receipt`,
+`relation_findings`, `evaluation`, `common`, `adapters`, `subjects`,
+`segmentation`, `checkpoint`, `llm`, `codex_cli`. Supporting modules for the
+lifecycle above and for experiments now concluded. RefSpec took what it needed
+from `invariants.py` (`2b4960e1`).
+
+**`universes/`** — three JSON files naming the requested regulations.gov
+universes, with 600 lines of the archived `PLAN.md` describing them. DocSpec
+owns the universe now.
+
+**The record** — `docs/superpowers/specs/` (20), `docs/evidence/` (202), 12
+of 14 notebooks. Every decision above has its measurement here.
+
+**`feat/rkaf-boundary-freeze`'s 26 fixture schemas** — an earlier v3 fixture
+layout.
+
+## Order of work
+
+1. Tell Eugene. Six PRs from a collaborator he has not heard from in five days
+   now sit in his repo, one of them this document.
+2. Merge #183 (changes no row of live data), then #181 (stops a full rebuild
+   publishing 1% of the Federal Register as complete), watch one nightly, then
+   #182 (stops a half-finished publish from retiring work it never uploaded).
+3. Reset local `main` to `origin/main`. The archived `main` is
+   `archive/landing-final` on the fork.
+4. PRs to spicy-regs in the order above: join surface, courts, bills, table
+   publisher, document-AI with corpora.
+5. Document populations to spicy-docs through its intake.
+6. The publish gate to RefSpec as a local commit; the minter to whoever holds
+   `iri_minting.py`.
+7. Delete `integrate/payload-prereqs` from civictechdc once step 4 has cut from
+   it. It stays on the fork at `8d9e7a2`.
+8. Remove the worktrees for closed PRs; delete the local branches that are on
+   the fork. What remains: one checkout tracking `origin/main`, a worktree per
+   open PR.
 
 ## Supersedes
 
-Three documents tried to do this before. Each was read against the pinned
-commits above; none survives as an authority.
+Three documents recorded parts of this before, each from its own product's
+side. This one reads across all of them against the pinned commits and adds
+the decisions.
 
-**`docs/migration/spicysearch-product-migration-manifest.json`** (spicy-regs,
-2026-08-29; on `9a79569` and `8d9e7a2`, not on `origin/main`). Two copies exist
-under one `manifest_version`, and they contradict each other on items 1, 6, and
-16 and on `status`. Its own `retirement_authorized` is `false`; the archived
-`PLAN.md` says it "cannot authorize deletion or shutdown by itself." Six of nine
-RefSpec paths it names do not exist. Three destinations it assigns to the
-rulespec Extrapolator were refused by rulespec in writing (C above). Its
-pinning test (`tests/test_document_release.py:615-663`) asserts that sixteen
-strings appear in the file it just read.
+- spicy-regs `docs/migration/spicysearch-product-migration-manifest.json`
+  (2026-08-29, on the archived branches only) inventoried sixteen product
+  surfaces for the SpicySearch migration and marked itself
+  `retirement_authorized: false`, pending a reconciliation. This is that
+  reconciliation.
+- RefSpec `plans/2026-08-31-refspec-intake-ledger.md` planned six ports from
+  this program. All six landed the day it was written (`5b8f4d8b`, `582461fe`,
+  `2b4960e1`). The ledger stands as the record of what was planned; the
+  table above records what shipped.
+- spicysearch `docs/history/2026-09-01-script-product-disposition.md` drew the
+  product boundaries this document uses, and set deletion gates for
+  spicysearch's own body-fetch scripts. Its boundaries hold; its premise that
+  the source-native gate had no survivor predates spicy-docs' `70a5b16` by
+  three days.
 
-**`plans/2026-08-31-refspec-intake-ledger.md`** (RefSpec, last edited
-2026-08-31 17:14, `18bf8a3d`). All six §1 ports landed on 2026-08-31 —
-`5b8f4d8b` 03:52, `582461fe` 04:12, `2b4960e1` 21:38 — four of them before the
-ledger's last edit. It still says none has. §2.2 was ruled the same day
-(REF-053); the ledger still says "until ruled." §5 item 3 books `ann_index` and
-`candidate_channels` as spicysearch's; spicysearch has neither.
-
-**`docs/history/2026-09-01-script-product-disposition.md`** (spicysearch). Its
-five deletion gates govern three spicysearch scripts and release no spicy-regs
-file. Its premise that the source-native gate "has no survivor in any product"
-was false three days before it was written (spicy-docs `70a5b16`). It says the
-landing branch is "not merged"; `dc89c65` is an ancestor of `main`. It is
-silent on nine of the thirteen buckets above.
-
-All three defer to a "platform value ledger" or "platform-value validator" as
-the reconciling authority. `git grep` for those terms at `fc1f5fa` returns no
-files.
-
-RefSpec and spicysearch are not pushed from this checkout. Each of those two
-documents needs a one-line note pointing here, through its own repo's lane.
-
-## Closing the checkout
-
-In order, once B has been cut and D has been handed over:
-
-1. Remove the worktrees for closed PRs: `spicy-regs-pr/feat/uscode-uslm-source-credits`, `spicy-regs-pr/feat/source-domain-drift-gate`. Their branches stay on origin.
-2. Delete the local branches that are on the fork: `archive/*`, `backup/pre-marker-fix`, `feat/rkaf-boundary-freeze`, and `integrate/payload-prereqs` (also on origin).
-3. Reset local `main` to `origin/main`. The archived `main` is `archive/landing-final` on the fork; its README banner declaring this checkout superseded goes with it.
-4. What remains: one checkout tracking `origin/main`, and a worktree per open PR.
+Each of the RefSpec and spicysearch documents takes a one-line note pointing
+here, through its own repo.

--- a/docs/disposition.md
+++ b/docs/disposition.md
@@ -2,11 +2,11 @@
 
 Written 2026-09-04. One record of what the program built, what each piece gives
 a user of the platform, and where each piece now lives. Decisions were taken
-2026-09-04 by the platform owner; this document records them. Two were revised
-the same afternoon and are recorded as revised: the table publisher's home is
-spicy-docs, not spicy-regs, and the document-AI orchestration's home is not yet
-ruled. Three of the spicy-regs pieces have since shipped; the *Order of work*
-section says where.
+2026-09-04 by the platform owner and completed 2026-09-05; this document records
+them. Two were revised after the first draft and are recorded as revised: the
+table publisher's home is spicy-docs, not spicy-regs, and the document-AI
+orchestration's home is spicy-docs (ruled 2026-09-05). Three of the spicy-regs
+pieces have shipped; the *Order of work* section says where.
 
 Every claim below was checked against a pinned commit, not read from a
 document. The pins:
@@ -21,6 +21,9 @@ document. The pins:
 | spicy-docs | `main` | `9f8c7ee` |
 | RefSpec | `main` | `da4fe055` |
 | rulespec | `main` | `a87d839` |
+| spicy-docs | `main`, for the 2026-09-05 pricing | `86e8416` |
+| rulespec | `main`, for the 2026-09-05 pricing | `a519d06` |
+| RefSpec | `main`, for the 2026-09-05 pricing | `00f22e9c` |
 
 ## What the program was
 
@@ -171,27 +174,53 @@ they must trust.
 
 Rulespec's own spec (`spec/rulespec-releases.md` §7, 2026-08-04) recorded
 these duties as parked with no owner and assigned the decision to the platform
-owner. Decided 2026-09-04, then refined the same afternoon into a split, from
-an AST map of `rkaf_projection.py`:
+owner. Decided 2026-09-04 as a split; ruled complete 2026-09-05. The split below is
+from the call graph of `rkaf_projection.py` at `8d9e7a2`, which corrects the
+first draft's count: `project_document` was listed as deterministic, but it
+calls the model layer, so it belongs to the orchestration.
 
-- **The deterministic layer, about 2,400 lines** — `assemble` (476),
-  `verify_candidate_rows` (191), `_federal_register_facts` (204),
-  `_unified_agenda_facts` (91), `verify_fragment`, `project_document`,
-  `load_artifact` — depends only on artifact identity, citation grammar,
-  attestations, and offset verification. It becomes
-  `rulespec/packages/rulespec-projection`: the format owner ships the reference
-  producer beside its verifier and fifteen conformance bundles. Its inputs turn
-  into a data contract — artifact identity from DocSpec's DocumentRelease 2.0,
-  IRIs from RefSpec's `iri_minting`, and the 286-line vocabulary loader's
-  `from refspec import` (line 2334, a cross-product import) becomes an ordinary
-  package dependency.
-- **The orchestration, 355 lines** — `_run_model_layer_with_vocabulary` is the
-  one function that calls the model, plus the six provider adapters,
-  `extraction`, `runtime`, `tag_task`, and `corpora/`. Its home is **not yet
-  ruled**. spicy-regs is the default; DocSpec is the alternative if
-  "interpretation lives in DocSpec" is meant strictly, because this layer emits
-  RKAF documents, not tables. Two lanes asked for an explicit ruling rather than
-  a default. Nothing is cut until it comes.
+- **The deterministic layer** — 21 functions, 1,307 lines of
+  `rkaf_projection.py`, plus its 13 data classes (221 lines): `assemble`
+  (476), `verify_candidate_rows` (191), `_federal_register_facts` (204),
+  `_unified_agenda_facts` (91), `verify_fragment`, `load_artifact`, and the
+  IRI and fragment helpers under them. It becomes
+  `rulespec/packages/rulespec-projection`, beside `rulespec-artifacts`, the
+  only package there today: the format owner ships the reference producer next
+  to its verifier and fifteen conformance bundles. Priced against rulespec's
+  closure (`rulespec-artifacts`, `pyshacl`, `rdflib`, `rdfcanon`): the layer's
+  own functions import nothing outside the standard library. What they reach
+  through spicy-regs modules: `ontology.citations` (1,025 lines, standard
+  library only), `ontology.attestations` (544, same), four helpers from
+  `ontology.common` (`canonical_json`, `stable_id`, `text_digest`,
+  `RunContext`; that module imports pyarrow and loguru at the top, so the four
+  are copied, or replaced by `rulespec_artifacts.canonical_json_bytes` and
+  `sha256_digest`, and the module is not), and `resolve_exact_evidence_offsets`
+  from `ontology.llm` (35 lines, no imports). `SourceArtifact` from
+  `docpipeline/source.py` becomes the input contract, filled from DocSpec's
+  DocumentRelease 2.0; IRIs come from RefSpec's `iri_minting`. Zero new
+  dependencies.
+- **The orchestration** — the 13 functions only the model path uses, 1,150
+  lines of `rkaf_projection.py` (`_run_model_layer_with_vocabulary` 355, the
+  two vocabulary loaders 552, `project_document` 71), plus the six provider
+  adapters (6,932 lines), `extraction` (954), `runtime` (1,792), `tag_task`
+  (961), `relation_task` (2,102), `executor` (536), and `corpora/` (16
+  modules, 23,798 lines). Its home is **spicy-docs**, ruled 2026-09-05: it
+  sits beside the source-native releases it reads and the table publisher it
+  feeds, so one install runs the whole path. It depends on
+  `rulespec-projection` for the 13 functions both layers share (878 lines).
+  Priced against spicy-docs at `86e8416` (`rulespec-artifacts`, `boto3`,
+  `httpx`, `jsonschema`, `loguru`, `polars`, `tqdm`; `pyarrow` as the
+  `public-table` extra). Present: `jsonschema`, `loguru`, `pyarrow`. Absent at
+  runtime: `anthropic`, `openai`, `tiktoken` (the model adapters);
+  `sentence_transformers` and `torch` (the embedding adapter); `docling` (the
+  layout adapter, imported lazily); `refspec` (the vocabulary loader);
+  `rdflib` (through `candidate_release`); `numpy` and `scikit-learn` (through
+  `ontology.concepts`, lazily). Each adapter's dependency belongs in an extra
+  named for it, the way `public-table` carries pyarrow. `corpora/` adds
+  `transformers`, `scipy`, `ir_measures`, `pypdf`, `python-dotenv`, `duckdb`:
+  an `experiments` extra. Test-only and absent: `docling_core`, `python-docx`,
+  `openpyxl`, `python-pptx` (the real-Docling test); `refspec` and `duckdb`
+  (the projection test).
 
 ## Ships to spicy-docs
 
@@ -361,30 +390,31 @@ layout.
    `1918409` #181 (639 passed) → `1374f90` #182 (645) → `64aa35d` #183 (657)
    → `abd229f` #193 (657) → `a3dc1b6` #194 (941) → `4b041c0` #195 (979)
    → `765815a` #196 (1,005 passed, 3 deselected; baseline 634).
-   `fork/main` = local `main` = `765815a`; `origin/main` untouched at `1f02a7f`.
+   After the seven merges `fork/main` = local `main` = `765815a`; this
+   document's revisions were merged on top. `origin/main` untouched at `1f02a7f`.
 3. **Done.** Local `main` was reset to `origin/main` before the merges; the
    archived `main` is `archive/landing-final` on the fork at `9a79569`.
 4. PRs to spicy-regs: join surface (#194), CourtListener (#195), bill subjects
    (#196) — **done**, each validated against live data before opening. The
    Supreme Court sub-cluster waits on the `bs4` decision. The document-AI
-   producer waits on the orchestration ruling above.
+   producer is split, priced, and ruled above; the brief went to the spicy-docs
+   and rulespec lanes 2026-09-05.
 5. The table publisher to spicy-docs through its intake (ruled afternoon
    2026-09-04; see *Ships to spicy-docs*). Document populations likewise.
 6. The publish gate to RefSpec as a local commit; the minter to whoever holds
    `iri_minting.py`.
-7. Delete the `integrate/payload-prereqs` branch from civictechdc once
-   spicy-docs has landed its copy of the publisher. A branch delete on another
-   owner's remote, reversible from the fork at `8d9e7a2`; the platform owner's
-   call. A file-deletion PR is not the shape: `origin/main` has none of the
-   files.
+7. **Done 2026-09-05.** `integrate/payload-prereqs` deleted from civictechdc
+   after spicy-docs landed the publisher at `2bb1dcf`; the fork holds it at
+   `8d9e7a2`. A file-deletion PR was not the shape: `origin/main` has none of
+   the files.
 8. Register the eight new tables — five from #194, two from #195, one from
    #196 — in the data dictionary and MCP server as one follow-up PR, the way
    #175 exposed the lifecycle rollups after they existed. The first
    `materialize-rulemaking` run needs `--allow-bootstrap` via
    `workflow_dispatch`.
-9. Remove the worktrees for merged and closed PRs; delete the local branches
-   that are on the fork. What remains: one checkout tracking `origin/main`, a
-   worktree per open PR.
+9. **Done 2026-09-05.** The nine worktrees for merged and closed PRs are
+   removed. What remains: one checkout on `main` with the merges on top of
+   `origin/main`, and a local branch per open PR, each at its PR head.
 
 ## Supersedes
 

--- a/docs/disposition.md
+++ b/docs/disposition.md
@@ -227,11 +227,14 @@ every count below by AST on 2026-09-05 and added the seams recorded here.
   five of its modules, and spicy-docs' `tests/test_reader_closure.py` at
   `86e8416` fails if `polars`, `httpx`, `boto3`, `botocore`, `loguru`, or
   `tqdm` sit in `sys.modules` after importing `source_native` and
-  `source_native_profiles`. That guard is the enforcement for this port. It
+  `source_native_profiles`. That guard is the enforcement for this port; it
   gains the seven model names (`anthropic`, `openai`, `sentence_transformers`,
-  `torch`, `docling`, `tiktoken`, `transformers`), and since DocSpec imports
-  five modules on that path and all five are clean today, it should name all
-  five. Import direction, after spicysearch's `AGENTS.md` table
+  `torch`, `docling`, `tiktoken`, `transformers`) in its one tuple. It named
+  two of the five modules DocSpec imports; spicy-docs `160dbe9` (local `main`,
+  2026-09-05) probes all five, together and each alone, because a batch probe
+  cannot tell a clean module from one shadowed by a sibling that imported
+  first. All five were already clean. An orchestration guard, if the port adds
+  one, mirrors the per-module probe. Import direction, after spicysearch's `AGENTS.md` table
   (`f97b904:100`):
 
   | From | Read/verify | Acquisition/publish | Orchestration | Experiments |
@@ -280,13 +283,23 @@ every count below by AST on 2026-09-05 and added the seams recorded here.
 
 - **`corpora/`** — 16 modules, 23,798 lines of experiment scripts, over half
   the producer by volume. Experiments may import everything and nothing imports
-  them, so they sequence last and defer at no cost. All 15 scripts were last
-  touched 2026-08-28; 13 of them are registered as 13 console-script
-  entries at `8d9e7a2`, and `mirrulations_document_corpus` is neither
-  registered nor cited by the evidence. They move per module, when the evidence
-  that cites one needs re-running, under an `experiments` extra
-  (`transformers`, `scipy`, `ir_measures`, `pypdf`, `python-dotenv`,
-  `duckdb`). None moves in the same change as the adapters.
+  them, so they sequence last and defer at no cost. Registration and
+  last-touched dates say someone declared them, not that anyone runs them:
+  all 15 were last touched 2026-08-28 and 13 are console scripts at `8d9e7a2`.
+  The basis that decides it is whether an in-tree evidence or receipt file
+  cites the script. Six do (`segmentation_experiment` four times;
+  `document_acceptance_scope`, `embedding_audit`,
+  `segmentation_embedding_audit`, `segmentation_rerank`,
+  `segmentation_tagging` once each; same nine files on `9a79569`). Nine are
+  cited by none: `artifact_retrieval_baseline`, `body_retrieval_corpus`,
+  `mirrulations_document_corpus`, `mixed_real_data`, `profile_evaluation`,
+  both `relation_exclusion_evaluation` scripts, `segmentation_evaluation`,
+  `segmentation_sparse_retrieval`. Runs whose outputs never entered the tree
+  are invisible to this count. The six move per module, when the evidence that
+  cites one needs re-running, under an `experiments` extra (`transformers`,
+  `scipy`, `ir_measures`, `pypdf`, `python-dotenv`, `duckdb`); the nine stay
+  on the fork unless someone names a run. None moves in the same change as
+  the adapters.
 
 ## Ships to spicy-docs
 

--- a/docs/disposition.md
+++ b/docs/disposition.md
@@ -218,7 +218,12 @@ goes through spicy-docs' own intake, commit-never-push.
 `public_table.py` (1,000 lines), `public_table_profiles.py` (165),
 `publication.py` (65), and `tests/test_public_table.py`. Ruled 2026-09-04
 afternoon: **canonical home spicy-docs**, superseding the morning's assignment
-to spicy-regs.
+to spicy-regs. **Landed on spicy-docs `main` at `2bb1dcf`** the same evening:
+`publication.py` was not copied because an identical module already existed
+there; `SUPPORTED_PRODUCER_PRODUCTS` was reused rather than re-hardcoded;
+`pyarrow` — a runtime import of the module, which spicy-docs did not carry and
+this record's first version did not name — was added as an optional extra plus
+a dev entry; the eight-ref provenance is in the commit.
 
 **What a user gets.** Everything a user touches — the Parquet files at
 `data.spicy-regs.dev`, the MCP server, the app — is a table something built.
@@ -248,7 +253,11 @@ exist on no live line — zero on `origin/main`, zero on `fork/main`, zero on
 `snapshots/pre-strip-2026-08-26`, and the fork's copies of those. spicy-docs
 copies from `8d9e7a2` and becomes the only implementation. **No spicy-regs
 branch re-cuts these modules.** There is nothing to delete and nothing to
-freeze on a live line; the archived branches are the record, not a rival.
+freeze on a live line; the archived branches are the record, not a rival. The
+lesson the landing taught: a port brief must list every *runtime* third-party
+import per module against the target's actual dependency closure, not only
+the test's — the first version of this record named `duckdb` and missed
+`pyarrow`, and the module would not import until it was added.
 
 One thing for spicy-docs' supply-precedence rule, recorded where the rule
 lives: once spicy-docs both produces the public tables and captures them as its

--- a/docs/disposition.md
+++ b/docs/disposition.md
@@ -2,7 +2,11 @@
 
 Written 2026-09-04. One record of what the program built, what each piece gives
 a user of the platform, and where each piece now lives. Decisions were taken
-2026-09-04 by the platform owner; this document records them.
+2026-09-04 by the platform owner; this document records them. Two were revised
+the same afternoon and are recorded as revised: the table publisher's home is
+spicy-docs, not spicy-regs, and the document-AI orchestration's home is not yet
+ruled. Three of the spicy-regs pieces have since shipped; the *Order of work*
+section says where.
 
 Every claim below was checked against a pinned commit, not read from a
 document. The pins:
@@ -59,8 +63,10 @@ four earlier snapshots whose tip trees are copies of one or the other:
 `bc8f534`, `feat/rkaf-boundary-freeze` `a8938b4`. Everything has a remote.
 
 Fifteen `src/` files exist on both branches with different content. Two matter:
-`sources/supreme_court_opinions.py` and `transforms/build_supreme_court_opinions.py`,
-when the courts PR is cut. The rest belong to pieces that ship from one branch
+`sources/supreme_court_opinions.py` and `transforms/build_supreme_court_opinions.py`.
+The `8d9e7a2` versions are the fuller ones — `9a79569` stripped the measured
+403 rate-limit guard and the bound-volume page-range logic — so `8d9e7a2` is
+the branch to cut from. The rest belong to pieces that ship from one branch
 only.
 
 Neither branch has PRs #181, #182, or #183. Both carry the earlier
@@ -73,7 +79,8 @@ corrected versions are on their own branches, and the PRs below cut from
 Each of these becomes one PR cut from `integrate/payload-prereqs` (or
 `archive/landing-final` where noted) onto `origin/main`, with the same
 treatment as #181: rebase, gate through `uv run`, validate against real data,
-one-paragraph description. In this order.
+one-paragraph description. Items 1–3 shipped on 2026-09-04 as PRs #194, #195,
+#196 — open on civictechdc, merged on the fork; see *Order of work*.
 
 ### 1. The rulemaking join surface
 
@@ -95,12 +102,19 @@ This is the product the platform was built to be.
 
 ### 2. Courts
 
-`sources/courtlistener_bulk.py`, `transforms/build_court_opinion_bodies.py`
-(356 lines), `build_court_opinion_clusters.py` (410), `court_scope.py` (348),
-`pipelines/court_opinion_{bodies,clusters}.py`, `sources/supreme_court_opinions.py`,
-`transforms/build_supreme_court_opinions.py`, `pipelines/supreme_court_opinions.py`,
-`transforms/pdf_text_pymupdf.py` (171). Ten files, about 2,000 lines, on
-`integrate`. A real run exists: `output/court-data-2026-08-22/`, 5.7 GB.
+Two sub-clusters, on `integrate`. **CourtListener** — `sources/courtlistener_bulk.py`,
+`transforms/build_court_opinion_bodies.py` (356 lines),
+`build_court_opinion_clusters.py` (410), `court_scope.py` (348),
+`pipelines/rollups/court_opinion_{bodies,clusters}.py`,
+`scripts/backfill_cluster_court_scope.py`, plus 84 additive lines in
+`sources/courtlistener.py`. Shipped as PR #195. **Supreme Court** —
+`sources/supreme_court_opinions.py`, `transforms/build_supreme_court_opinions.py`,
+`pipelines/rollups/supreme_court_opinions.py` — held back: its source imports
+`bs4`, which `origin/main` does not carry and no other source uses, so that
+dependency is a separate PR and a separate decision. `transforms/pdf_text_pymupdf.py`
+is not courts at all: it is imported by `docpipeline/source.py`, and it is
+AGPL; it goes with the document-AI producer, where the licence choice is made
+explicitly. A real run exists: `output/court-data-2026-08-22/`, 5.7 GB.
 
 **What a user gets.** Court opinions cite statutes, not CFR parts, so a user
 asking "which cases touch this rule" gets nothing today. These pipelines bring
@@ -127,21 +141,7 @@ statute citation.
 
 Ships whole, same reasoning as courts.
 
-### 4. The table publisher
-
-`public_table.py`, `public_table_profiles.py`, `publication.py`. 1,230 lines
-on `integrate`.
-
-**What a user gets.** Everything a user touches — the Parquet files at
-`data.spicy-regs.dev`, the MCP server, the app — is a table something built.
-Today that something is 21 hand-written scrapers. This is the path that builds
-the same tables from verified, digest-pinned source-native releases instead: an
-admitted release goes in, faithful Parquet/DuckDB/Iceberg views come out, and
-the provenance of every row is the release it came from. spicy-docs' supply
-rule already treats these tables as its first rung of acquisition and captures
-them; this is what makes them.
-
-### 5. The document-AI producer
+### 4. The document-AI producer
 
 `docpipeline/rkaf_projection.py` (3,124 lines), `docpipeline/{extraction,runtime,tag_task,relation_task,executor}.py`,
 `docpipeline/adapters/` (Anthropic, OpenAI, OpenAI-compatible, Codex CLI,
@@ -171,9 +171,27 @@ they must trust.
 
 Rulespec's own spec (`spec/rulespec-releases.md` §7, 2026-08-04) recorded
 these duties as parked with no owner and assigned the decision to the platform
-owner. Decided 2026-09-04: spicy-regs owns them. One line changes on the way
-in — `rkaf_projection.py:2334` imports `refspec` directly; it takes a vendored
-wheel instead, the pattern spicysearch uses.
+owner. Decided 2026-09-04, then refined the same afternoon into a split, from
+an AST map of `rkaf_projection.py`:
+
+- **The deterministic layer, about 2,400 lines** — `assemble` (476),
+  `verify_candidate_rows` (191), `_federal_register_facts` (204),
+  `_unified_agenda_facts` (91), `verify_fragment`, `project_document`,
+  `load_artifact` — depends only on artifact identity, citation grammar,
+  attestations, and offset verification. It becomes
+  `rulespec/packages/rulespec-projection`: the format owner ships the reference
+  producer beside its verifier and fifteen conformance bundles. Its inputs turn
+  into a data contract — artifact identity from DocSpec's DocumentRelease 2.0,
+  IRIs from RefSpec's `iri_minting`, and the 286-line vocabulary loader's
+  `from refspec import` (line 2334, a cross-product import) becomes an ordinary
+  package dependency.
+- **The orchestration, 355 lines** — `_run_model_layer_with_vocabulary` is the
+  one function that calls the model, plus the six provider adapters,
+  `extraction`, `runtime`, `tag_task`, and `corpora/`. Its home is **not yet
+  ruled**. spicy-regs is the default; DocSpec is the alternative if
+  "interpretation lives in DocSpec" is meant strictly, because this layer emits
+  RKAF documents, not tables. Two lanes asked for an explicit ruling rather than
+  a default. Nothing is cut until it comes.
 
 ## Ships to spicy-docs
 
@@ -194,6 +212,51 @@ spicy-docs is the acquisition product — "spicy-docs gets; it does not
 interpret" — and already carries `source_domains.py`, the documented-vs-observed
 drift gate. Populations are the same kind of thing: acquisition metadata. It
 goes through spicy-docs' own intake, commit-never-push.
+
+### The table publisher
+
+`public_table.py` (1,000 lines), `public_table_profiles.py` (165),
+`publication.py` (65), and `tests/test_public_table.py`. Ruled 2026-09-04
+afternoon: **canonical home spicy-docs**, superseding the morning's assignment
+to spicy-regs.
+
+**What a user gets.** Everything a user touches — the Parquet files at
+`data.spicy-regs.dev`, the MCP server, the app — is a table something built.
+Today that something is 21 hand-written scrapers. This is the path that builds
+the same tables from verified, digest-pinned source-native releases instead: an
+admitted release goes in, faithful Parquet/DuckDB/Iceberg views come out, and
+the provenance of every row is the release it came from. Its own docstring
+draws the line — "Rulespec owns the artifact root, member manifests, digests,
+and admission; [the product] owns only the faithful flat source view" — and a
+faithful flat view is no interpretation.
+
+**Why spicy-docs.** `public_table_profiles.py` imports thirteen names from the
+source-native readers spicy-docs owns, and every one resolves at spicy-docs
+`9f8c7ee`; the publisher and `publication.py` import nineteen names from
+`rulespec_artifacts`, every one present in 1.0.11; the six release schemas are
+byte-identical between `8d9e7a2` and spicy-docs, so it reads what spicy-docs
+emits today. Its CLI entry, `spicy-regs-source-native`, is already spicy-docs'
+`source_native_cli.py`. `duckdb` is test-only — zero imports in the three
+modules, one in the test, proving the "DuckDB reads the declared members
+directly" claim; it stays a test dependency and the claim stays proven.
+
+**Provenance and the rule that keeps one implementation.** The four files
+exist on no live line — zero on `origin/main`, zero on `fork/main`, zero on
+`archive/landing-final`. They exist on eight refs, all history:
+`integrate/payload-prereqs` @ `8d9e7a2` on both civictechdc and the fork,
+`archive/integrate-payload-prereqs-pre-reorg`, `archive/pre-strip-2026-08-26`,
+`snapshots/pre-strip-2026-08-26`, and the fork's copies of those. spicy-docs
+copies from `8d9e7a2` and becomes the only implementation. **No spicy-regs
+branch re-cuts these modules.** There is nothing to delete and nothing to
+freeze on a live line; the archived branches are the record, not a rival.
+
+One thing for spicy-docs' supply-precedence rule, recorded where the rule
+lives: once spicy-docs both produces the public tables and captures them as its
+first rung, "capture the pinned upstream artifact" and "capture our own output"
+are the same operation for this one source. Benign — it is how every source is
+treated — but a rule that appears to defer to an upstream authority must say
+that here the upstream is itself, or it reads as corroboration when it is a
+self-reference.
 
 ## Ships to RefSpec
 
@@ -280,23 +343,39 @@ layout.
 
 ## Order of work
 
-1. Tell Eugene. Six PRs from a collaborator he has not heard from in five days
-   now sit in his repo, one of them this document.
-2. Merge #183 (changes no row of live data), then #181 (stops a full rebuild
-   publishing 1% of the Federal Register as complete), watch one nightly, then
-   #182 (stops a half-finished publish from retiring work it never uploaded).
-3. Reset local `main` to `origin/main`. The archived `main` is
-   `archive/landing-final` on the fork.
-4. PRs to spicy-regs in the order above: join surface, courts, bills, table
-   publisher, document-AI with corpora.
-5. Document populations to spicy-docs through its intake.
+1. Tell Eugene. Seven PRs from a collaborator he has not heard from in five
+   days now sit in his repo, one of them this document.
+2. **Done 2026-09-04, on the fork and the local checkout only.** By the
+   platform owner's ruling the seven PRs stay open on civictechdc and were
+   merged onto `fork/main` and local `main` as merge commits, each gated
+   through `uv run` before the next:
+   `1918409` #181 (639 passed) → `1374f90` #182 (645) → `64aa35d` #183 (657)
+   → `abd229f` #193 (657) → `a3dc1b6` #194 (941) → `4b041c0` #195 (979)
+   → `765815a` #196 (1,005 passed, 3 deselected; baseline 634).
+   `fork/main` = local `main` = `765815a`; `origin/main` untouched at `1f02a7f`.
+3. **Done.** Local `main` was reset to `origin/main` before the merges; the
+   archived `main` is `archive/landing-final` on the fork at `9a79569`.
+4. PRs to spicy-regs: join surface (#194), CourtListener (#195), bill subjects
+   (#196) — **done**, each validated against live data before opening. The
+   Supreme Court sub-cluster waits on the `bs4` decision. The document-AI
+   producer waits on the orchestration ruling above.
+5. The table publisher to spicy-docs through its intake (ruled afternoon
+   2026-09-04; see *Ships to spicy-docs*). Document populations likewise.
 6. The publish gate to RefSpec as a local commit; the minter to whoever holds
    `iri_minting.py`.
-7. Delete `integrate/payload-prereqs` from civictechdc once step 4 has cut from
-   it. It stays on the fork at `8d9e7a2`.
-8. Remove the worktrees for closed PRs; delete the local branches that are on
-   the fork. What remains: one checkout tracking `origin/main`, a worktree per
-   open PR.
+7. Delete the `integrate/payload-prereqs` branch from civictechdc once
+   spicy-docs has landed its copy of the publisher. A branch delete on another
+   owner's remote, reversible from the fork at `8d9e7a2`; the platform owner's
+   call. A file-deletion PR is not the shape: `origin/main` has none of the
+   files.
+8. Register the eight new tables — five from #194, two from #195, one from
+   #196 — in the data dictionary and MCP server as one follow-up PR, the way
+   #175 exposed the lifecycle rollups after they existed. The first
+   `materialize-rulemaking` run needs `--allow-bootstrap` via
+   `workflow_dispatch`.
+9. Remove the worktrees for merged and closed PRs; delete the local branches
+   that are on the fork. What remains: one checkout tracking `origin/main`, a
+   worktree per open PR.
 
 ## Supersedes
 

--- a/docs/disposition.md
+++ b/docs/disposition.md
@@ -1,0 +1,182 @@
+# Disposition of the archived spicy-regs work
+
+Written 2026-09-04. One record of where every piece of the July–August 2026
+research program now lives, what replaced it, and what still needs a home. It
+replaces three earlier documents that disagreed with each other and with the
+code; see *Supersedes*.
+
+Every claim below was checked against a pinned commit, not read from a
+document. The pins:
+
+| repo | ref | commit |
+|---|---|---|
+| spicy-regs | `origin/main` (live upstream) | `1f02a7f` |
+| spicy-regs | `archive/landing-final` (was local `main`) | `9a79569` |
+| spicy-regs | `integrate/payload-prereqs` | `8d9e7a2` |
+| spicysearch | `main` | `fc1f5fa` |
+| DocSpec | `main` | `0bb2add` |
+| spicy-docs | `main` | `9f8c7ee` |
+| RefSpec | `main` | `da4fe055` |
+| rulespec | `main` | `a87d839` |
+
+## Where the work is
+
+Two branches carry all the content. They forked from `origin/main` at
+`01ecbef` (2026-08-19) and were cut one day apart from the same program.
+Neither removes anything from upstream; the nine files they "lack" are what
+upstream added after the fork (`org_committee_links`, `seed_dockets_catalog`,
+`check_purge_credential`).
+
+| branch | commit | date | vs `origin/main` | holds |
+|---|---|---|---|---|
+| `archive/landing-final` | `9a79569` | 2026-08-29 | +609 files | the shared core plus `source_catalog/`, `universes/` |
+| `integrate/payload-prereqs` | `8d9e7a2` | 2026-08-28 | +649 files | the shared core plus source-native, courts, bills, `public_table` |
+
+Both are on `github.com/mikewolfd/spicy-regs` (a fork; remote `fork`), with
+four older snapshots whose tip trees are copies of one or the other:
+`archive/landing-main-pre-reorg` `31a4bfe`, `archive/integrate-payload-prereqs-pre-reorg`
+`a6ab98a`, `archive/pre-strip-2026-08-26` `57d46bf`, `backup/pre-marker-fix`
+`bc8f534`, `feat/rkaf-boundary-freeze` `a8938b4`. Nothing is single-disk.
+
+Fifteen `src/` files exist on both branches with different content. Only two
+matter after the dispositions below — `sources/supreme_court_opinions.py` and
+`transforms/build_supreme_court_opinions.py` — and only when the courts PR is
+cut. The rest belong to buckets that drop.
+
+Neither branch has PRs #181, #182, or #183. Both carry the pre-fix
+`uscode_uslm.py` (no memory bound) and `integrate` carries the pre-fix
+`source_domains.py` (fabricated publisher URL). Landing `integrate` wholesale
+would reintroduce both.
+
+## Dispositions
+
+**Drop** means: the code stays on the fork, nothing is ported, and the check
+in the last column is the reason. **PR** means cut a branch from
+`integrate/payload-prereqs` onto `origin/main` and treat it like #181 — rebase,
+gate through `uv run`, validate against real data, one-paragraph description.
+**Port** means the work belongs in another repo and goes through that repo's
+own intake.
+
+### A. Already re-homed — drop
+
+| bucket | branch | files | replaced by | check |
+|---|---|---|---|---|
+| `source_native*.py`, `schemas/source_native_release/1.0/` | integrate | 22 | spicy-docs `src/spicy_docs/source_native.py` and siblings, shipped `70a5b16` 2026-08-29 | integrate's copy is byte-identical to `ff8d202`, the extraction point; zero commits touched it since |
+| `sources/uscode_uslm.py`, `uscode_olrc.py` | both | 2 | RefSpec `tools/build_usc_source_credits.py` (`5b8f4d8b`), `registry/act_resolution.py` | both copies got the `element.clear()` memory bound independently: spicy-regs `5ecfd5a`, RefSpec `93d244a3` |
+| `ontology/citations.py` | both | 1 | RefSpec `registry/iri_minting.py` (`582461fe`) — seven minters, 1,570 test lines | one minter did not travel; see D |
+| `ontology/act_index.py` | both | 1 | RefSpec `registry/act_resolution.py`, which names it as provenance | — |
+| `transforms/build_authority_edges.py` | both | 1 | RefSpec `registry/unified_agenda_parquet.py` | — |
+| `document_release.py` (M1) | both | 1 | DocSpec `tests/fixtures/document_release_v2{,_docspec}/` (`bdab0b8`, 2026-08-30) — 49 sealed cases, FR-2026-03227 included | — |
+| `document_release_v3*.py` (6) and `fixtures/releases/` (56) | both | 77 | DocSpec DocumentRelease 2.0: `src/docspec/schemas/document_release/2.0/`, `adapters/document_release_verify.py`, ADR `docs/decisions/0001-document-release-2-0.md`, three mint receipts | the two directories are one bucket; earlier counts listed them twice |
+| `docpipeline/source.py`, `segments.py` | both | 2 | DocSpec `processing/bounded_segmentation.py`, `retention_floors.py` (`be3c865`, `9bcc9ba`, 2026-08-30) | DocSpec addresses UTF-8 bytes; spicy-regs addressed codepoints. Region ids do not compare equal across the two. |
+| `sources/source_domains.py` | integrate | 1 | archived on `feat/source-domain-drift-gate-revived` `f8e9e35` (PR #192, closed) | the archived copy has the corrected publisher URL; integrate's does not |
+| `enrichment/accepted_output.py` | landing-final | 1 | nothing | imports `refspec.accepted_output`, which RefSpec no longer provides (`9a79569` commit message says so) |
+| `enrichment/managed_release.py` | landing-final | 1 | RefSpec `src/refspec/managed_release.py` (2,638 lines) — this was a consumer wrapper over it | — |
+
+### B. Unowned — PR to spicy-regs
+
+Absent from DocSpec, spicysearch, and spicy-docs at the pinned commits. Each
+was grepped in all three.
+
+| bucket | files | lines | why it matters | what downstream has instead |
+|---|---|---|---|---|
+| `sources/document_populations.py`, `sample-data/document-populations/` | 2 + 7 captures | 468 | the coverage denominator. Its docstring: "you cannot state what a run missed without a publisher-issued enumeration to miss it against." Digest-pinned captures of CBO, FCC ECFS, GovInfo PREMIS; refuses a bot-challenge body rather than yield an empty population. **No consumer anywhere.** | nothing |
+| `public_table.py`, `public_table_profiles.py`, `publication.py` | 3 | 1,230 | the Parquet/DuckDB/Iceberg **producer**. The 2026-08-27 sweep ruled the public-view path "not safe to abandon." | spicy-docs has a **consumer** (`spicy_regs_public_tables_source_native.py`) whose supply-precedence ruling assumes these tables keep existing. No producer. |
+| courts: `sources/courtlistener_bulk.py`, `transforms/build_court_opinion_{bodies,clusters}.py`, `court_scope.py`, `pipelines/court_opinion_{bodies,clusters}.py`, `sources/supreme_court_opinions.py`, `transforms/build_supreme_court_opinions.py`, `pipelines/supreme_court_opinions.py`, `transforms/pdf_text_pymupdf.py` | 10 | ~2,000 | rollup pipelines that emit parquet. A real run exists: `output/court-data-2026-08-22/`, 5.7 GB. | spicysearch consumes pinned court parquet and tags it (`derived_topic_passes/postings.py`); no fetcher, no PyMuPDF dependency. spicy-docs took `courtlistener_bulk.py` as a reader (`9c75f0b`) and built nothing on it. DocSpec: zero hits. |
+| `sources/bill_subjects.py`, `transforms/enrich_bill_subjects.py`, `pipelines/bill_subjects.py` | 3 | 722 | wired with a cron entry point and workflow | nothing |
+
+When cutting the courts PR, diff `sources/supreme_court_opinions.py` and
+`transforms/build_supreme_court_opinions.py` between `8d9e7a2` and `9a79569`
+first; they differ.
+
+### C. Refused on the record — drop
+
+| bucket | files | lines | who refused, where |
+|---|---|---|---|
+| `docpipeline/{extraction,runtime,tag_task,relation_task,executor}.py`, `docpipeline/adapters/` (Anthropic, OpenAI, OpenAI-compatible, Codex CLI, Docling, sentence-transformers) | 11 | — | rulespec `spec/rulespec-releases.md:340-361` §7 parks approval, selection, and baseline-validation execution with no owner and rejects the inference that the Extrapolator inherits them. `docs/decisions.md:170-175` (ADR 2026-08-02): "no producer of an `ExtrapolationRelease` outside the fixture path … do not implement." |
+| `docpipeline/retrieval.py` | 1 | 5,479 | spicysearch reimplemented it as three lanes plus one optional (`src/spicysearch/search_application.py`, `POST /v1/search`). The interface the manifest named, `search_documents` / `SearchResultSet`, has zero hits in spicysearch source. |
+| `ontology/concepts.py`, `concept_dimensions.py`, `transforms/build_concept{s,_assignments,_events}.py` | 5 | — | RefSpec REF-053 (2026-08-31): "Open-vocabulary concept lifecycle stays unported — no owner, no consumer, no check." |
+| `candidate_release.py` | 1 | — | reads `ATLAS_FORMAT = "refspec-vocabulary-atlas-nquads-1.0"` (line 24). RefSpec retired Atlas 1.0 and 2.0 at `5c6d889a`, 2026-08-09. No producer of that format exists. |
+| `docpipeline/rkaf_projection.py` | 1 | 3,124 | rulespec's refusal above. Also: `from refspec import` at line 2334 violates spicysearch `docs/decisions/0001-four-product-boundary.md:56-57`; its `RulespecCoreRelease` pin `urn:rulespec:core:5ac6ba59…` was re-keyed by rulespec `8bce779` on 2026-08-11. The largest single module in this group. |
+| `feat/rkaf-boundary-freeze` fixture schemas | 26 | — | a superseded v3 fixture layout; nothing references them by name; `9a79569`'s 645 tests pass without them |
+
+### D. Genuine gaps — port
+
+| bucket | lines | to | why |
+|---|---|---|---|
+| `ontology/rulespec_release.py` | 178 | RefSpec | an executable publish gate that recomputes the L0 contract digest from the tagged rulespec archive and refuses on mismatch. RefSpec's pin is verified only against its own `RULESPEC_DEPENDENCY_SHA256`; `profiles/rulespec-dependency.json` says `releaseAvailability: localUnpublished`; `vendor/README.md` calls rc18 a provisional pin from an unmerged branch. |
+| `canonical_usc_chapter_iri` and its lowercase-suffix rule (`citations.py:404-418`) | ~15 | RefSpec `iri_minting.py` | the one URN producer of eight that the port left behind |
+| `ontology/attestations.py` | — | RefSpec, when REF-058 reopens | RefSpec considered and deferred `rkaf:Attestation` alignment. Hold on the fork until then. |
+
+### E. No owner, no refusal — decision pending
+
+Nothing downstream took these and nothing on the record rules them out. The
+call is between dropping them with the evidence preserved on the fork, or
+holding them as gaps to fill.
+
+| bucket | files | note |
+|---|---|---|
+| `ontology/ann_index.py`, `candidate_channels.py` | 2 | RefSpec's ledger books them as spicysearch's. spicysearch has zero hits for usearch, hnsw, faiss, annoy, or `candidate_channels`. The older manifest's "inventoried-not-moved" was right. |
+| `corpora/` | 16 | six console scripts point into it. No document addresses it. |
+| `ontology/{ledger,invariants,receipt,relation_findings,evaluation,common,adapters,subjects,segmentation,checkpoint,llm,codex_cli}.py` | 12 | RefSpec ported one of five functions from `invariants.py` (`2b4960e1`). `ledger.py` is out of RefSpec's scope by REF-022. The rest are unaddressed. |
+| `evaluation_boundary.py`, `rulespec_testbed.py`, `evaluate_tag_quality.py`, `source_profiles.py`, `source_profile_artifacts*.py`, `published.py`, `document_file_pipeline.py`, `pipelines/{materialized,ontology_dataset}.py` | 10 | `published.py` reads the ontology tables at `data.spicy-regs.dev/materialized/ontology/latest.json`, which has returned 404 since at least 2026-08-27. The `materialize-ontology` workflow is not on `origin/main`. |
+| `transforms/{build_comment_periods,build_proceedings,build_regulatory_agenda,build_rule_targets}.py` | 4 | RefSpec's ledger assigns `build_rule_targets` to DocSpec's scope; DocSpec has nothing. |
+| `universes/` | 3 JSON | 600 lines of the archived `PLAN.md` describe them |
+| `docs/superpowers/specs/` (20), `docs/evidence/` (202), 12 of 14 notebooks | 234 | provenance for the decisions above. Stays on the fork either way. |
+
+### F. `source_catalog/` — drop the code, keep the namespace
+
+Ten files, 7,239 lines, on `archive/landing-final` only. DocSpec owns it:
+`src/docspec/domain/source_catalog.py`, `schemas/source_catalog/1.0/`, about
+1,800 live lines. The commit that added it (`4e9d192`) says "This is superseded
+work. DocSpec owns SourceCatalog."
+
+But DocSpec pins `urn:spicy-regs:source-catalog-release:v1:` in **83 files**
+(`adapters/document_release_verify.py:138`, with a sealed
+`catalog-pin-mismatch` refusal case). That URN prefix is DocSpec's contract
+now. Never reuse it in spicy-regs for anything else.
+
+## Supersedes
+
+Three documents tried to do this before. Each was read against the pinned
+commits above; none survives as an authority.
+
+**`docs/migration/spicysearch-product-migration-manifest.json`** (spicy-regs,
+2026-08-29; on `9a79569` and `8d9e7a2`, not on `origin/main`). Two copies exist
+under one `manifest_version`, and they contradict each other on items 1, 6, and
+16 and on `status`. Its own `retirement_authorized` is `false`; the archived
+`PLAN.md` says it "cannot authorize deletion or shutdown by itself." Six of nine
+RefSpec paths it names do not exist. Three destinations it assigns to the
+rulespec Extrapolator were refused by rulespec in writing (C above). Its
+pinning test (`tests/test_document_release.py:615-663`) asserts that sixteen
+strings appear in the file it just read.
+
+**`plans/2026-08-31-refspec-intake-ledger.md`** (RefSpec, last edited
+2026-08-31 17:14, `18bf8a3d`). All six §1 ports landed on 2026-08-31 —
+`5b8f4d8b` 03:52, `582461fe` 04:12, `2b4960e1` 21:38 — four of them before the
+ledger's last edit. It still says none has. §2.2 was ruled the same day
+(REF-053); the ledger still says "until ruled." §5 item 3 books `ann_index` and
+`candidate_channels` as spicysearch's; spicysearch has neither.
+
+**`docs/history/2026-09-01-script-product-disposition.md`** (spicysearch). Its
+five deletion gates govern three spicysearch scripts and release no spicy-regs
+file. Its premise that the source-native gate "has no survivor in any product"
+was false three days before it was written (spicy-docs `70a5b16`). It says the
+landing branch is "not merged"; `dc89c65` is an ancestor of `main`. It is
+silent on nine of the thirteen buckets above.
+
+All three defer to a "platform value ledger" or "platform-value validator" as
+the reconciling authority. `git grep` for those terms at `fc1f5fa` returns no
+files.
+
+RefSpec and spicysearch are not pushed from this checkout. Each of those two
+documents needs a one-line note pointing here, through its own repo's lane.
+
+## Closing the checkout
+
+In order, once B has been cut and D has been handed over:
+
+1. Remove the worktrees for closed PRs: `spicy-regs-pr/feat/uscode-uslm-source-credits`, `spicy-regs-pr/feat/source-domain-drift-gate`. Their branches stay on origin.
+2. Delete the local branches that are on the fork: `archive/*`, `backup/pre-marker-fix`, `feat/rkaf-boundary-freeze`, and `integrate/payload-prereqs` (also on origin).
+3. Reset local `main` to `origin/main`. The archived `main` is `archive/landing-final` on the fork; its README banner declaring this checkout superseded goes with it.
+4. What remains: one checkout tracking `origin/main`, and a worktree per open PR.


### PR DESCRIPTION
One record of the July–August document-AI research program: what each piece gives a user of the platform, and where it now ships. Five pieces go to spicy-regs as PRs, in order — the rulemaking join surface (follow one rule across every identifier the government uses for it), court opinions (which cases touch this rule), bill subjects, the table publisher that builds the public Parquet from verified releases, and the document-AI producer that tags documents in open language and writes the portable graph three other products already read. Document populations go to spicy-docs, so a result set can say "412 of 415." A publish gate and one minter go to RefSpec. Twelve pieces are already delivered to users through spicy-docs, DocSpec, RefSpec, and spicysearch, and the table says where. The open-vocabulary concept lifecycle waits on the fork for its first reader. Every claim is checked against a pinned commit in six repos, and the three earlier documents this replaces are named with what each contributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)