### PR TITLE
feat(rulemaking): publish the join surface as one materialized generation

### DIFF
--- a/.github/workflows/materialize-rulemaking.yml
+++ b/.github/workflows/materialize-rulemaking.yml
@@ -1,0 +1,81 @@
+name: Materialize — rulemaking join surface
+
+# Builds one generation of the rule-identity tables (rule_targets, proceedings,
+# regulatory_agenda_items, agenda_item_proceedings, comment_periods) from the
+# published base tables and publishes it atomically under
+# materialized/rulemaking/. Standalone rather than via _rollup.yml because a
+# first publication needs --allow-bootstrap, which that reusable workflow does
+# not pass through.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Build and validate without publishing'
+        required: false
+        default: false
+        type: boolean
+      allow_bootstrap:
+        description: 'Allow the first publication when no prior generation exists'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: materialize-rulemaking
+  cancel-in-progress: false
+
+jobs:
+  materialize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Materialize one rulemaking generation
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET_NAME: ${{ secrets.R2_BUCKET_NAME }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          SKIP_UPLOAD: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}
+          ALLOW_BOOTSTRAP: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_bootstrap || false }}
+        run: |
+          ARGS=()
+          if [ "$SKIP_UPLOAD" = "true" ]; then
+            ARGS+=(--skip-upload)
+          else
+            ARGS+=(--no-skip-upload)
+          fi
+          if [ "$ALLOW_BOOTSTRAP" = "true" ]; then
+            ARGS+=(--allow-bootstrap)
+          else
+            ARGS+=(--no-allow-bootstrap)
+          fi
+          uv run materialize-rulemaking "${ARGS[@]}"
+
+      - name: Upload failed generation for debugging
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rulemaking-generation
+          path: output/
+          retention-days: 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ docs = [
 ]
 
 [project.scripts]
+materialize-rulemaking = "spicy_regs.pipelines.rulemaking_dataset:app"
 run-pipeline = "spicy_regs.pipelines.regulations:app"
 run-rollup-feed-summary = "spicy_regs.pipelines.rollups.feed_summary:app"
 run-rollup-agency-stats = "spicy_regs.pipelines.rollups.agency_stats:app"

--- a/src/spicy_regs/ontology/__init__.py
+++ b/src/spicy_regs/ontology/__init__.py
@@ -1,0 +1,40 @@
+"""Metadata and ontology primitives for the regulatory corpus.
+
+The public tables are built by transforms under :mod:`spicy_regs.transforms`.
+This package contains the shared citation grammars, identifier expansion,
+provenance helpers, concept-loop logic, and invariants used by those transforms.
+"""
+
+from spicy_regs.ontology.citations import (
+    AuthorityCitation,
+    CfrCitation,
+    canonical_cfr_iri,
+    canonical_frdoc_iri,
+    canonical_pl_iri,
+    canonical_regsgov_iri,
+    canonical_rin_iri,
+    canonical_usc_iri,
+    federal_register_identifier,
+    normalize_regsgov_identifier,
+    parse_authority_citation,
+    parse_cfr_citation,
+)
+from spicy_regs.ontology.common import ATTESTATION_COLUMNS, RunContext, stable_id
+
+__all__ = [
+    "ATTESTATION_COLUMNS",
+    "AuthorityCitation",
+    "CfrCitation",
+    "RunContext",
+    "canonical_cfr_iri",
+    "canonical_frdoc_iri",
+    "canonical_pl_iri",
+    "canonical_regsgov_iri",
+    "canonical_rin_iri",
+    "canonical_usc_iri",
+    "federal_register_identifier",
+    "normalize_regsgov_identifier",
+    "parse_authority_citation",
+    "parse_cfr_citation",
+    "stable_id",
+]

--- a/src/spicy_regs/ontology/citations.py
+++ b/src/spicy_regs/ontology/citations.py
@@ -1,0 +1,1025 @@
+"""Citation grammars and Rulespec canonical identifier expansion."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from collections.abc import Container
+from typing import cast
+from urllib.parse import quote
+
+_CFR_COMPACT = re.compile(
+    r"^\s*(?P<title>[1-9]\d*)-(?P<part>\d+)(?:\.(?P<section>[A-Za-z0-9][A-Za-z0-9.-]*))?\s*$",
+    re.IGNORECASE,
+)
+
+#: The Code of Federal Regulations has 50 titles.
+#:
+#: Every other CFR branch is held in place by something the source text says:
+#: :data:`_CFR_STANDARD` requires the literal "CFR", :data:`_CFR_TITLE_PART`
+#: requires the word "part". The compact key is the internal ``title-part``
+#: spelling of :attr:`CfrCitation.cfr_ref` and has no anchor at all, so pointed
+#: at free text it reads any bare ``N-M`` as a citation — greedily, which is how
+#: ``'5401-5405'`` published ``urn:rkaf:us:cfr:5401:5405``
+#: (docs/evidence/citation-bakeoff-2026-08-02.md, "False positives"). With no
+#: anchor to require, the shape has to carry the refusal, and the only fact
+#: available in the shape is whether the title is one the CFR has.
+_CFR_TITLE_COUNT = 50
+
+#: A section's inner dots and hyphens are part of its name ("60.5-1"); a
+#: trailing one is the sentence's punctuation, not the section's.
+#:
+#: The greedy ``[A-Za-z0-9][A-Za-z0-9.-]*`` this replaces read "49 CFR 900.42."
+#: as section "900.42.", which :func:`_cfr_section` then refused — and
+#: :func:`_cfr_from_match` drops the *whole* citation when a section was
+#: written and could not be read, so a question typed as a sentence lost its
+#: citation entirely rather than losing the period. Requiring the last
+#: character to be alphanumeric hands the trailing punctuation back to the
+#: sentence.
+#:
+#: Ported from SpicySearch ``identifiers.py:149``. That module's ``_LEFT`` and
+#: ``_RIGHT`` boundary guards are deliberately not part of this port: they fix
+#: a different defect, and this file's 25 compiled patterns carry no boundary
+#: lookbehind at all, so importing the guards for one of them would state a
+#: discipline the other 24 do not keep.
+_CFR_SECTION_CAPTURE = r"[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?"
+
+_CFR_STANDARD = re.compile(
+    r"(?P<title>[1-9]\d*)\s*C\.?\s*F\.?\s*R\.?"
+    r"\s*(?:parts?|pt\.?|§{1,2}|sections?|secs?\.?)?\s*"
+    rf"(?P<part>\d+)(?:\.(?P<section>{_CFR_SECTION_CAPTURE}))?",
+    re.IGNORECASE,
+)
+#: The other 24 compiled patterns in this module, including this one and
+#: :data:`_CFR_COMPACT`, keep their own section spelling. The port is scoped to
+#: the one expression the two regression cases reach; widening it is a separate
+#: decision about a grammar nobody has measured.
+_CFR_TITLE_PART = re.compile(
+    r"(?:title\s+)?(?P<title>[1-9]\d*)\s*[,;:-]?\s*"
+    r"(?:C\.?\s*F\.?\s*R\.?\s*)?(?:parts?|pt\.?)\s+(?P<part>\d+)"
+    r"(?:\.(?P<section>[A-Za-z0-9][A-Za-z0-9.-]*))?",
+    re.IGNORECASE,
+)
+
+#: "3 CFR, 1977 Comp., p. 123" — a Title 3 *compilation* locator.
+#:
+#: Title 3 of the CFR is the annual compilation of presidential documents, so
+#: this form points at the page an Executive Order was printed on. It is not a
+#: CFR section reference and there is no 3 CFR § 1977. Only title 3 compiles
+#: presidential documents, so only title 3 is recognized: another title's
+#: "Comp." is a form this parser has never seen and has no meaning to give.
+#:
+#: Both the single-year volume ("1977 Comp.") and the multi-year one
+#: ("1949-1953 Comp") occur; the page is optional, because a volume alone
+#: locates no single order.
+#: A comma may fall on either side of the volume — "3 CFR, 1977 Comp." and
+#: "3 CFR 1979, Comp." both occur — and the range may be spelled rather than
+#: dashed ("1949 to 1953"). Every separator here is punctuation around the two
+#: facts that matter, the volume and the page, so each is optional and none of
+#: them decides anything.
+_EO_COMPILATION = re.compile(
+    r"\b3\s*C\.?\s*F\.?\s*R\.?\s*,?\s*"
+    r"(?P<start>(?:1[789]|20)\d{2})"
+    # The separator set is closed, not enumerated. Whatever joins two years in
+    # front of "Comp." is punctuation between a volume's endpoints -- a dash, a
+    # slash, "to", "through", "thru", "and" -- and none of it is ever a part
+    # number. Enumerating instead left "through", the ordinary legal spelling,
+    # still minting urn:rkaf:us:cfr:3:1949.
+    r"(?:\s*(?:[-–—/]|to|thru|through|and)\s*(?P<end>(?:1[789]|20)\d{2}))?"
+    r"\s*,?\s*Comp\.?"
+    r"(?:\s*,?\s*(?:pp?\.?|pages?)\s*(?P<page>\d+))?",
+    re.IGNORECASE,
+)
+
+_USC_STANDARD = re.compile(
+    r"(?P<title>[1-9]\d*)\s*U\.?\s*S\.?\s*"
+    # The code names itself three ways on this corpus: abbreviated ("U.S.C."),
+    # written out ("49 U.S. Code 106"), and as the annotated edition
+    # ("50 U.S.C.A. 4701(a)"). All three are the same code, so all three read to
+    # the same title and section.
+    r"(?:Code\b|C\.?(?:\s*A\.?)?)"
+    r"(?:\s*(?:§{1,2}|sections?|secs?\.?))?\s*"
+    r"(?P<section>\d+[A-Za-z]?(?:-\d+[A-Za-z]?)?)"
+    # A spelled range tail. The hyphenated spelling is already inside
+    # ``section`` (the hyphen is also part of the section grammar, so it has to
+    # be); this covers ``7401 to 7671q`` and the dash characters the section
+    # token cannot hold. Whether either spelling is really a range is decided
+    # by :func:`_usc_section_range`, never by the shape of the separator.
+    r"(?:(?:\s+(?:to|through)\s+|\s*[–—]\s*)(?P<range_end>\d+[A-Za-z]?))?",
+    re.IGNORECASE,
+)
+#: "49 U.S.C. ch. 311" — a U.S. Code *chapter*, the unit above a section.
+#:
+#: Measured as the largest well-defined slice of the bakeoff's shared-miss cell:
+#: 31 strings neither the project nor CiteURL detected
+#: (docs/evidence/citation-bakeoff-2026-08-02.md, "The measured gain"). The
+#: corpus spells the abbreviation every way it can — "ch.", "Ch", "ch.13" with
+#: no space, "chapter", "Chapter" — and the chapter number may carry a letter
+#: ("chapter 13A").
+#:
+#: Unlike a section, a chapter number never contains a hyphen — there is no
+#: chapter "1395w-4" — so a hyphen after one is always a separator and the range
+#: tail can accept it directly. It still has to be followed by a number:
+#: "22 USC Ch. 34- The Peace Corps Act" cites chapter 34, and the dash there is
+#: punctuation before a title. Whether an accepted pair is really a range is
+#: decided by the ordering rule, never by the separator.
+_USC_CHAPTER = re.compile(
+    r"(?P<title>[1-9]\d*)\s*U\.?\s*S\.?\s*(?:Code\b|C\.?(?:\s*A\.?)?)"
+    r"\s*(?:chapters?|chaps?\.?|chs?\.?)\s*"
+    r"(?P<chapter>\d+[A-Za-z]?)\b"
+    r"(?:(?:\s+(?:to|through)\s+|\s*[-–—]\s*)(?P<chapter_end>\d+[A-Za-z]?)\b)?",
+    re.IGNORECASE,
+)
+
+_USC_LIST_TAIL = re.compile(
+    r"(?:,|\band\b|\bor\b)\s*(?P<section>\d+[A-Za-z]?(?:-\d+[A-Za-z]?)?)\b"
+    r"(?!\s*(?:U\.?\s*S\.?\s*C|C\.?\s*F\.?\s*R|stat\b))",
+    re.IGNORECASE,
+)
+_USC_TITLE_FORM = re.compile(
+    r"(?:sec(?:tion)?\.?\s+)(?P<section>\d+[A-Za-z]?(?:-\d+[A-Za-z]?)?)"
+    r"\s+of\s+title\s+(?P<title>[1-9]\d*)",
+    re.IGNORECASE,
+)
+#: A code that names itself instead of its title number. The Internal Revenue
+#: Code *is* title 26 of the U.S. Code, so "I.R.C. 337(d)" and "26 U.S.C.
+#: 337(d)" are two spellings of one section and must reach one identifier. The
+#: title is read off the code the text names, never inferred from anything else,
+#: which is why each such code gets its own expression and its own pinned title
+#: in :data:`_NAMED_CODE_USC_TITLE` rather than a shared "guess the code" rule.
+#:
+#: The abbreviation is three letters and appears inside ordinary words, so the
+#: expression is anchored on a word boundary and publishes nothing without a
+#: section behind it — naming a code is not citing one.
+_INTERNAL_REVENUE_CODE = re.compile(
+    r"\bI\.?\s*R\.?\s*C\.?(?:\s*(?:§{1,2}|sections?|secs?\.?))?\s*"
+    r"(?P<section>\d+[A-Za-z]?(?:-\d+[A-Za-z]?)?)",
+    re.IGNORECASE,
+)
+_NAMED_CODE_USC_TITLE: dict[re.Pattern[str], str] = {_INTERNAL_REVENUE_CODE: "26"}
+
+_PUBLIC_LAW = re.compile(
+    # "Public Law", "Pub. L.", "Pub. Law", "P.L." — one law, four spellings.
+    r"(?:pub(?:lic)?\.?\s*l(?:aw)?\.?|p\.?\s*l\.?)\s*(?:no\.?\s*)?"
+    r"(?P<congress>[1-9]\d*)\s*[-–—]\s*(?P<number>[1-9]\d*)",
+    re.IGNORECASE,
+)
+_STATUTES_AT_LARGE = re.compile(
+    r"(?P<volume>[1-9]\d*)\s+stat\.?\s+(?P<page>[1-9]\d*)",
+    re.IGNORECASE,
+)
+_EXECUTIVE_ORDER = re.compile(
+    r"(?:executive\s+order|exec\.?\s*order|e\.?\s*o\.?)\s*(?:no\.?\s*)?(?P<number>[1-9]\d*)",
+    re.IGNORECASE,
+)
+
+_IGNORABLE_TAIL = re.compile(
+    r"^[\s,;:.]*(?:et\s+seq\.?|as\s+amended|and\s+following|ff\.?)?[\s,;:.]*$",
+    re.IGNORECASE,
+)
+
+
+def _digits(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return str(int(text)) if text.isdigit() else None
+
+
+def _section(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    text = re.sub(r"\([^)]*\)", "", text)
+    return text or None
+
+
+def _cfr_section(value: object) -> str | None:
+    """Normalize a Rulespec CFR section suffix, excluding subsection detail."""
+    text = _section(value)
+    if text is None:
+        return None
+    return text if re.fullmatch(r"\d+[a-z]{0,3}(?:-[0-9a-z]+)*", text) else None
+
+
+def _cfr_title_exists(title: str | None) -> bool:
+    """Whether a normalized title number names a title of the CFR."""
+    return title is not None and 1 <= int(title) <= _CFR_TITLE_COUNT
+
+
+_USC_SECTION_ATOM = re.compile(r"(?P<number>\d+)(?P<suffix>[a-z]*)")
+
+
+def _usc_section_key(section: str | None) -> tuple[int, str] | None:
+    """Order a U.S.C. section by numeric stem, then letter suffix.
+
+    ``7671`` < ``7671a`` < ``7671q`` < ``7672``. Returns ``None`` for anything
+    that is not a single well-formed section token, so a caller can never
+    compare two values it does not understand.
+    """
+    if not section:
+        return None
+    match = _USC_SECTION_ATOM.fullmatch(section)
+    return (int(match["number"]), match["suffix"]) if match else None
+
+
+def _usc_section_range(section: str | None, range_end: str | None = None) -> tuple[str | None, str | None]:
+    """Split a U.S.C. section token into ``(section, range_end)``.
+
+    A hyphen means two different things in the U.S. Code. In ``1395w-4``,
+    ``1831p-1`` and ``300j-9`` it is part of one section's name; in
+    ``7401-7671q`` and ``1702-1715z`` it separates the endpoints of a range.
+    Nothing in the character sequence distinguishes them, so the ordering does:
+    a range is a pair whose second endpoint sorts strictly after its first.
+    Compound section names never satisfy that, because their suffix is a small
+    ordinal (``1831p-1``: 1831 > 1) rather than a later section.
+
+    Fail-closed by construction. An unordered or unparsable pair keeps the
+    original token whole rather than guessing, which is why ``42 U.S.C. 1484-86``
+    (an abbreviated range) stays a single opaque section: reading it as
+    1484-to-86 would be wrong, and reading it as 1484-to-1486 would be an
+    invention.
+    """
+    if not section:
+        return (section, None)
+    if range_end is not None:
+        start, end = section, range_end
+    elif section.count("-") == 1:
+        start, end = section.split("-")
+    else:
+        return (section, None)
+    low, high = _usc_section_key(start), _usc_section_key(end)
+    if low is None or high is None or low >= high:
+        return (section, None)
+    return (start, end)
+
+
+def usc_section_covers(section: object, *, start: object, end: object = None) -> bool:
+    """Whether an ``authority_edges`` row's section covers ``section``.
+
+    A row whose ``usc_section_end`` is null denotes the single section in
+    ``usc_section``. A row that carries one denotes the **closed interval**
+    ``[usc_section, usc_section_end]`` — the endpoints are the two sections the
+    source text actually names, and the members between them are deliberately
+    never materialized, because U.S. Code ranges are sparse and lettered
+    (``42 U.S.C. 7401-7671q`` spans the Clean Air Act, whose sections do not
+    enumerate to a dense integer sequence).
+
+    So ``usc_section = '7401'`` finds a range's first section and nothing
+    inside it; this predicate is the documented way to ask the containment
+    question without inventing rows.
+    """
+    target = _usc_section_key(_section(section))
+    low = _usc_section_key(_section(start))
+    if target is None or low is None:
+        return False
+    high = _usc_section_key(_section(end))
+    return target == low if high is None else low <= target <= high
+
+
+@dataclass(frozen=True)
+class CfrCitation:
+    title: str
+    part: str
+    section: str | None = None
+
+    @property
+    def cfr_ref(self) -> str:
+        suffix = f".{self.section}" if self.section else ""
+        return f"{self.title}-{self.part}{suffix}"
+
+    @property
+    def iri(self) -> str:
+        return canonical_cfr_iri(self.title, self.part, self.section)
+
+
+#: A U.S. Code chapter is not expressible in Rulespec's ``rkaf:us-usc`` lexical
+#: space, which the compiled profile constrains to
+#: ``^urn:rkaf:us:usc:[1-9][0-9]*:[1-9][0-9]*[a-z]*(-[0-9a-z]+)*$`` — a title
+#: and a **section**. Reusing it for a chapter would be worse than merely
+#: irregular: title 5 has both a chapter 131 and a section 131, and they are
+#: different provisions, so ``urn:rkaf:us:usc:5:131`` would name two objects and
+#: be indistinguishable downstream from a correct citation.
+#:
+#: So a chapter takes the route :func:`federal_register_identifier` already
+#: takes for legacy FR document numbers: Rulespec's ``partner-defined`` escape
+#: hatch, under this repo's own URN prefix, until the scheme is broadened.
+USC_CHAPTER_IDENTIFIER_SCHEME = "rkaf:partner-defined"
+
+
+@dataclass(frozen=True)
+class UscChapterCitation:
+    """A U.S. Code chapter: the unit a section belongs to, not a section.
+
+    A range carries its two endpoints and never its members, the same rule
+    :class:`AuthorityCitation` follows for sections and for the same reason —
+    the members between them are not enumerable without inventing chapters.
+    :attr:`iri` names the first chapter, which is a chapter the text states.
+    """
+
+    title: str
+    chapter: str
+    chapter_end: str | None = None
+
+    @property
+    def iri(self) -> str:
+        return canonical_usc_chapter_iri(self.title, self.chapter)
+
+
+@dataclass(frozen=True)
+class ExecutiveOrderCompilation:
+    """Where an Executive Order was printed, not which order it is.
+
+    "3 CFR, 1977 Comp., p. 123" locates a presidential document by the page of
+    the Title 3 annual compilation it appears on. The order is what the string
+    identifies; the page is only how it points there.
+
+    **This type carries no identifier, and that is the whole point.** Two wrong
+    answers are available and both are refused. Reading it as a CFR section
+    mints ``urn:rkaf:us:cfr:3:1977`` for a section that does not exist — the
+    reading the bakeoff found in CiteURL (``title=3, section=1977``), which
+    additionally discards the page, the one component that identifies the order.
+    Reading it as an Executive Order requires an order number that is not in the
+    string, so publishing one would be an invention.
+
+    Resolving it honestly needs an index this repo does not have: a mapping from
+    (Title 3 compilation volume, page) to Executive Order number. The Federal
+    Register tables carry ``executive_order_number`` beside an *FR* volume and
+    page, which is a different citation system; ``cfr_sections`` carries
+    current-edition section metadata from GovInfo, not historical compilations.
+    A resolver would need the compilation's own front matter or GovInfo's
+    Title 3 compilation packages, neither of which is ingested.
+
+    Until then the honest output is the locator itself, typed so a consumer
+    cannot mistake it for an identifier.
+    """
+
+    compilation_start: str
+    compilation_end: str | None = None
+    page: str | None = None
+
+
+@dataclass(frozen=True)
+class AuthorityCitation:
+    authority_type: str
+    parse_status: str
+    usc_title: str | None = None
+    usc_section: str | None = None
+    usc_section_end: str | None = None
+    pl_number: str | None = None
+    statute_at_large: str | None = None
+    executive_order: str | None = None
+
+    @property
+    def canonical_iri(self) -> str | None:
+        if self.authority_type == "usc" and self.usc_title and self.usc_section:
+            return canonical_usc_iri(self.usc_title, self.usc_section)
+        if self.authority_type == "public_law" and self.pl_number:
+            return canonical_pl_iri(self.pl_number)
+        if self.authority_type == "eo" and self.executive_order:
+            return f"urn:rkaf:us:eo:{int(self.executive_order)}"
+        return None
+
+
+def canonical_cfr_iri(title: object, part: object, section: object = None) -> str:
+    title_number = _digits(title)
+    part_number = _digits(part)
+    section_number = _cfr_section(section)
+    if not title_number or not part_number:
+        raise ValueError(f"invalid CFR identifier components: title={title!r}, part={part!r}")
+    if section is not None and section_number is None:
+        raise ValueError(f"invalid CFR section: {section!r}")
+    suffix = f".{section_number}" if section_number else ""
+    return f"urn:rkaf:us:cfr:{title_number}:{part_number}{suffix}"
+
+
+def canonical_usc_iri(title: object, section: object) -> str:
+    title_number = _digits(title)
+    section_number = _section(section)
+    if not title_number or not section_number or not re.fullmatch(r"\d+[a-z]?(?:-\d+[a-z]?)?", section_number):
+        raise ValueError(f"invalid U.S.C. identifier components: title={title!r}, section={section!r}")
+    return f"urn:rkaf:us:usc:{title_number}:{section_number}"
+
+
+def canonical_usc_chapter_iri(title: object, chapter: object) -> str:
+    """Expand a U.S. Code chapter under :data:`USC_CHAPTER_IDENTIFIER_SCHEME`.
+
+    Alphabetic suffixes normalize to lowercase, the rule ``rkaf:us-usc`` states
+    for sections, so "chapter 13A" and "chapter 13a" are one chapter.
+    """
+    title_number = _digits(title)
+    chapter_number = _section(chapter)
+    if not title_number or not chapter_number or not re.fullmatch(r"[1-9]\d*[a-z]?", chapter_number):
+        raise ValueError(f"invalid U.S.C. chapter components: title={title!r}, chapter={chapter!r}")
+    return f"urn:spicy-regs:usc-chapter:{title_number}:{chapter_number}"
+
+
+#: A Regulation Identifier Number: a four-digit agency code, then a two-letter
+#: sub-agency code and a two-digit sequence. The one definition of the shape —
+#: every reader of a RIN column goes through :func:`normalize_rin`.
+_RIN = re.compile(r"^\d{4}-[A-Z]{2}\d{2}$")
+
+
+def normalize_rin(value: object) -> str | None:
+    """Return the canonical RIN a value states, or ``None`` when it states none."""
+    text = str(value or "").strip().upper()
+    return text if _RIN.fullmatch(text) else None
+
+
+def canonical_rin_iri(rin: object) -> str:
+    value = normalize_rin(rin)
+    if value is None:
+        raise ValueError(f"invalid RIN: {rin!r}")
+    return f"urn:rkaf:us:rin:{value}"
+
+
+def canonical_frdoc_iri(document_number: object) -> str:
+    value = str(document_number).strip()
+    if not re.fullmatch(r"\d{4}-\d{5}", value):
+        raise ValueError(f"invalid Federal Register document number: {document_number!r}")
+    return f"urn:rkaf:us:frdoc:{value}"
+
+
+def federal_register_identifier(document_number: object) -> tuple[str, str]:
+    """Expand an FR document number without misclassifying legacy identifiers.
+
+    Rulespec's ``us-frdoc`` lexical space currently covers only
+    ``YYYY-NNNNN``. The Federal Register corpus also contains official legacy
+    numbers (for example ``E7-21559``) and correction identifiers (for example
+    ``C1-2026-13078``). Those values remain losslessly identifiable through
+    Rulespec's ``partner-defined`` escape hatch until its scheme is broadened.
+    """
+    value = str(document_number).strip()
+    if not value or any(ord(character) < 32 for character in value):
+        raise ValueError(f"invalid Federal Register document number: {document_number!r}")
+    try:
+        return ("rkaf:us-frdoc", canonical_frdoc_iri(value))
+    except ValueError:
+        return (
+            "rkaf:partner-defined",
+            f"urn:spicy-regs:frdoc:{quote(value, safe='')}",
+        )
+
+
+def normalize_regsgov_identifier(identifier: object) -> str | None:
+    """Return a canonical Regulations.gov identifier when syntax permits it."""
+    value = str(identifier or "").strip().upper()
+    return value if re.fullmatch(r"[A-Z0-9]+(?:[-_][A-Z0-9]+)*", value) else None
+
+
+#: Federal Register metadata writes a docket id behind a human label — "Docket
+#: No. FSIS-2025-0012", "Doc. No. AMS-SC-24-0046", "Docket Number X", and
+#: sometimes the department names itself first ("DHS Docket No. USCIS-2025-0004").
+#: The label is presentation, not identity.
+_DOCKET_LABEL_PREFIX = re.compile(
+    r"^\s*(?:[A-Za-z]{2,6}\s+)?(?:docket|doc\.?)\s*(?:no\.?|nos\.?|number|id)?\s*",
+    re.IGNORECASE,
+)
+
+#: What a stripped label must have uncovered for the remainder to be identity:
+#: a Regulations.gov docket names its organization, then the year, then the
+#: sequence — "FAA-2026-3485", "AMS-SC-24-0046", "FDA-2011-N-0002",
+#: "OSHA-V05-2-2006-0785". The organization token opens on a letter, and that is
+#: the whole difference between reading "DHS Docket No. USCIS-2025-0004" and
+#: turning "MM Docket No. 98-213" into "98-213": a remainder that opens on a
+#: number is what the label was numbering, not an identifier hiding behind it.
+#: Measured on output/rin-ontology-revision-candidate, requiring the shape
+#: refuses 5,214 of the 5,506 mutilated references and costs no real docket.
+_REGSGOV_DOCKET_SHAPE = re.compile(r"[A-Z][A-Z0-9]*(?:[-_][A-Z0-9]+)*[-_]\d{2}(?:\d{2})?(?:[-_][A-Z0-9]+)*[-_]\d+")
+
+#: The spellings a stringified null leaves behind. Matches the sentinel set
+#: ``spicy_regs.docpipeline.rkaf_projection._clean`` removes, so both readers of
+#: a docket column agree on what "no reference" looks like.
+_UNSTATED_SENTINELS = frozenset({"", "None", "nan", "null"})
+
+
+def docket_reference_as_stated(reference: object) -> str:
+    """Return the reference text a source states, or ``""`` when it states none.
+
+    One cleaning for every reader of a docket column, so the link table and the
+    RKAF projection quarantine and drop exactly the same strings. Three kinds of
+    value state nothing: an empty one, the sentinel a stringified null leaves
+    behind, and a bare label — "Docket No." with nothing behind it is
+    presentation with nothing to present, and publishing it would key a docket
+    on decoration. A value the scheme can already express is never read as a
+    label, for the same reason :func:`normalize_docket_reference` validates
+    before it strips.
+    """
+    text = "" if reference is None else str(reference).strip()
+    if text in _UNSTATED_SENTINELS:
+        return ""
+    if normalize_regsgov_identifier(text) is not None:
+        return text
+    return "" if not _DOCKET_LABEL_PREFIX.sub("", text, count=1).strip() else text
+
+
+def normalize_docket_reference(reference: object) -> str | None:
+    """Return the Regulations.gov docket identifier a reference states, if any.
+
+    Strip-then-validate, in that order and only in that order. A value that is
+    already a well-formed identifier is returned untouched, because the label
+    grammar overlaps real agency codes: Commerce dockets are ``DOC-2010-0001``,
+    and stripping the ``DOC`` a label rule sees there would destroy the very
+    identifier being read. Only a value the scheme cannot express is offered to
+    the label rule, and only then is the remainder validated.
+
+    Validating the remainder is stricter than validating the stated value: a
+    label may only uncover a docket, never manufacture one, so the remainder has
+    to look like a docket id (:data:`_REGSGOV_DOCKET_SHAPE`) and not merely like
+    something the scheme could spell. Otherwise "MM Docket No. 98-213" publishes
+    the FCC proceeding number "98-213" as a Regulations.gov docket.
+
+    ``None`` means the reference names no Regulations.gov docket — a refusal,
+    not a repair. Callers quarantine it; nothing here invents a match.
+    """
+    stated = docket_reference_as_stated(reference)
+    if not stated:
+        return None
+    direct = normalize_regsgov_identifier(stated)
+    if direct is not None:
+        return direct
+    uncovered = normalize_regsgov_identifier(_DOCKET_LABEL_PREFIX.sub("", stated, count=1))
+    if uncovered is None or not _REGSGOV_DOCKET_SHAPE.fullmatch(uncovered):
+        return None
+    return uncovered
+
+
+#: Decoration must be followed by whitespace or a colon. A bare hyphen does
+#: not qualify, so a real identifier like ``DOC-2005-0010`` (Commerce) or a
+#: hypothetical ``DOCKET-2020-0001`` cannot be truncated into a false match.
+DOCKET_DECORATION_PATTERN = r"^\s*(?:docket\s*(?:no|number)?|doc\.?\s*no)\.?[\s:]+"
+
+DOCKET_NORMALIZATION_RULES = (
+    "strip_leading_docket_decorations",
+    "remove_internal_whitespace",
+    "uppercase",
+)
+
+_DOCKET_DECORATION = re.compile(DOCKET_DECORATION_PATTERN, re.IGNORECASE)
+_INTERNAL_WHITESPACE = re.compile(r"\s+")
+
+
+def normalize_docket_id(value: object) -> str:
+    """Reduce a docket reference to its comparison key.
+
+    A key, not an identifier, and the distinction is what makes it safe.
+    :func:`normalize_docket_reference` answers "what docket does this reference
+    state?" and refuses anything that is not a Regulations.gov docket; this
+    answers "what do I compare it against?" and refuses nothing, because a key
+    that matches no docket is simply a key that matches no docket. Comparing is
+    not identifying, and a key licenses no join on its own — a key that names
+    more than one docket is a collision the joiner quarantines, never resolves.
+
+    Applies :data:`DOCKET_NORMALIZATION_RULES` in order: strip leading Federal
+    Register docket decorations (repeatedly, since some references carry two),
+    remove internal whitespace that split a real identifier, and upper-case.
+    Returns ``""`` when nothing survives.
+
+    Proven in 54f07a6 across 276,326 dockets: 88,073 link rows recovered, zero
+    normalized keys covering two dockets
+    (docs/corpus-edge-coverage-findings-2026-07-24.md finding #1, RULE-010).
+    """
+    text = "" if value is None else str(value).strip()
+    if not text:
+        return ""
+    previous = None
+    while previous != text:
+        previous = text
+        text = _DOCKET_DECORATION.sub("", text).strip()
+    return _INTERNAL_WHITESPACE.sub("", text).upper()
+
+
+def canonical_regsgov_iri(identifier: object) -> str:
+    value = normalize_regsgov_identifier(identifier)
+    if value is None:
+        raise ValueError(f"invalid regulations.gov identifier: {identifier!r}")
+    return f"urn:rkaf:us:regsgov:{value}"
+
+
+def canonical_pl_iri(pl_number: object) -> str:
+    value = str(pl_number).strip().replace("–", "-").replace("—", "-")
+    match = re.fullmatch(r"([1-9]\d*)-([1-9]\d*)", value)
+    if not match:
+        raise ValueError(f"invalid public-law number: {pl_number!r}")
+    return f"urn:rkaf:us:pl:{int(match.group(1))}-{int(match.group(2))}"
+
+
+def _cfr_from_match(match: re.Match[str]) -> CfrCitation | None:
+    title = _digits(match.group("title"))
+    part = _digits(match.group("part"))
+    raw_section = match.groupdict().get("section")
+    section = _cfr_section(raw_section)
+    if not title or not part:
+        return None
+    # Every branch carries the title bound, not only the unanchored one. The
+    # anchor was never the guarantee: `_CFR_TITLE_PART` reads "<N>, Part <M>",
+    # so a *part* number can be read as a title, and a real Unified Agenda value
+    # -- "Part 2300, Part 2336, and Part 2339 of 2 CFR" -- published
+    # urn:rkaf:us:cfr:2300:2336 in 14 generations from a publishing path.
+    if not _cfr_title_exists(title):
+        return None
+    if raw_section is not None and section is None:
+        return None
+    return CfrCitation(title=title, part=part, section=section)
+
+
+def parse_cfr_citation(value: object) -> list[CfrCitation]:
+    """Parse a CFR reference from API dictionaries, compact keys, or prose.
+
+    A source string may contain more than one citation. Duplicate normalized
+    citations are collapsed while preserving their first occurrence.
+    """
+    if isinstance(value, dict):
+        components = cast(dict[str, object], value)
+        title = _digits(components.get("title"))
+        part = _digits(components.get("part"))
+        section = _section(components.get("section"))
+        return [CfrCitation(title, part, section)] if title and part else []
+    if value is None:
+        return []
+    text = str(value).strip()
+    if not text:
+        return []
+    compact = _CFR_COMPACT.fullmatch(text)
+    if compact:
+        citation = _cfr_from_match(compact)
+        if citation is None or not _cfr_title_exists(citation.title):
+            return []
+        return [citation]
+
+    # A Title 3 compilation locator ("3 CFR, 1977 Comp., p. 123") opens on
+    # something a CFR expression can read as title-and-part, and the reading is
+    # wrong: it names a page in the presidential compilation, not a section.
+    # Refusing its span — rather than the whole string — leaves a real citation
+    # standing beside it. See :class:`ExecutiveOrderCompilation`.
+    compilations = [match.span() for match in _EO_COMPILATION.finditer(text)]
+
+    def locates_a_compilation(position: int) -> bool:
+        return any(start <= position < end for start, end in compilations)
+
+    found: list[CfrCitation] = []
+    for pattern in (_CFR_STANDARD, _CFR_TITLE_PART):
+        for match in pattern.finditer(text):
+            if locates_a_compilation(match.start()):
+                continue
+            citation = _cfr_from_match(match)
+            if citation is not None and citation not in found:
+                found.append(citation)
+
+    # Common UA form: "40 CFR Parts 60 and 63". The primary expression finds
+    # the first part; expand simple trailing part numbers under the same title.
+    #
+    # ``(?!\d)`` is the boundary this expansion was missing. The negative
+    # lookahead for "CFR" was meant to stop the expansion from swallowing the
+    # opening of the *next* citation, but a bare ``\d+`` backtracks out from
+    # under it: in "1CFR9,10CFR1" the engine tried "10", failed the CFR
+    # lookahead, gave back the "0", and matched "1" — publishing a phantom
+    # 1 CFR 1 beside the two real citations the primary expression had already
+    # found. Refusing to stop in the middle of a number leaves the lookahead
+    # nothing to backtrack into, and a part number never abuts a digit it does
+    # not own.
+    if found:
+        first = found[0]
+        tail_start = next(
+            (match for match in _CFR_STANDARD.finditer(text) if not locates_a_compilation(match.start())),
+            None,
+        )
+        if tail_start:
+            tail = text[tail_start.end() :]
+            for match in re.finditer(r"(?:,|\band\b|\bor\b)\s*(\d+)(?!\d)(?!\s*C\.?F\.?R\.?)", tail, re.IGNORECASE):
+                if locates_a_compilation(tail_start.end() + match.start()):
+                    continue
+                candidate = CfrCitation(first.title, str(int(match.group(1))), None)
+                if candidate not in found:
+                    found.append(candidate)
+    return found
+
+
+#: A section reference, in the spellings the corpus uses after an act name:
+#: "sec. 112", "section 111", "secs. 2791", "§112".
+_ACT_SECTION = re.compile(
+    r"(?:sec(?:tion)?s?\.?|§{1,2})\s*(?P<section>\d+[A-Za-z]?)",
+    re.IGNORECASE,
+)
+
+#: "div. L", "division J", "Division EE" — the division of the enacting public
+#: law a citation names, when it names one. A public law may enact dozens of
+#: acts, one per division, so this is the discriminator the source text carries.
+_CITED_DIVISION = re.compile(r"\bdiv(?:ision)?\.?\s+(?P<division>[A-Z]{1,3})\b")
+
+#: The inverted spelling: "sec. 3505 of the Modernization of Cosmetics ... Act".
+_ACT_SECTION_OF_THE = re.compile(r"\A\s*of\s+(?:the\s+)?", re.IGNORECASE)
+
+#: No popular name in the Popular Name Tool is longer than this many words, and
+#: bounding the backward scan keeps recognition linear in the length of the text
+#: rather than quadratic.
+_MAX_ACT_NAME_WORDS = 24
+
+#: Punctuation a name may pick up from the sentence around it.
+_NAME_EDGE = re.compile(r"^[\s(\"'“”]+|[\s,;:.)\"'“”]+$")
+_CURLY_APOSTROPHE = re.compile(r"[’‘`]")
+_LONG_DASH = re.compile(r"[–—]")
+
+
+def normalize_popular_name(name: object) -> str:
+    """The key a popular name joins on.
+
+    Case, whitespace, sentence punctuation and the difference between a curly
+    and a straight apostrophe are all spelling, not identity: the Popular Name
+    Tool writes "Workers’ Compensation Act" and prose writes "Workers'
+    Compensation Act", and they are one act. Internal commas are kept, because
+    "Federal Food, Drug, and Cosmetic Act" is how that act is named.
+    """
+    text = _NAME_EDGE.sub("", str(name or ""))
+    text = _CURLY_APOSTROPHE.sub("'", _LONG_DASH.sub("-", text))
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+@dataclass(frozen=True)
+class ActRelativeCitation:
+    """A provision cited through the act that created it.
+
+    "Clean Air Act section 111" identifies a real provision, but names no code,
+    title or section number — it resolves only through the Office of the Law
+    Revision Counsel's tables (``spicy_regs.sources.uscode_olrc``), so this type
+    carries what the text said and nothing it did not.
+    """
+
+    act_name: str
+    act_key: str
+    section: str
+    #: The division the citation itself names, when it names one. ``None`` means
+    #: the text stated none — never that it stated the whole law.
+    division: str | None = None
+
+
+def find_act_relative_citations(text: object, *, act_names: Container[str]) -> list[ActRelativeCitation]:
+    """Find act-relative citations whose act ``act_names`` knows.
+
+    **The index is the grammar.** ``act_names`` holds normalized popular names —
+    in production, the 13,627 the OLRC publishes — and a span is an act name
+    only if the index says so. The alternative, recognizing a shape
+    (capitalized words ending in "Act"), was measured against the 4,777 sealed
+    authority strings and matched "U.S.C." 108 times.
+
+    Longest match wins, because one popular name may end with another: the Clean
+    Air Act Amendments of 1977 are not the Clean Air Act, and a shortest-match
+    rule would silently cite the wrong statute.
+
+    An act this index does not name is not read. The corpus writes "INA sec.
+    103(a)(1)" and "PHS Act secs. 2791(b)(5)", and inferring which acts those
+    abbreviate is precisely the guess the identity fence exists to stop.
+    """
+    document = "" if text is None else str(text)
+    found: list[ActRelativeCitation] = []
+    for marker in _ACT_SECTION.finditer(document):
+        section = _section(marker.group("section"))
+        named = _longest_name_before(document[: marker.start()], act_names) or _longest_name_after(
+            document[marker.end() :], act_names
+        )
+        if section is None or named is None:
+            continue
+        # A division stated anywhere across the citation's own span belongs to
+        # it: "Consolidated Appropriations Act of 2018, div. L, title IV, sec.
+        # 410" puts it between the name and the section, and the inverted
+        # spelling puts it after. The window is the span, not the string, so a
+        # second citation's division is never borrowed.
+        window = document[max(0, marker.start() - len(named) - 40) : marker.end() + 40]
+        stated_division = _CITED_DIVISION.search(window)
+        citation = ActRelativeCitation(
+            act_name=named,
+            act_key=normalize_popular_name(named),
+            section=section,
+            division=stated_division.group("division") if stated_division else None,
+        )
+        if citation not in found:
+            found.append(citation)
+    return found
+
+
+def _longest_name_before(before: str, act_names: Container[str]) -> str | None:
+    """The longest known act name ending where a section reference begins."""
+    words = before.split()
+    for length in range(min(_MAX_ACT_NAME_WORDS, len(words)), 0, -1):
+        candidate = " ".join(words[-length:])
+        if normalize_popular_name(candidate) in act_names:
+            return _NAME_EDGE.sub("", candidate)
+    return None
+
+
+def _longest_name_after(after: str, act_names: Container[str]) -> str | None:
+    """The longest known act name in "… of the <Act>" following a section."""
+    opening = _ACT_SECTION_OF_THE.match(after)
+    if opening is None:
+        return None
+    words = after[opening.end() :].split()
+    for length in range(min(_MAX_ACT_NAME_WORDS, len(words)), 0, -1):
+        candidate = " ".join(words[:length])
+        if normalize_popular_name(candidate) in act_names:
+            return _NAME_EDGE.sub("", candidate)
+    return None
+
+
+def parse_usc_chapter_citation(value: object) -> list[UscChapterCitation]:
+    """Parse U.S. Code chapter references, in order of appearance.
+
+    A chapter reference needs the code that numbers it. A bare "Chapter 33"
+    names no title, so it identifies nothing and is not read — attaching it to
+    whatever title appeared nearby would be a guess, and the corpus contains
+    exactly that string.
+
+    A listed chapter ("47 U.S.C. chs. 2, 5, 9, 13") is expanded under the title
+    that introduced it, by the same expression and the same stop rule
+    :func:`_usc_list_expansion` uses for sections — so a number that leads a
+    different citation ("46 U.S.C. ch. 553, 49 CFR 1.93(a)") is not taken as a
+    chapter.
+    """
+    if value is None:
+        return []
+    text = str(value).strip()
+    if not text:
+        return []
+    found: list[UscChapterCitation] = []
+    matches = list(_USC_CHAPTER.finditer(text))
+    for index, match in enumerate(matches):
+        title = _digits(match.group("title"))
+        # A chapter number is ordered exactly like a section: numeric stem, then
+        # letter suffix. The pair is a range only when the second endpoint sorts
+        # strictly after the first; otherwise the first chapter stands alone.
+        chapter, chapter_end = _usc_section_range(
+            _section(match.group("chapter")),
+            _section(match.group("chapter_end")),
+        )
+        if not title or not chapter:
+            continue
+        for citation in (
+            UscChapterCitation(title=title, chapter=chapter, chapter_end=chapter_end),
+            *(
+                UscChapterCitation(title=title, chapter=listed)
+                for listed in _listed_chapters(text, match, matches[index + 1 :])
+            ),
+        ):
+            if citation not in found:
+                found.append(citation)
+    return found
+
+
+def _listed_chapters(text: str, match: re.Match[str], later: list[re.Match[str]]) -> list[str]:
+    """Chapter numbers listed after ``match`` and before the next chapter citation."""
+    stop = later[0].start() if later else len(text)
+    listed = (_section(tail.group("section")) for tail in _USC_LIST_TAIL.finditer(text[match.end() : stop]))
+    return [chapter for chapter in listed if chapter]
+
+
+def parse_eo_compilation_citation(value: object) -> list[ExecutiveOrderCompilation]:
+    """Recognize Title 3 compilation locators without identifying anything.
+
+    Returns one :class:`ExecutiveOrderCompilation` per locator in the text, in
+    order of appearance. The type carries no identifier on purpose — see its
+    docstring for the two wrong answers this refuses and the index that would
+    make a right one possible.
+    """
+    if value is None:
+        return []
+    text = str(value).strip()
+    if not text:
+        return []
+    return [
+        ExecutiveOrderCompilation(
+            compilation_start=match.group("start"),
+            compilation_end=match.group("end"),
+            page=match.group("page"),
+        )
+        for match in _EO_COMPILATION.finditer(text)
+    ]
+
+
+def _usc_list_expansion(text: str) -> list[tuple[str, str, str | None]]:
+    """Expand a U.S.C. section list under the title that introduces it.
+
+    Common UA form: "42 U.S.C. 1395, 1396, 1397". The primary expression
+    requires a title before every section, so it finds only the first; expand
+    simple trailing section numbers under the same title, mirroring the CFR
+    tail expansion in :func:`parse_cfr_citation`. Each expansion stops at the
+    next explicit U.S.C. citation so a later title is never mis-attributed, and
+    a number that leads another citation form ("117 Stat. 429") is not taken.
+
+    A listed member may itself be a range ("42 U.S.C. 7401, 7671a-7671q"), so
+    each one is split by the same rule the leading citation uses.
+    """
+    matches = list(_USC_STANDARD.finditer(text))
+    expanded: list[tuple[str, str, str | None]] = []
+    for index, match in enumerate(matches):
+        title = _digits(match.group("title"))
+        if not title:
+            continue
+        stop = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        for tail in _USC_LIST_TAIL.finditer(text[match.end() : stop]):
+            section, section_end = _usc_section_range(_section(tail.group("section")))
+            if section is not None:
+                expanded.append((title, section, section_end))
+    return expanded
+
+
+def _status_for_span(text: str, start: int, end: int) -> str:
+    """Status for a citation that covers ``text[start:end]`` and nothing else.
+
+    The span is passed rather than taken from the match because a U.S.C. match
+    may consume a range tail it then declines to read as a range; the declined
+    characters are not covered, so they must still count against ``ok``.
+    """
+    remainder = f"{text[:start]} {text[end:]}"
+    return "ok" if _IGNORABLE_TAIL.fullmatch(remainder) else "partial"
+
+
+def parse_authority_citation(value: object) -> list[AuthorityCitation]:
+    """Parse the common legal-authority forms used by the Unified Agenda.
+
+    Every input produces at least one result. Unknown text is retained as an
+    ``other``/``failed`` result; recognized citations embedded in extra prose
+    are marked ``partial`` rather than discarded.
+    """
+    text = "" if value is None else str(value).strip()
+    if not text:
+        return [AuthorityCitation(authority_type="other", parse_status="failed")]
+
+    citations: list[AuthorityCitation] = []
+    patterns: tuple[tuple[re.Pattern[str], str], ...] = (
+        (_USC_STANDARD, "usc"),
+        (_USC_TITLE_FORM, "usc"),
+        (_INTERNAL_REVENUE_CODE, "usc"),
+        (_PUBLIC_LAW, "public_law"),
+        (_STATUTES_AT_LARGE, "statute_at_large"),
+        (_EXECUTIVE_ORDER, "eo"),
+    )
+    for pattern, authority_type in patterns:
+        # A named code states its title without spelling a number, so the title
+        # comes from the expression that recognized the code.
+        named_code_title = _NAMED_CODE_USC_TITLE.get(pattern)
+        for match in pattern.finditer(text):
+            if authority_type == "usc":
+                usc_section, usc_section_end = _usc_section_range(
+                    _section(match.group("section")),
+                    _section(match.groupdict().get("range_end")),
+                )
+                # A range tail the ordering rule declined stays uncovered text,
+                # so ``12 U.S.C. 1831p–1`` is still a partial parse of 1831p
+                # rather than an ``ok`` one that quietly dropped the suffix.
+                covered_end = (
+                    match.end("section")
+                    if match.groupdict().get("range_end") is not None and usc_section_end is None
+                    else match.end()
+                )
+                citation = AuthorityCitation(
+                    authority_type="usc",
+                    parse_status=_status_for_span(text, match.start(), covered_end),
+                    usc_title=_digits(match.groupdict().get("title")) or named_code_title,
+                    usc_section=usc_section,
+                    usc_section_end=usc_section_end,
+                )
+                if citation not in citations:
+                    citations.append(citation)
+                continue
+            status = _status_for_span(text, match.start(), match.end())
+            if authority_type == "public_law":
+                citation = AuthorityCitation(
+                    authority_type="public_law",
+                    parse_status=status,
+                    pl_number=f"{int(match.group('congress'))}-{int(match.group('number'))}",
+                )
+            elif authority_type == "statute_at_large":
+                citation = AuthorityCitation(
+                    authority_type="statute_at_large",
+                    parse_status=status,
+                    statute_at_large=f"{int(match.group('volume'))}-{int(match.group('page'))}",
+                )
+            else:
+                citation = AuthorityCitation(
+                    authority_type="eo",
+                    parse_status=status,
+                    executive_order=str(int(match.group("number"))),
+                )
+            if citation not in citations:
+                citations.append(citation)
+
+    # A section list is never covered by a single citation, so every member is
+    # ``partial`` — the same status the multi-citation normalization below
+    # would assign anyway.
+    for usc_title, usc_section, usc_section_end in _usc_list_expansion(text):
+        listed = AuthorityCitation(
+            authority_type="usc",
+            parse_status="partial",
+            usc_title=usc_title,
+            usc_section=usc_section,
+            usc_section_end=usc_section_end,
+        )
+        if listed not in citations:
+            citations.append(listed)
+
+    if not citations:
+        return [AuthorityCitation(authority_type="other", parse_status="failed")]
+    if len(citations) > 1:
+        # ``replace`` rather than a restated field list: a hand-copied one is
+        # how the citation columns fell out of the dedup key in 91db195.
+        citations = [replace(item, parse_status="partial") for item in citations]
+    return citations

--- a/src/spicy_regs/ontology/common.py
+++ b/src/spicy_regs/ontology/common.py
@@ -1,0 +1,226 @@
+"""Shared storage and provenance helpers for ontology rollups."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from loguru import logger
+
+ATTESTATION_COLUMNS: tuple[str, ...] = (
+    "method",
+    "actor_id",
+    "run_id",
+    "asserted_at",
+    "supersedes_id",
+)
+
+NON_DETERMINISTIC_METHODS = frozenset({"llm", "embedding", "human"})
+
+
+def iso_now() -> str:
+    """Return the current UTC instant in a stable ISO-8601 representation."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True)
+class RunContext:
+    """Provenance values shared by all rows produced in one pipeline run."""
+
+    run_id: str
+    asserted_at: str
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        run_id: str | None = None,
+        asserted_at: str | None = None,
+        prefix: str = "ontology",
+    ) -> RunContext:
+        now = asserted_at or iso_now()
+        configured = run_id or os.environ.get("ONTOLOGY_RUN_ID")
+        if configured:
+            return cls(run_id=configured, asserted_at=now)
+        timestamp = now.replace("-", "").replace(":", "").replace("+", "").replace("Z", "Z")
+        return cls(run_id=f"{prefix}-{timestamp}", asserted_at=now)
+
+    def provenance(
+        self,
+        *,
+        method: str,
+        actor_id: str,
+        supersedes_id: str | None = None,
+    ) -> dict[str, str | None]:
+        return {
+            "method": method,
+            "actor_id": actor_id,
+            "run_id": self.run_id,
+            "asserted_at": self.asserted_at,
+            "supersedes_id": supersedes_id,
+        }
+
+
+def stable_id(prefix: str, *parts: object, length: int = 24) -> str:
+    """Return a stable opaque id derived from the supplied identity parts."""
+    encoded = "\x1f".join("" if part is None else str(part) for part in parts).encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()[:length]
+    return f"{prefix}_{digest}"
+
+
+def text_digest(*parts: object) -> str:
+    """SHA-256 digest used to detect changed source text between tagging runs."""
+    encoded = "\x1f".join("" if part is None else str(part) for part in parts).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def canonical_json(value: object) -> str:
+    """Serialize JSON deterministically for stable ids, comparisons, and Parquet.
+
+    ``allow_nan=False`` because the default spells NaN and the infinities as
+    ``NaN``/``Infinity``, which no JSON reader accepts: a digest taken over that
+    text is stable and the artifact it describes is unparseable. Raising says so
+    where the value enters, instead of in whatever reads the column back.
+    """
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+@dataclass
+class JsonReadStats:
+    """Counts malformed source JSON without allowing it to abort an entire rollup."""
+
+    malformed_rows: int = 0
+    examples: list[str] = field(default_factory=list)
+
+    def malformed(self, *, table: str, row_id: object, column: str, value: object) -> None:
+        self.malformed_rows += 1
+        if len(self.examples) < 5:
+            preview = repr(value)
+            if len(preview) > 160:
+                preview = f"{preview[:157]}..."
+            self.examples.append(f"{table}.{column} row={row_id!r}: {preview}")
+
+    def log(self, rollup: str) -> None:
+        if not self.malformed_rows:
+            return
+        logger.warning(
+            "{}: skipped {:,} malformed JSON source rows; examples: {}",
+            rollup,
+            self.malformed_rows,
+            "; ".join(self.examples),
+        )
+
+
+def parse_json_list(
+    value: object,
+    *,
+    stats: JsonReadStats | None = None,
+    table: str = "source",
+    row_id: object = None,
+    column: str = "json",
+) -> list | None:
+    """Parse a source JSON array.
+
+    ``None`` and blank strings represent an empty array. A malformed value or a
+    valid non-array JSON value returns ``None`` so callers can skip and count the
+    affected source row, as required by the rollup error-handling contract.
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return []
+    try:
+        parsed = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        if stats is not None:
+            stats.malformed(table=table, row_id=row_id, column=column, value=value)
+        return None
+    if not isinstance(parsed, list):
+        if stats is not None:
+            stats.malformed(table=table, row_id=row_id, column=column, value=value)
+        return None
+    return parsed
+
+
+def all_varchar_schema(columns: Sequence[str]) -> pa.Schema:
+    """Return the repository's standard all-VARCHAR Arrow schema."""
+    return pa.schema([(column, pa.string()) for column in columns])
+
+
+def normalize_row(row: dict, columns: Sequence[str]) -> dict[str, str | None]:
+    """Coerce a row onto an all-string schema while preserving nulls."""
+    normalized: dict[str, str | None] = {}
+    for column in columns:
+        value = row.get(column)
+        if value is None or isinstance(value, str):
+            normalized[column] = value
+        elif isinstance(value, (dict, list, tuple)):
+            normalized[column] = canonical_json(value)
+        else:
+            normalized[column] = str(value)
+    return normalized
+
+
+def write_parquet_rows(
+    path: Path,
+    *,
+    columns: Sequence[str],
+    rows: Iterable[dict],
+    row_group_size: int = 50_000,
+) -> Path:
+    """Write rows to an all-VARCHAR Parquet file in bounded batches."""
+    schema = all_varchar_schema(columns)
+    writer = pq.ParquetWriter(path, schema, compression="zstd")
+    batch: list[dict[str, str | None]] = []
+    written = 0
+    try:
+        for row in rows:
+            batch.append(normalize_row(row, columns))
+            if len(batch) >= row_group_size:
+                writer.write_table(pa.Table.from_pylist(batch, schema=schema))
+                written += len(batch)
+                batch.clear()
+        if batch:
+            writer.write_table(pa.Table.from_pylist(batch, schema=schema))
+            written += len(batch)
+        if written == 0:
+            writer.write_table(schema.empty_table())
+    finally:
+        writer.close()
+    return path
+
+
+def iter_parquet_rows(path: Path, *, columns: Sequence[str] | None = None) -> Iterator[dict]:
+    """Yield Parquet rows in batches without loading the full table into memory."""
+    parquet = pq.ParquetFile(path)
+    for batch in parquet.iter_batches(columns=list(columns) if columns else None, batch_size=20_000):
+        yield from batch.to_pylist()
+
+
+def read_parquet_rows(path: Path) -> list[dict]:
+    """Read a small registry/audit Parquet table into dictionaries."""
+    if not path.exists():
+        return []
+    return pq.read_table(path).to_pylist()
+
+
+def unique_rows(rows: Iterable[dict], *, key_columns: Sequence[str]) -> list[dict]:
+    """Deduplicate identical logical rows, preserving the first occurrence."""
+    seen: set[tuple[object, ...]] = set()
+    result: list[dict] = []
+    for row in rows:
+        key = tuple(row.get(column) for column in key_columns)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(row)
+    return result

--- a/src/spicy_regs/pipelines/materialized.py
+++ b/src/spicy_regs/pipelines/materialized.py
@@ -1,0 +1,533 @@
+"""Contract for multi-stage, multi-artifact materialized datasets.
+
+Ordinary :class:`~spicy_regs.pipelines.rollups.base.RollupPipeline` jobs publish
+one independently schedulable artifact.  This module owns the different case:
+derived tables that depend on one another, share prior state, or must become
+visible as one coherent generation.
+
+Each run:
+
+1. downloads every source input once into a local snapshot;
+2. restores state from one previously published dataset generation;
+3. executes an explicit, cycle-checked stage DAG against those local files; and
+4. uploads immutable versioned artifacts before atomically replacing one small
+   ``latest.json`` pointer.
+
+Readers that resolve the pointer see either the complete prior generation or the
+complete new generation. A failed build or partial upload never exposes a mixed
+set of tables.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from abc import abstractmethod
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from os import getenv
+from pathlib import Path
+from typing import ClassVar
+
+import pyarrow.parquet as pq
+from loguru import logger
+
+from spicy_regs.ontology.common import RunContext, canonical_json, stable_id
+from spicy_regs.pipelines.base import Pipeline
+from spicy_regs.sources import r2
+
+_SAFE_NAME = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_SAFE_SNAPSHOT_ID = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+#: The snapshot format this build writes.
+#:
+#: Version 2 makes ``visibility`` a required field on every artifact record.
+#: Version 1 manifests carry it in practice — this pipeline has written it
+#: since the field existed — but nothing in the format required it, so a
+#: reader could not tell "internal" from "the producer forgot", and both read
+#: as absent. A public resolver that cannot distinguish those two answers is
+#: one missing key away from handing out an internal object's URL.
+_FORMAT_VERSION = 2
+
+#: Versions this build can *read*. A published snapshot outlives the code that
+#: wrote it, and the prior generation a run restores from was written before
+#: this bump, so refusing version 1 outright would strand every existing
+#: dataset's state at its next build.
+SUPPORTED_FORMAT_VERSIONS = (1, 2)
+
+#: The version at which each added field becomes required. Below it the field
+#: is unconstrained, because a snapshot cannot be held to a rule that did not
+#: exist when it was sealed.
+_ARTIFACT_FIELD_SINCE = {"visibility": 2}
+
+_ROOT_PREFIX = "materialized"
+
+
+@dataclass(frozen=True)
+class DatasetStage:
+    """One node in a materialized-dataset build graph."""
+
+    name: str
+    depends_on: tuple[str, ...]
+    outputs: tuple[str, ...]
+    build: Callable[[Path, RunContext], None]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _file_record(path: Path) -> dict[str, int | str]:
+    return {
+        "bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+    }
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Invalid materialized-dataset JSON at {path}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError(f"Materialized-dataset JSON at {path} must be an object")
+    return value
+
+
+def _manifest_format_version(value: object, *, label: str) -> int:
+    """Return a readable snapshot format version, or refuse the document."""
+    if value not in SUPPORTED_FORMAT_VERSIONS:
+        raise RuntimeError(
+            f"Unsupported {label} snapshot format version {value!r}; this build reads {list(SUPPORTED_FORMAT_VERSIONS)}"
+        )
+    assert isinstance(value, int)  # membership above narrows it
+    return value
+
+
+def _check_artifact_fields(record: dict, *, format_version: int, label: str) -> None:
+    """Enforce the fields the snapshot's own version made required."""
+    missing = sorted(
+        field for field, since in _ARTIFACT_FIELD_SINCE.items() if format_version >= since and field not in record
+    )
+    if missing:
+        raise RuntimeError(f"{label} artifact record at format version {format_version} is missing {missing}")
+
+
+def _safe_remote_key(value: object, *, prefix: str) -> str:
+    key = str(value or "")
+    if (
+        not key.startswith(prefix)
+        or key.startswith("/")
+        or "://" in key
+        or any(part in {"", ".", ".."} for part in key.split("/"))
+        or any(char in key for char in ("\\", "\x00", "\n", "\r"))
+    ):
+        raise RuntimeError(f"Unsafe materialized-dataset object key: {key!r}")
+    return key
+
+
+class MaterializedDatasetPipeline(Pipeline):
+    """Build and atomically publish a versioned set of related artifacts."""
+
+    dataset_name: ClassVar[str]
+    source_inputs: ClassVar[tuple[str, ...]] = ()
+    prior_outputs: ClassVar[tuple[tuple[str, str], ...]] = ()
+    optional_prior_outputs: ClassVar[tuple[tuple[str, str], ...]] = ()
+    published_outputs: ClassVar[tuple[str, ...]] = ()
+    internal_outputs: ClassVar[tuple[str, ...]] = ()
+
+    @classmethod
+    def generation_outputs(cls) -> tuple[str, ...]:
+        """Return public and internal artifacts bound to one generation."""
+        overlap = set(cls.published_outputs) & set(cls.internal_outputs)
+        if overlap:
+            raise RuntimeError(f"Materialized dataset outputs cannot be both public and internal: {sorted(overlap)}")
+        return (*cls.published_outputs, *cls.internal_outputs)
+
+    def __init__(
+        self,
+        *,
+        output_dir: Path | None = None,
+        skip_upload: bool = True,
+        allow_bootstrap: bool = False,
+        run_id: str | None = None,
+        asserted_at: str | None = None,
+    ) -> None:
+        self.output_dir = output_dir
+        self.skip_upload = skip_upload
+        self.allow_bootstrap = allow_bootstrap
+        self.run_id = run_id
+        self.asserted_at = asserted_at
+
+    @abstractmethod
+    def stages(self) -> tuple[DatasetStage, ...]:
+        """Return the dataset's build graph; declaration order breaks DAG ties."""
+        ...
+
+    def prepare(
+        self,
+        output_dir: Path,
+        *,
+        previous_manifest: dict | None,
+        context: RunContext,
+    ) -> None:
+        """Optional hook after inputs are restored and before stages execute."""
+
+    def source_column_requirements(self) -> dict[str, tuple[str, ...]]:
+        """Return required Parquet columns by source key."""
+        return {}
+
+    def run(self) -> None:
+        if not _SAFE_NAME.fullmatch(self.dataset_name):
+            raise RuntimeError(f"Invalid materialized dataset name: {self.dataset_name!r}")
+        self._validate_publication_environment()
+        output_dir = self.output_dir or (Path.cwd() / "output")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        context = RunContext.resolve(
+            run_id=self.run_id,
+            asserted_at=self.asserted_at,
+            prefix=self.dataset_name,
+        )
+
+        self._prime_sources(output_dir)
+        self._validate_source_schemas(output_dir)
+        previous_manifest = self._prime_previous_generation(output_dir)
+        input_snapshot = self._input_snapshot(output_dir, previous_manifest)
+        self.prepare(
+            output_dir,
+            previous_manifest=previous_manifest,
+            context=context,
+        )
+
+        ordered = self._ordered_stages(self.stages())
+        for stage in ordered:
+            logger.info("Materializing {} stage {}...", self.dataset_name, stage.name)
+            stage.build(output_dir, context)
+            missing = [name for name in stage.outputs if not (output_dir / name).exists()]
+            if missing:
+                raise RuntimeError(f"Materialized stage {stage.name!r} did not produce: {', '.join(missing)}")
+
+        missing_outputs = [name for name in self.generation_outputs() if not (output_dir / name).exists()]
+        if missing_outputs:
+            raise RuntimeError(
+                f"Materialized dataset {self.dataset_name!r} is incomplete: {', '.join(missing_outputs)}"
+            )
+
+        manifest_path, pointer_path, artifact_paths = self._write_publication_files(
+            output_dir,
+            context=context,
+            stages=ordered,
+            input_snapshot=input_snapshot,
+        )
+        self.validate_before_publish(manifest_path)
+        if self.skip_upload:
+            logger.info(
+                "skip_upload=True — materialized dataset {} left at {}",
+                self.dataset_name,
+                output_dir,
+            )
+            return
+        self._publish(
+            manifest_path=manifest_path,
+            pointer_path=pointer_path,
+            artifact_paths=artifact_paths,
+        )
+
+    def validate_before_publish(self, manifest_path: Path) -> None:
+        """Run dataset-specific semantic gates before the first remote write."""
+
+    def _validate_publication_environment(self) -> None:
+        """Reject a purported publication before building if R2 is incomplete."""
+        if self.skip_upload:
+            return
+        required = [
+            "R2_ACCESS_KEY_ID",
+            "R2_SECRET_ACCESS_KEY",
+            "R2_ENDPOINT",
+        ]
+        if self.source_inputs or self.prior_outputs or self.optional_prior_outputs:
+            required.append("R2_PUBLIC_URL")
+        missing = [name for name in required if not getenv(name)]
+        if missing:
+            raise RuntimeError(
+                f"Cannot publish materialized dataset {self.dataset_name!r}; "
+                f"missing R2 configuration: {', '.join(missing)}"
+            )
+
+    def _prime_sources(self, output_dir: Path) -> None:
+        """Capture each source once; all DAG stages read the same local bytes."""
+        for remote_key in self.source_inputs:
+            local = output_dir / remote_key
+            if self.skip_upload and local.exists():
+                logger.info("Using local source snapshot {}", remote_key)
+                continue
+            if not r2.download(remote_key, local):
+                raise RuntimeError(
+                    f"Materialized dataset {self.dataset_name!r}: required source {remote_key!r} is not published"
+                )
+
+    def _validate_source_schemas(self, output_dir: Path) -> None:
+        """Fail before materialization when a declared Parquet contract is stale."""
+        for remote_key, required in self.source_column_requirements().items():
+            if remote_key not in self.source_inputs:
+                raise RuntimeError(
+                    f"Materialized dataset {self.dataset_name!r} declares columns for unknown source {remote_key!r}"
+                )
+            path = output_dir / remote_key
+            actual = set(pq.ParquetFile(path).schema_arrow.names)
+            missing = sorted(set(required) - actual)
+            if missing:
+                raise RuntimeError(
+                    f"Materialized dataset {self.dataset_name!r}: source "
+                    f"{remote_key!r} is missing required columns: {', '.join(missing)}"
+                )
+
+    def _prime_previous_generation(self, output_dir: Path) -> dict | None:
+        """Restore all stateful inputs from one prior manifest, never loose latest files."""
+        if not self.prior_outputs:
+            return None
+        pointer_key = f"{_ROOT_PREFIX}/{self.dataset_name}/latest.json"
+        pointer_path = output_dir / f"_{self.dataset_name}_latest.json"
+        use_cached_pointer = self.skip_upload and pointer_path.exists()
+        if not use_cached_pointer and not r2.download(pointer_key, pointer_path):
+            if not self.skip_upload and not self.allow_bootstrap:
+                raise RuntimeError(
+                    f"No prior {self.dataset_name} materialized generation is published; "
+                    "refusing an implicit state reset. Set allow_bootstrap=True only for "
+                    "the first publication or an intentional recovery."
+                )
+            if not self.skip_upload:
+                pointer_path.unlink(missing_ok=True)
+                (output_dir / f"_{self.dataset_name}_previous_manifest.json").unlink(missing_ok=True)
+                for _, prior_name in (
+                    *self.prior_outputs,
+                    *self.optional_prior_outputs,
+                ):
+                    (output_dir / prior_name).unlink(missing_ok=True)
+            logger.info(
+                "No prior {} materialized generation; bootstrapping",
+                self.dataset_name,
+            )
+            return None
+
+        pointer = _read_json(pointer_path)
+        pointer_version = _manifest_format_version(pointer.get("format_version"), label=f"{self.dataset_name} pointer")
+        if pointer.get("dataset") != self.dataset_name:
+            raise RuntimeError(f"Invalid {self.dataset_name} latest pointer")
+        snapshot_id = str(pointer.get("snapshot_id") or "")
+        if not _SAFE_SNAPSHOT_ID.fullmatch(snapshot_id):
+            raise RuntimeError(f"Invalid {self.dataset_name} snapshot id")
+        expected_prefix = f"{_ROOT_PREFIX}/{self.dataset_name}/snapshots/{snapshot_id}/"
+        manifest_key = _safe_remote_key(
+            pointer.get("manifest_key"),
+            prefix=expected_prefix,
+        )
+        if manifest_key != f"{expected_prefix}manifest.json":
+            raise RuntimeError(f"Invalid {self.dataset_name} manifest key")
+        manifest_path = output_dir / f"_{self.dataset_name}_previous_manifest.json"
+        use_cached_manifest = self.skip_upload and manifest_path.exists()
+        if not use_cached_manifest and not r2.download(manifest_key, manifest_path):
+            raise RuntimeError(f"{self.dataset_name} latest pointer references missing {manifest_key}")
+        manifest = _read_json(manifest_path)
+        manifest_version = _manifest_format_version(
+            manifest.get("format_version"), label=f"{self.dataset_name} manifest"
+        )
+        if (
+            manifest_version != pointer_version
+            or manifest.get("dataset") != self.dataset_name
+            or manifest.get("snapshot_id") != pointer.get("snapshot_id")
+        ):
+            raise RuntimeError(f"Invalid {self.dataset_name} materialized manifest")
+
+        artifacts = manifest.get("artifacts")
+        if not isinstance(artifacts, dict):
+            raise RuntimeError(f"{self.dataset_name} manifest has no artifact map")
+        required_prior_names = {artifact_name for artifact_name, _ in self.prior_outputs}
+        prior_declarations = (
+            *self.prior_outputs,
+            *self.optional_prior_outputs,
+        )
+        if len({name for name, _ in prior_declarations}) != len(prior_declarations):
+            raise RuntimeError("Materialized prior artifact declarations must be unique")
+        for artifact_name, prior_name in prior_declarations:
+            target = output_dir / prior_name
+            record = artifacts.get(artifact_name)
+            if not isinstance(record, dict):
+                if artifact_name not in required_prior_names:
+                    target.unlink(missing_ok=True)
+                    logger.info(
+                        "Prior {} generation predates optional artifact {}; starting its migration history empty",
+                        self.dataset_name,
+                        artifact_name,
+                    )
+                    continue
+                raise RuntimeError(f"{self.dataset_name} manifest is missing stateful artifact {artifact_name}")
+            _check_artifact_fields(
+                record,
+                format_version=manifest_version,
+                label=f"{self.dataset_name} {artifact_name}",
+            )
+            remote_key = _safe_remote_key(record.get("remote_key"), prefix=expected_prefix)
+            if remote_key != f"{expected_prefix}{artifact_name}":
+                raise RuntimeError(f"{self.dataset_name} manifest has an invalid key for {artifact_name}")
+            use_cached_artifact = self.skip_upload and target.exists()
+            if not use_cached_artifact and not r2.download(remote_key, target):
+                raise RuntimeError(f"{self.dataset_name} manifest artifact is missing: {remote_key}")
+            expected_digest = str(record.get("sha256") or "")
+            if not expected_digest or _sha256(target) != expected_digest:
+                target.unlink(missing_ok=True)
+                raise RuntimeError(f"{self.dataset_name} prior artifact failed its SHA-256 check: {artifact_name}")
+        return manifest
+
+    def _input_snapshot(
+        self,
+        output_dir: Path,
+        previous_manifest: dict | None,
+    ) -> dict:
+        sources = {name: _file_record(output_dir / name) for name in self.source_inputs}
+        prior = {
+            artifact: _file_record(output_dir / local_name)
+            for artifact, local_name in (
+                *self.prior_outputs,
+                *self.optional_prior_outputs,
+            )
+            if (output_dir / local_name).exists()
+        }
+        return {
+            "sources": sources,
+            "prior_artifacts": prior,
+            "previous_snapshot_id": (previous_manifest.get("snapshot_id") if previous_manifest is not None else None),
+        }
+
+    @staticmethod
+    def _ordered_stages(stages: Iterable[DatasetStage]) -> tuple[DatasetStage, ...]:
+        declared = tuple(stages)
+        by_name = {stage.name: stage for stage in declared}
+        if len(by_name) != len(declared):
+            raise RuntimeError("Materialized dataset stage names must be unique")
+        names = set(by_name)
+        unknown = {dependency for stage in declared for dependency in stage.depends_on if dependency not in names}
+        if unknown:
+            raise RuntimeError(f"Materialized dataset has unknown stage dependencies: {sorted(unknown)}")
+
+        ordered: list[DatasetStage] = []
+        completed: set[str] = set()
+        pending = list(declared)
+        while pending:
+            ready = [stage for stage in pending if set(stage.depends_on) <= completed]
+            if not ready:
+                cycle = ", ".join(stage.name for stage in pending)
+                raise RuntimeError(f"Materialized dataset stage cycle: {cycle}")
+            for stage in ready:
+                ordered.append(stage)
+                completed.add(stage.name)
+                pending.remove(stage)
+        return tuple(ordered)
+
+    def _write_publication_files(
+        self,
+        output_dir: Path,
+        *,
+        context: RunContext,
+        stages: tuple[DatasetStage, ...],
+        input_snapshot: dict,
+    ) -> tuple[Path, Path, dict[str, Path]]:
+        artifact_paths = {name: output_dir / name for name in self.generation_outputs()}
+        artifact_records = {
+            name: {
+                **_file_record(path),
+                "rows": pq.ParquetFile(path).metadata.num_rows,
+            }
+            for name, path in artifact_paths.items()
+        }
+        stage_records = [
+            {
+                "name": stage.name,
+                "depends_on": list(stage.depends_on),
+                "outputs": list(stage.outputs),
+            }
+            for stage in stages
+        ]
+        snapshot_id = stable_id(
+            "snapshot",
+            self.dataset_name,
+            context.run_id,
+            context.asserted_at,
+            canonical_json(input_snapshot),
+            canonical_json(artifact_records),
+            canonical_json(stage_records),
+            length=32,
+        )
+        prefix = f"{_ROOT_PREFIX}/{self.dataset_name}/snapshots/{snapshot_id}"
+        artifacts = {
+            name: {
+                **artifact_records[name],
+                "remote_key": f"{prefix}/{name}",
+                "visibility": ("public" if name in self.published_outputs else "internal"),
+            }
+            for name in artifact_paths
+        }
+        manifest = {
+            "format_version": _FORMAT_VERSION,
+            "dataset": self.dataset_name,
+            "snapshot_id": snapshot_id,
+            "run_id": context.run_id,
+            "asserted_at": context.asserted_at,
+            "inputs": input_snapshot,
+            "stages": stage_records,
+            "artifacts": artifacts,
+        }
+        manifest_path = output_dir / f"{self.dataset_name}-dataset-manifest.json"
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        pointer = {
+            "format_version": _FORMAT_VERSION,
+            "dataset": self.dataset_name,
+            "snapshot_id": snapshot_id,
+            "manifest_key": f"{prefix}/manifest.json",
+        }
+        pointer_path = output_dir / f"{self.dataset_name}-dataset-latest.json"
+        pointer_path.write_text(
+            json.dumps(pointer, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        return manifest_path, pointer_path, artifact_paths
+
+    def _publish(
+        self,
+        *,
+        manifest_path: Path,
+        pointer_path: Path,
+        artifact_paths: dict[str, Path],
+    ) -> None:
+        manifest = _read_json(manifest_path)
+        artifacts = manifest["artifacts"]
+        for name, path in artifact_paths.items():
+            logger.info("Uploading immutable {} dataset artifact {}...", self.dataset_name, name)
+            r2.upload_file(path, remote_key=artifacts[name]["remote_key"])
+
+        pointer = _read_json(pointer_path)
+        manifest_key = str(pointer["manifest_key"])
+        r2.upload_file(manifest_path, remote_key=manifest_key)
+
+        # This single object replacement is the publication commit. It happens
+        # only after every immutable object and the manifest are durable.
+        # The pointer is a few hundred bytes and roughly constant in size, so the
+        # shrink guard in upload_file does not apply; R2_ALLOW_SHRINK=1 is the
+        # documented override if a snapshot id ever makes it fire.
+        r2.upload_file(
+            pointer_path,
+            remote_key=f"{_ROOT_PREFIX}/{self.dataset_name}/latest.json",
+        )
+        logger.info(
+            "Published materialized dataset {} snapshot {}",
+            self.dataset_name,
+            pointer["snapshot_id"],
+        )

--- a/src/spicy_regs/pipelines/rulemaking_dataset.py
+++ b/src/spicy_regs/pipelines/rulemaking_dataset.py
@@ -1,0 +1,172 @@
+"""Materialized dataset pipeline for the rulemaking join surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, ClassVar
+
+from cyclopts import App, Parameter
+
+from spicy_regs.ontology.common import RunContext
+from spicy_regs.pipelines.materialized import DatasetStage, MaterializedDatasetPipeline
+from spicy_regs.transforms import (
+    build_comment_periods,
+    build_proceedings,
+    build_regulatory_agenda,
+    build_rule_targets,
+)
+
+
+class RulemakingDatasetPipeline(MaterializedDatasetPipeline):
+    """Build one coherent generation of the rule-identity tables.
+
+    A rule is a RIN on reginfo, a docket on regulations.gov, a set of CFR parts
+    in the Code, and a document number in the Federal Register. Nothing joins
+    the four. These stages do: ``rule_targets`` is the docket ↔ CFR ↔ RIN
+    spine; ``proceedings`` promotes each rulemaking to a first-class record with
+    its actions; ``regulatory_agenda`` links agenda items to those actions; and
+    ``comment_periods`` materializes every comment interval, reopenings included.
+
+    Stages run in dependency order and publish atomically as one generation
+    under ``materialized/rulemaking/``, so a consumer never sees a spine from
+    one run beside proceedings from another.
+    """
+
+    name: ClassVar[str] = "rulemaking-dataset"
+    dataset_name: ClassVar[str] = "rulemaking"
+    source_inputs: ClassVar[tuple[str, ...]] = (
+        "dockets.parquet",
+        "documents.parquet",
+        "federal_register.parquet",
+        "unified_agenda.parquet",
+        "fr_docket_links.parquet",
+    )
+    prior_outputs: ClassVar[tuple[tuple[str, str], ...]] = (("proceedings.parquet", "_proceedings_prior.parquet"),)
+    published_outputs: ClassVar[tuple[str, ...]] = (
+        "rule_targets.parquet",
+        "proceedings.parquet",
+        "regulatory_agenda_items.parquet",
+        "agenda_item_proceedings.parquet",
+        "comment_periods.parquet",
+    )
+
+    def source_column_requirements(self) -> dict[str, tuple[str, ...]]:
+        return {
+            "dockets.parquet": (
+                "docket_id",
+                "rin",
+                "docket_type",
+                "title",
+                "abstract",
+                "agency_code",
+                "modify_date",
+            ),
+            "documents.parquet": (
+                "document_id",
+                "docket_id",
+                "additional_rins",
+                "fr_doc_num",
+                "document_type",
+                "title",
+                "agency_code",
+                "posted_date",
+                "modify_date",
+                "comment_start_date",
+                "comment_end_date",
+            ),
+            "federal_register.parquet": (
+                "document_number",
+                "title",
+                "abstract",
+                "document_type",
+                "publication_date",
+                "comments_close_on",
+                "docket_ids_json",
+                "regulation_id_numbers_json",
+                "cfr_references_json",
+            ),
+            "unified_agenda.parquet": (
+                "rin",
+                "agenda_edition",
+                "legal_authority_json",
+                "cfr_references_json",
+                "title",
+                "agency_code",
+                "rule_stage",
+                "priority_category",
+                "first_action_date",
+                "next_action_date",
+                "url",
+            ),
+            "fr_docket_links.parquet": (
+                "document_number",
+                "docket_id",
+            ),
+        }
+
+    def stages(self) -> tuple[DatasetStage, ...]:
+        def rule_targets(output_dir: Path, context: RunContext) -> None:
+            build_rule_targets(output_dir, run_id=context.run_id, asserted_at=context.asserted_at)
+
+        def proceedings(output_dir: Path, context: RunContext) -> None:
+            build_proceedings(output_dir, run_id=context.run_id, asserted_at=context.asserted_at)
+
+        def regulatory_agenda(output_dir: Path, context: RunContext) -> None:
+            build_regulatory_agenda(output_dir, run_id=context.run_id, asserted_at=context.asserted_at)
+
+        def comment_periods(output_dir: Path, context: RunContext) -> None:
+            build_comment_periods(output_dir, run_id=context.run_id, asserted_at=context.asserted_at)
+
+        return (
+            DatasetStage(
+                name="rule-targets",
+                depends_on=(),
+                outputs=("rule_targets.parquet",),
+                build=rule_targets,
+            ),
+            DatasetStage(
+                name="proceedings",
+                depends_on=("rule-targets",),
+                outputs=("proceedings.parquet",),
+                build=proceedings,
+            ),
+            DatasetStage(
+                name="regulatory-agenda",
+                depends_on=("proceedings",),
+                outputs=("regulatory_agenda_items.parquet", "agenda_item_proceedings.parquet"),
+                build=regulatory_agenda,
+            ),
+            DatasetStage(
+                name="comment-periods",
+                depends_on=("proceedings",),
+                outputs=("comment_periods.parquet",),
+                build=comment_periods,
+            ),
+        )
+
+
+app = App(
+    name="materialize-rulemaking",
+    help="Build and atomically publish the rulemaking join-surface dataset.",
+)
+
+
+@app.default
+def main(
+    *,
+    output_dir: Annotated[Path | None, Parameter(help="Output directory")] = None,
+    skip_upload: Annotated[bool, Parameter(help="Skip R2 upload (recommended while vetting)")] = True,
+    allow_bootstrap: Annotated[
+        bool,
+        Parameter(help="Allow a first publication with no prior rulemaking generation"),
+    ] = False,
+) -> None:
+    RulemakingDatasetPipeline(
+        output_dir=output_dir,
+        skip_upload=skip_upload,
+        allow_bootstrap=allow_bootstrap,
+    ).run()
+
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/transforms/__init__.py
+++ b/src/spicy_regs/transforms/__init__.py
@@ -13,6 +13,10 @@ from spicy_regs.transforms.build_federal_register import build_federal_register
 from spicy_regs.transforms.build_feed_summary import build_feed_summary
 from spicy_regs.transforms.build_fr_docket_links import build_fr_docket_links
 from spicy_regs.transforms.build_org_committee_links import build_org_committee_links
+from spicy_regs.transforms.build_comment_periods import build_comment_periods
+from spicy_regs.transforms.build_proceedings import build_proceedings
+from spicy_regs.transforms.build_regulatory_agenda import build_regulatory_agenda
+from spicy_regs.transforms.build_rule_targets import build_rule_targets
 from spicy_regs.transforms.build_gao_reports import build_gao_reports
 from spicy_regs.transforms.build_lobbying_filings import build_lobbying_filings
 from spicy_regs.transforms.build_rulemaking_lifecycles import build_rulemaking_lifecycles
@@ -62,6 +66,10 @@ __all__ = [
     "build_federal_register",
     "build_fr_docket_links",
     "build_org_committee_links",
+    "build_comment_periods",
+    "build_proceedings",
+    "build_regulatory_agenda",
+    "build_rule_targets",
     "build_gao_reports",
     "build_lobbying_filings",
     "build_unified_agenda",

--- a/src/spicy_regs/transforms/build_comment_periods.py
+++ b/src/spicy_regs/transforms/build_comment_periods.py
@@ -1,0 +1,398 @@
+"""Transform: materialize continuous and reopened public-comment intervals."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from urllib.parse import quote
+
+import pyarrow.parquet as pq
+from loguru import logger
+
+from spicy_regs.ontology.citations import normalize_regsgov_identifier, normalize_rin
+from spicy_regs.ontology.common import (
+    ATTESTATION_COLUMNS,
+    JsonReadStats,
+    RunContext,
+    canonical_json,
+    iter_parquet_rows,
+    parse_json_list,
+    stable_id,
+    write_parquet_rows,
+)
+
+OUTPUT = "comment_periods.parquet"
+ACTOR_ID = "spicy-regs:comment-periods:v2"
+
+COLUMNS = (
+    "comment_period_id",
+    "proceeding_ids_json",
+    "rins_json",
+    "docket_ids_json",
+    "open_date",
+    "close_date",
+    "source",
+    "opened_by_artifact_ids_json",
+    "evidence_ids_json",
+    *ATTESTATION_COLUMNS,
+)
+
+
+@dataclass(frozen=True)
+class _Interval:
+    proceeding_ids: tuple[str, ...]
+    rins: tuple[str, ...]
+    docket_ids: tuple[str, ...]
+    start: date
+    end: date
+    source: str
+    evidence_id: str
+    opened_by_artifact_id: str
+
+
+def _day(value: object) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+def _artifact_url(source: str, identifier: object) -> str | None:
+    value = str(identifier or "").strip()
+    if not value:
+        return None
+    escaped = quote(value, safe="-._~")
+    if source == "documents.comment_end_date":
+        return f"https://www.regulations.gov/document/{escaped}"
+    if source == "federal_register.comments_close_on":
+        return f"https://www.federalregister.gov/d/{escaped}"
+    return None
+
+
+def _merge_intervals(intervals: list[_Interval]) -> list[dict]:
+    """Coalesce extensions without losing joint or unresolved anchors.
+
+    Docket anchors are the grouping key when available because they remain
+    usable while Proceeding identity is unresolved. Proceeding anchors are
+    unioned only from uniquely resolved source assertions. A docket-less
+    interval falls back to its resolved Proceeding anchors.
+    """
+    grouped: dict[tuple[str, tuple[str, ...]], list[_Interval]] = defaultdict(list)
+    for interval in intervals:
+        anchor = ("dockets", interval.docket_ids) if interval.docket_ids else ("proceedings", interval.proceeding_ids)
+        grouped[anchor].append(interval)
+
+    merged: list[dict] = []
+    for _, values in grouped.items():
+        values.sort(
+            key=lambda interval: (
+                interval.start,
+                interval.end,
+                interval.source,
+                interval.evidence_id,
+            )
+        )
+        current_start: date | None = None
+        current_end: date | None = None
+        proceeding_ids: set[str] = set()
+        rins: set[str] = set()
+        docket_ids: set[str] = set()
+        sources: set[str] = set()
+        evidence: set[str] = set()
+        opened_by: set[str] = set()
+
+        def flush() -> None:
+            if current_start is None or current_end is None:
+                return
+            sorted_proceedings = sorted(proceeding_ids)
+            sorted_dockets = sorted(docket_ids)
+            merged.append(
+                {
+                    "comment_period_id": stable_id(
+                        "comment_period",
+                        canonical_json(sorted_proceedings),
+                        canonical_json(sorted_dockets),
+                        current_start.isoformat(),
+                    ),
+                    "proceeding_ids_json": canonical_json(sorted_proceedings),
+                    "rins_json": canonical_json(sorted(rins)),
+                    "docket_ids_json": canonical_json(sorted_dockets),
+                    "open_date": current_start.isoformat(),
+                    "close_date": current_end.isoformat(),
+                    "source": "+".join(sorted(sources)),
+                    "opened_by_artifact_ids_json": canonical_json(sorted(opened_by)),
+                    "evidence_ids_json": canonical_json(sorted(evidence)),
+                }
+            )
+
+        def begin(interval: _Interval) -> None:
+            nonlocal current_start, current_end
+            nonlocal proceeding_ids, rins, docket_ids, sources, evidence, opened_by
+            current_start, current_end = interval.start, interval.end
+            proceeding_ids = set(interval.proceeding_ids)
+            rins = set(interval.rins)
+            docket_ids = set(interval.docket_ids)
+            sources = {interval.source}
+            evidence = {interval.evidence_id}
+            opened_by = {interval.opened_by_artifact_id}
+
+        for interval in values:
+            if current_start is None:
+                begin(interval)
+                continue
+            assert current_end is not None
+            if interval.start <= current_end + timedelta(days=1):
+                current_end = max(current_end, interval.end)
+                proceeding_ids.update(interval.proceeding_ids)
+                rins.update(interval.rins)
+                docket_ids.update(interval.docket_ids)
+                sources.add(interval.source)
+                evidence.add(interval.evidence_id)
+                if interval.start == current_start:
+                    opened_by.add(interval.opened_by_artifact_id)
+                continue
+            flush()
+            begin(interval)
+        flush()
+    return merged
+
+
+def build_comment_periods(
+    output_dir: Path,
+    *,
+    run_id: str | None = None,
+    asserted_at: str | None = None,
+) -> Path:
+    """Build comment periods, retaining docket-only and joint intervals."""
+    required = {
+        name: output_dir / f"{name}.parquet"
+        for name in (
+            "proceedings",
+            "dockets",
+            "documents",
+            "federal_register",
+            "fr_docket_links",
+        )
+    }
+    missing = [path.name for path in required.values() if not path.exists()]
+    if missing:
+        raise FileNotFoundError(f"comment_periods inputs missing from {output_dir}: {', '.join(missing)}")
+    context = RunContext.resolve(
+        run_id=run_id,
+        asserted_at=asserted_at,
+        prefix="comment-periods",
+    )
+    provenance = context.provenance(method="deterministic", actor_id=ACTOR_ID)
+    json_stats = JsonReadStats()
+
+    proceeding_by_id: dict[str, dict] = {}
+    dockets_by_proceeding: dict[str, set[str]] = {}
+    proceeding_ids_by_docket: dict[str, set[str]] = defaultdict(set)
+    proceeding_ids_by_fr_document: dict[str, set[str]] = defaultdict(set)
+    for row in iter_parquet_rows(required["proceedings"]):
+        proceeding_id = str(row["proceeding_id"])
+        proceeding_by_id[proceeding_id] = row
+        dockets = parse_json_list(
+            row.get("docket_ids_json"),
+            stats=json_stats,
+            table="proceedings",
+            row_id=proceeding_id,
+            column="docket_ids_json",
+        )
+        docket_set = (
+            set()
+            if dockets is None
+            else {normalized for docket in dockets if (normalized := normalize_regsgov_identifier(docket)) is not None}
+        )
+        dockets_by_proceeding[proceeding_id] = docket_set
+        for docket in docket_set:
+            proceeding_ids_by_docket[docket].add(proceeding_id)
+        fr_documents = parse_json_list(
+            row.get("fr_document_numbers_json"),
+            stats=json_stats,
+            table="proceedings",
+            row_id=proceeding_id,
+            column="fr_document_numbers_json",
+        )
+        if fr_documents is not None:
+            for document_number in fr_documents:
+                proceeding_ids_by_fr_document[str(document_number)].add(proceeding_id)
+
+    trusted_dockets = {
+        normalized
+        for row in iter_parquet_rows(required["dockets"], columns=("docket_id",))
+        if (normalized := normalize_regsgov_identifier(row.get("docket_id"))) is not None
+    }
+
+    intervals: list[_Interval] = []
+    inverted_by_source: Counter[str] = Counter()
+    inverted_examples: list[str] = []
+    ambiguous_document_intervals = 0
+    ambiguous_fr_intervals = 0
+    unanchored_intervals = 0
+
+    def add_interval(
+        *,
+        proceeding_ids: set[str],
+        docket_ids: set[str],
+        rins: set[str],
+        start: object,
+        end: object,
+        source: str,
+        evidence_id: object,
+    ) -> None:
+        nonlocal unanchored_intervals
+        open_date, close_date = _day(start), _day(end)
+        evidence = str(evidence_id or "").strip()
+        opened_by = _artifact_url(source, evidence)
+        if open_date is None or close_date is None or not evidence or opened_by is None:
+            return
+        if close_date < open_date:
+            inverted_by_source[source] += 1
+            if len(inverted_examples) < 5:
+                inverted_examples.append(f"{source} {evidence}: {open_date.isoformat()}..{close_date.isoformat()}")
+            return
+        if not proceeding_ids and not docket_ids:
+            unanchored_intervals += 1
+            return
+        resolved_rins = set(rins)
+        resolved_rins.update(
+            rin
+            for proceeding_id in proceeding_ids
+            if (rin := normalize_rin(proceeding_by_id[proceeding_id].get("rin"))) is not None
+        )
+        intervals.append(
+            _Interval(
+                proceeding_ids=tuple(sorted(proceeding_ids)),
+                rins=tuple(sorted(resolved_rins)),
+                docket_ids=tuple(sorted(docket_ids)),
+                start=open_date,
+                end=close_date,
+                source=source,
+                evidence_id=evidence,
+                opened_by_artifact_id=opened_by,
+            )
+        )
+
+    for row in iter_parquet_rows(required["documents"]):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        if docket is None or not row.get("comment_end_date"):
+            continue
+        # The document endpoint is itself a source-of-record membership signal.
+        trusted_dockets.add(docket)
+        docket_targets = set(proceeding_ids_by_docket.get(docket, ()))
+        raw_rins = parse_json_list(
+            row.get("additional_rins"),
+            stats=json_stats,
+            table="documents",
+            row_id=row.get("document_id"),
+            column="additional_rins",
+        )
+        rins = set() if raw_rins is None else {rin for value in raw_rins if (rin := normalize_rin(value)) is not None}
+        # The source-backed docket is action identity. A RIN is retained as
+        # interval metadata but never filters or selects a Proceeding.
+        candidates = docket_targets
+        proceeding_ids = candidates if len(candidates) == 1 else set()
+        if len(candidates) > 1:
+            ambiguous_document_intervals += 1
+        add_interval(
+            proceeding_ids=proceeding_ids,
+            docket_ids={docket},
+            rins=rins,
+            start=row.get("comment_start_date") or row.get("posted_date"),
+            end=row.get("comment_end_date"),
+            source="documents.comment_end_date",
+            evidence_id=row.get("document_id"),
+        )
+
+    linked_dockets_by_fr: dict[str, set[str]] = defaultdict(set)
+    for row in iter_parquet_rows(
+        required["fr_docket_links"],
+        columns=("document_number", "docket_id"),
+    ):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        if row.get("document_number") and docket in trusted_dockets:
+            linked_dockets_by_fr[str(row["document_number"])].add(docket)
+
+    for row in iter_parquet_rows(required["federal_register"]):
+        if not row.get("comments_close_on") or not row.get("publication_date"):
+            continue
+        document_number = str(row.get("document_number") or "")
+        raw_rins = parse_json_list(
+            row.get("regulation_id_numbers_json"),
+            stats=json_stats,
+            table="federal_register",
+            row_id=document_number,
+            column="regulation_id_numbers_json",
+        )
+        rins = set() if raw_rins is None else {rin for value in raw_rins if (rin := normalize_rin(value)) is not None}
+        dockets = set(linked_dockets_by_fr.get(document_number, ()))
+        docket_targets: set[str] = set()
+        for docket in dockets:
+            docket_targets.update(proceeding_ids_by_docket.get(docket, ()))
+        artifact_targets = set(proceeding_ids_by_fr_document.get(document_number, ()))
+        # Direct artifact membership is strongest. Docket membership is the
+        # fallback for older rows that predate the artifact projection.
+        candidates = artifact_targets or docket_targets
+        proceeding_ids = candidates if len(candidates) == 1 else set()
+        if len(candidates) > 1:
+            ambiguous_fr_intervals += 1
+        add_interval(
+            proceeding_ids=proceeding_ids,
+            docket_ids=dockets,
+            rins=rins,
+            start=row.get("publication_date"),
+            end=row.get("comments_close_on"),
+            source="federal_register.comments_close_on",
+            evidence_id=document_number,
+        )
+
+    rows = _merge_intervals(intervals)
+    for row in rows:
+        row.update(provenance)
+    rows.sort(
+        key=lambda row: (
+            row["docket_ids_json"],
+            row["proceeding_ids_json"],
+            row["open_date"],
+        )
+    )
+    out_file = write_parquet_rows(output_dir / OUTPUT, columns=COLUMNS, rows=rows)
+    json_stats.log("comment_periods")
+    if inverted_by_source:
+        logger.warning(
+            "comment_periods: skipped {:,} inverted source intervals ({}); examples: {}",
+            sum(inverted_by_source.values()),
+            ", ".join(f"{source}={count:,}" for source, count in sorted(inverted_by_source.items())),
+            "; ".join(inverted_examples),
+        )
+    if ambiguous_fr_intervals:
+        logger.warning(
+            "comment_periods: retained {:,} ambiguous FR intervals with docket-only anchors",
+            ambiguous_fr_intervals,
+        )
+    if ambiguous_document_intervals:
+        logger.warning(
+            "comment_periods: retained {:,} ambiguous document intervals with docket-only anchors",
+            ambiguous_document_intervals,
+        )
+    if unanchored_intervals:
+        logger.warning(
+            "comment_periods: skipped {:,} intervals with neither a resolved Proceeding nor a source-backed Docket",
+            unanchored_intervals,
+        )
+    anchor_counts = Counter((row["proceeding_ids_json"], row["docket_ids_json"]) for row in rows)
+    reopenings = sum(count - 1 for count in anchor_counts.values() if count > 1)
+    docket_only = sum(row["proceeding_ids_json"] == "[]" and row["docket_ids_json"] != "[]" for row in rows)
+    logger.info(
+        "Comment periods: {:,} rows ({:,} reopened; {:,} docket-only)",
+        len(rows),
+        reopenings,
+        docket_only,
+    )
+    assert pq.ParquetFile(out_file).schema_arrow.names == list(COLUMNS)
+    return out_file

--- a/src/spicy_regs/transforms/build_proceedings.py
+++ b/src/spicy_regs/transforms/build_proceedings.py
@@ -1,0 +1,499 @@
+"""Transform: promote action-specific evidence into first-class proceedings."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from loguru import logger
+
+from spicy_regs.ontology.citations import (
+    canonical_cfr_iri,
+    normalize_regsgov_identifier,
+    normalize_rin,
+)
+from spicy_regs.ontology.common import (
+    ATTESTATION_COLUMNS,
+    JsonReadStats,
+    RunContext,
+    canonical_json,
+    iter_parquet_rows,
+    parse_json_list,
+    read_parquet_rows,
+    stable_id,
+    write_parquet_rows,
+)
+
+OUTPUT = "proceedings.parquet"
+ACTOR_ID = "spicy-regs:proceedings:v2"
+
+COLUMNS = (
+    "proceeding_id",
+    "rin",
+    "docket_ids_json",
+    "title",
+    "agency_code",
+    "current_stage",
+    "stage_events_json",
+    "fr_document_numbers_json",
+    "cfr_refs_json",
+    "cfr_target_iris_json",
+    "authority_refs_json",
+    "identity_predecessors_json",
+    *ATTESTATION_COLUMNS,
+)
+
+STAGES = frozenset({"prerule", "proposed", "supplemental", "final", "withdrawn", "longterm"})
+_STAGE_KIND = {
+    "prerule": "proceedingPrerule",
+    "proposed": "proceedingProposed",
+    "supplemental": "proceedingSupplemental",
+    "final": "proceedingFinal",
+    "withdrawn": "proceedingWithdrawn",
+    "longterm": "proceedingLongterm",
+}
+
+
+def _stage_from_document(document_type: object, title: object) -> str | None:
+    kind = str(document_type or "").casefold()
+    text = f"{kind} {str(title or '').casefold()}"
+    if "withdraw" in text:
+        return "withdrawn"
+    if "supplement" in text and ("proposed" in text or "proposal" in text):
+        return "supplemental"
+    if kind == "rule" or "final rule" in text:
+        return "final"
+    if kind == "proposed rule" or "proposed rule" in text:
+        return "proposed"
+    return None
+
+
+def _current_stage_from_events(events: list[dict]) -> str | None:
+    """Return the unique stage at the latest evidenced date."""
+    for event in events:
+        stage = event.get("stage")
+        if stage in STAGES and event.get("event_kind") != _STAGE_KIND[stage]:
+            raise ValueError(f"stage event kind disagrees with stage: {stage!r} / {event.get('event_kind')!r}")
+    dated = [event for event in events if event.get("effective_date")]
+    if not dated:
+        return None
+    latest_date = max(str(event["effective_date"]) for event in dated)
+    latest_stages = {
+        str(event["stage"])
+        for event in dated
+        if str(event["effective_date"]) == latest_date and event.get("stage") in STAGES
+    }
+    return next(iter(latest_stages)) if len(latest_stages) == 1 else None
+
+
+def _require_inputs(output_dir: Path, names: tuple[str, ...]) -> dict[str, Path]:
+    paths = {name: output_dir / f"{name}.parquet" for name in names}
+    missing = [path.name for path in paths.values() if not path.exists()]
+    if missing:
+        raise FileNotFoundError(f"proceedings inputs missing from {output_dir}: {', '.join(missing)}")
+    return paths
+
+
+def build_proceedings(
+    output_dir: Path,
+    *,
+    run_id: str | None = None,
+    asserted_at: str | None = None,
+) -> Path:
+    """Build proceedings from dockets and Federal Register action artifacts.
+
+    A RIN identifies a Regulatory Agenda item, not an action. It is retained as
+    denormalized evidence when exactly one RIN is observed for an action, but
+    it never groups dockets, creates an agenda-only proceeding, or preserves a
+    stable proceeding id. One Federal Register artifact may explicitly connect
+    multiple trusted dockets; otherwise docket and artifact identities stay
+    separate.
+    """
+    paths = _require_inputs(
+        output_dir,
+        (
+            "dockets",
+            "documents",
+            "federal_register",
+            "fr_docket_links",
+            "rule_targets",
+        ),
+    )
+    context = RunContext.resolve(
+        run_id=run_id,
+        asserted_at=asserted_at,
+        prefix="proceedings",
+    )
+    provenance = context.provenance(method="deterministic", actor_id=ACTOR_ID)
+    json_stats = JsonReadStats()
+    prior_file = output_dir / "_proceedings_prior.parquet"
+    if not prior_file.exists() and (output_dir / OUTPUT).exists():
+        prior_file = output_dir / OUTPUT
+    prior_proceedings = read_parquet_rows(prior_file)
+
+    def empty_group(
+        *,
+        dockets: set[str],
+        identity: tuple[object, ...],
+    ) -> dict:
+        return {
+            "dockets": set(dockets),
+            "identity": identity,
+            "rins": set(),
+            "titles": [],
+            "agencies": [],
+            "events": [],
+            "fr_documents": set(),
+            "cfr_refs": set(),
+            "cfr_target_iris": set(),
+        }
+
+    # Establish source-backed docket membership before trusting FR link rows.
+    trusted_dockets: set[str] = set()
+    action_dockets: set[str] = set()
+    docket_metadata: dict[str, dict] = {}
+    for row in iter_parquet_rows(paths["dockets"]):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        if docket is None:
+            continue
+        trusted_dockets.add(docket)
+        docket_metadata[docket] = row
+        if normalize_rin(row.get("rin")) or "rulemaking" in str(row.get("docket_type") or "").casefold():
+            action_dockets.add(docket)
+
+    for row in iter_parquet_rows(paths["documents"]):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        if docket is None:
+            continue
+        trusted_dockets.add(docket)
+        raw_rins = parse_json_list(
+            row.get("additional_rins"),
+            stats=json_stats,
+            table="documents",
+            row_id=row.get("document_id"),
+            column="additional_rins",
+        )
+        has_rin = raw_rins is not None and any(normalize_rin(value) for value in raw_rins)
+        if has_rin or _stage_from_document(
+            row.get("document_type"),
+            row.get("title"),
+        ):
+            action_dockets.add(docket)
+
+    linked_dockets_by_fr: dict[str, set[str]] = defaultdict(set)
+    for row in iter_parquet_rows(
+        paths["fr_docket_links"],
+        columns=("document_number", "docket_id"),
+    ):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        if row.get("document_number") and docket in trusted_dockets:
+            document_number = str(row["document_number"])
+            linked_dockets_by_fr[document_number].add(docket)
+            action_dockets.add(docket)
+
+    # Docket identity is action-specific. A Federal Register document is the
+    # only cross-docket union signal used by this carrier.
+    parent: dict[str, str] = {}
+
+    def find(node: str) -> str:
+        parent.setdefault(node, node)
+        while parent[node] != node:
+            parent[node] = parent[parent[node]]
+            node = parent[node]
+        return node
+
+    def union(left: str, right: str) -> None:
+        left_root, right_root = find(left), find(right)
+        if left_root == right_root:
+            return
+        winner, loser = sorted((left_root, right_root))
+        parent[loser] = winner
+
+    for docket in action_dockets:
+        find(docket)
+    for dockets in linked_dockets_by_fr.values():
+        ordered = sorted(dockets)
+        for docket in ordered:
+            find(docket)
+        for docket in ordered[1:]:
+            union(ordered[0], docket)
+
+    members_by_root: dict[str, set[str]] = defaultdict(set)
+    for docket in parent:
+        members_by_root[find(docket)].add(docket)
+
+    groups: dict[str, dict] = {}
+    group_key_by_docket: dict[str, str] = {}
+    for dockets in sorted(members_by_root.values(), key=lambda values: min(values)):
+        anchor = min(dockets)
+        key = f"docket:{anchor}"
+        groups[key] = empty_group(
+            dockets=dockets,
+            identity=("docket", anchor),
+        )
+        for docket in dockets:
+            group_key_by_docket[docket] = key
+
+    def ensure_fr(document_number: str) -> tuple[str, dict]:
+        key = f"fr-document:{document_number}"
+        return key, groups.setdefault(
+            key,
+            empty_group(
+                dockets=set(),
+                identity=("fr-document", document_number),
+            ),
+        )
+
+    def add_event(
+        group: dict,
+        *,
+        stage: str | None,
+        date: object,
+        source: str,
+        evidence_id: object,
+    ) -> None:
+        if stage not in STAGES:
+            return
+        event = {
+            "stage": stage,
+            "event_kind": _STAGE_KIND[stage],
+            "effective_date": None if date is None else str(date)[:10],
+            "source": source,
+            "evidence_id": None if evidence_id is None else str(evidence_id),
+        }
+        if event not in group["events"]:
+            group["events"].append(event)
+
+    for docket, row in docket_metadata.items():
+        key = group_key_by_docket.get(docket)
+        if key is None:
+            continue
+        group = groups[key]
+        if rin := normalize_rin(row.get("rin")):
+            group["rins"].add(rin)
+        if row.get("title"):
+            group["titles"].append((str(row.get("modify_date") or ""), str(row["title"])))
+        if row.get("agency_code"):
+            group["agencies"].append(str(row["agency_code"]))
+
+    for row in iter_parquet_rows(paths["documents"]):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        key = group_key_by_docket.get(docket or "")
+        if key is None:
+            continue
+        group = groups[key]
+        raw_rins = parse_json_list(
+            row.get("additional_rins"),
+            stats=json_stats,
+            table="documents",
+            row_id=row.get("document_id"),
+            column="additional_rins",
+        )
+        if raw_rins is not None:
+            group["rins"].update(rin for value in raw_rins if (rin := normalize_rin(value)) is not None)
+        if row.get("title"):
+            group["titles"].append((str(row.get("posted_date") or ""), str(row["title"])))
+        if row.get("agency_code"):
+            group["agencies"].append(str(row["agency_code"]))
+        add_event(
+            group,
+            stage=_stage_from_document(
+                row.get("document_type"),
+                row.get("title"),
+            ),
+            date=row.get("posted_date"),
+            source="documents.document_type",
+            evidence_id=row.get("document_id"),
+        )
+
+    for row in iter_parquet_rows(paths["federal_register"]):
+        document_number = str(row.get("document_number") or "").strip()
+        if not document_number:
+            continue
+        raw_rins = parse_json_list(
+            row.get("regulation_id_numbers_json"),
+            stats=json_stats,
+            table="federal_register",
+            row_id=document_number,
+            column="regulation_id_numbers_json",
+        )
+        rins = set() if raw_rins is None else {rin for value in raw_rins if (rin := normalize_rin(value)) is not None}
+        stage = _stage_from_document(row.get("document_type"), row.get("title"))
+        linked_keys = {
+            group_key_by_docket[docket]
+            for docket in linked_dockets_by_fr.get(document_number, ())
+            if docket in group_key_by_docket
+        }
+        if linked_keys:
+            # All trusted dockets named by one FR artifact were unioned above.
+            key = next(iter(linked_keys))
+            if len(linked_keys) != 1:
+                raise RuntimeError(f"FR document {document_number} spans unmerged docket components")
+            group = groups[key]
+        elif rins or stage:
+            _, group = ensure_fr(document_number)
+        else:
+            continue
+        group["fr_documents"].add(document_number)
+        group["rins"].update(rins)
+        if row.get("title"):
+            group["titles"].append((str(row.get("publication_date") or ""), str(row["title"])))
+        add_event(
+            group,
+            stage=stage,
+            date=row.get("publication_date"),
+            source="federal_register.document_type",
+            evidence_id=document_number,
+        )
+
+    for row in iter_parquet_rows(paths["rule_targets"]):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        key = group_key_by_docket.get(docket or "")
+        if key is None:
+            continue
+        group = groups[key]
+        if rin := normalize_rin(row.get("rin")):
+            group["rins"].add(rin)
+        if row.get("cfr_ref"):
+            group["cfr_refs"].add(str(row["cfr_ref"]))
+            try:
+                group["cfr_target_iris"].add(
+                    canonical_cfr_iri(
+                        row.get("cfr_title"),
+                        row.get("cfr_part"),
+                        row.get("cfr_section"),
+                    )
+                )
+            except ValueError:
+                logger.warning(
+                    "proceedings: retained compact CFR ref but could not project Rulespec target {}",
+                    row.get("cfr_ref"),
+                )
+
+    # Stable partner ids follow action evidence, never RIN equality. Docket
+    # overlap preserves ordinary continuity; FR overlap preserves a provisional
+    # document-based proceeding when its docket is discovered later.
+    prior_identity: list[tuple[str, set[str], set[str]]] = []
+    for row in prior_proceedings:
+        proceeding_id = str(row.get("proceeding_id") or "")
+        if not proceeding_id:
+            continue
+        raw_dockets = parse_json_list(
+            row.get("docket_ids_json"),
+            stats=json_stats,
+            table="proceedings_prior",
+            row_id=proceeding_id,
+            column="docket_ids_json",
+        )
+        raw_fr_documents = parse_json_list(
+            row.get("fr_document_numbers_json"),
+            stats=json_stats,
+            table="proceedings_prior",
+            row_id=proceeding_id,
+            column="fr_document_numbers_json",
+        )
+        prior_identity.append(
+            (
+                proceeding_id,
+                set() if raw_dockets is None else set(map(str, raw_dockets)),
+                (set() if raw_fr_documents is None else set(map(str, raw_fr_documents))),
+            )
+        )
+
+    prior_by_id = {
+        prior_id: (prior_dockets, prior_fr_documents) for prior_id, prior_dockets, prior_fr_documents in prior_identity
+    }
+    prior_ids_by_docket: dict[str, set[str]] = defaultdict(set)
+    prior_ids_by_fr: dict[str, set[str]] = defaultdict(set)
+    for prior_id, prior_dockets, prior_fr_documents in prior_identity:
+        for docket in prior_dockets:
+            prior_ids_by_docket[docket].add(prior_id)
+        for document_number in prior_fr_documents:
+            prior_ids_by_fr[document_number].add(prior_id)
+
+    predecessor_ids_by_group: dict[str, set[str]] = defaultdict(set)
+    candidate_edges: list[tuple[int, str, str]] = []
+    for group_key, group in groups.items():
+        current_dockets = set(group["dockets"])
+        current_fr_documents = set(group["fr_documents"])
+        plausible_prior_ids: set[str] = set()
+        for docket in current_dockets:
+            plausible_prior_ids.update(prior_ids_by_docket.get(docket, ()))
+        for document_number in current_fr_documents:
+            plausible_prior_ids.update(prior_ids_by_fr.get(document_number, ()))
+        for prior_id in plausible_prior_ids:
+            prior_dockets, prior_fr_documents = prior_by_id[prior_id]
+            docket_overlap = len(current_dockets & prior_dockets)
+            fr_overlap = len(current_fr_documents & prior_fr_documents)
+            if not docket_overlap and not fr_overlap:
+                continue
+            predecessor_ids_by_group[group_key].add(prior_id)
+            score = docket_overlap * 100 + fr_overlap * 10
+            candidate_edges.append((-score, prior_id, group_key))
+
+    proceeding_id_by_group: dict[str, str] = {}
+    claimed_prior_ids: set[str] = set()
+    for _, prior_id, group_key in sorted(candidate_edges):
+        if group_key in proceeding_id_by_group or prior_id in claimed_prior_ids:
+            continue
+        proceeding_id_by_group[group_key] = prior_id
+        claimed_prior_ids.add(prior_id)
+    for group_key, group in groups.items():
+        proceeding_id_by_group.setdefault(
+            group_key,
+            stable_id("proceeding", *group["identity"]),
+        )
+
+    rows: list[dict] = []
+    for group_key, group in groups.items():
+        events = sorted(
+            group["events"],
+            key=lambda event: (
+                event.get("effective_date") or "",
+                event.get("stage") or "",
+                event.get("evidence_id") or "",
+            ),
+        )
+        titles = sorted(group["titles"])
+        rins = sorted(group["rins"])
+        proceeding_id = proceeding_id_by_group[group_key]
+        matched_predecessors = predecessor_ids_by_group.get(group_key, set())
+        predecessors = sorted(matched_predecessors - {proceeding_id})
+        rows.append(
+            {
+                "proceeding_id": proceeding_id,
+                # Compatibility/query aid only; never the row's identity.
+                "rin": rins[0] if len(rins) == 1 else None,
+                "docket_ids_json": canonical_json(sorted(group["dockets"])),
+                "title": titles[-1][1] if titles else None,
+                "agency_code": (Counter(group["agencies"]).most_common(1)[0][0] if group["agencies"] else None),
+                "current_stage": _current_stage_from_events(events),
+                "stage_events_json": canonical_json(events),
+                "fr_document_numbers_json": canonical_json(sorted(group["fr_documents"])),
+                "cfr_refs_json": canonical_json(sorted(group["cfr_refs"])),
+                "cfr_target_iris_json": canonical_json(sorted(group["cfr_target_iris"])),
+                # Unified Agenda authority belongs to the editioned agenda
+                # observation and is never fanned out to an action.
+                "authority_refs_json": "[]",
+                "identity_predecessors_json": canonical_json(predecessors),
+                **{
+                    **provenance,
+                    "supersedes_id": (proceeding_id if proceeding_id in matched_predecessors else None),
+                },
+            }
+        )
+
+    rows.sort(key=lambda row: row["proceeding_id"])
+    out_file = write_parquet_rows(output_dir / OUTPUT, columns=COLUMNS, rows=rows)
+    json_stats.log("proceedings")
+    logger.info(
+        "Proceedings: {:,} rows ({:,} multi-docket; {:,} FR-only; {:,} with one action-evidenced RIN)",
+        len(rows),
+        sum(len(json.loads(row["docket_ids_json"])) > 1 for row in rows),
+        sum(row["docket_ids_json"] == "[]" for row in rows),
+        sum(row["rin"] is not None for row in rows),
+    )
+    assert pq.ParquetFile(out_file).schema_arrow.names == list(COLUMNS)
+    return out_file

--- a/src/spicy_regs/transforms/build_regulatory_agenda.py
+++ b/src/spicy_regs/transforms/build_regulatory_agenda.py
@@ -1,0 +1,364 @@
+"""Transform: materialize durable agenda items and qualified action links."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+from urllib.parse import quote
+
+import pyarrow.parquet as pq
+from loguru import logger
+
+from spicy_regs.ontology.citations import normalize_regsgov_identifier, normalize_rin
+from spicy_regs.ontology.common import (
+    ATTESTATION_COLUMNS,
+    JsonReadStats,
+    RunContext,
+    iter_parquet_rows,
+    parse_json_list,
+    stable_id,
+    write_parquet_rows,
+)
+
+ITEMS_OUTPUT = "regulatory_agenda_items.parquet"
+RELATIONSHIPS_OUTPUT = "agenda_item_proceedings.parquet"
+ITEM_ACTOR_ID = "spicy-regs:regulatory-agenda-items:v1"
+RELATIONSHIP_ACTOR_ID = "spicy-regs:agenda-item-proceedings:v1"
+
+ITEM_COLUMNS = (
+    "agenda_item_id",
+    "rin",
+    "scope_status",
+    "scope_basis",
+    "linked_proceeding_count",
+    "observation_count",
+    "latest_agenda_edition",
+    "first_seen",
+    "last_seen",
+    *ATTESTATION_COLUMNS,
+)
+
+RELATIONSHIP_COLUMNS = (
+    "relationship_id",
+    "agenda_item_id",
+    "rin",
+    "proceeding_id",
+    "relationship_role",
+    "source",
+    "evidence_id",
+    "evidence_uri",
+    "evidence_date",
+    *ATTESTATION_COLUMNS,
+)
+
+SOURCES = frozenset({"docket_rin", "document_rin", "federal_register_rin"})
+SCOPE_STATUSES = frozenset({"recurring", "single_observed", "unresolved"})
+
+
+def _agenda_date(edition: object) -> str | None:
+    text = str(edition or "").strip()
+    if re.fullmatch(r"\d{6}", text) and 1 <= int(text[4:]) <= 12:
+        return f"{text[:4]}-{text[4:]}-01"
+    return None
+
+
+def _source_date(*values: object) -> str | None:
+    dates = sorted(str(value)[:10] for value in values if value)
+    return dates[-1] if dates else None
+
+
+def _agenda_item_id(rin: str) -> str:
+    return f"urn:rkaf:us:rin:{rin}"
+
+
+def _source_uri(source: str, evidence_id: str) -> str:
+    escaped = quote(evidence_id, safe="-._~")
+    if source == "docket_rin":
+        return f"https://www.regulations.gov/docket/{escaped}"
+    if source == "document_rin":
+        return f"https://www.regulations.gov/document/{escaped}"
+    if source == "federal_register_rin":
+        return f"https://www.federalregister.gov/d/{escaped}"
+    raise ValueError(f"unknown agenda relationship evidence source: {source}")
+
+
+def _require_inputs(output_dir: Path, names: tuple[str, ...]) -> dict[str, Path]:
+    paths = {name: output_dir / f"{name}.parquet" for name in names}
+    missing = [path.name for path in paths.values() if not path.exists()]
+    if missing:
+        raise FileNotFoundError(f"regulatory agenda inputs missing from {output_dir}: {', '.join(missing)}")
+    return paths
+
+
+def build_regulatory_agenda(
+    output_dir: Path,
+    *,
+    run_id: str | None = None,
+    asserted_at: str | None = None,
+) -> tuple[Path, Path]:
+    """Build one agenda item per RIN and provenance-bearing action links.
+
+    Unified Agenda equality creates the item and its editioned observations,
+    but never an action relationship. Only a docket, regulations.gov document,
+    or Federal Register artifact that directly reports the RIN can link the
+    agenda item to an independently assembled Proceeding.
+    """
+    paths = _require_inputs(
+        output_dir,
+        (
+            "dockets",
+            "documents",
+            "federal_register",
+            "unified_agenda",
+            "proceedings",
+        ),
+    )
+    context = RunContext.resolve(
+        run_id=run_id,
+        asserted_at=asserted_at,
+        prefix="regulatory-agenda",
+    )
+    item_provenance = context.provenance(
+        method="deterministic",
+        actor_id=ITEM_ACTOR_ID,
+    )
+    relationship_provenance = context.provenance(
+        method="deterministic",
+        actor_id=RELATIONSHIP_ACTOR_ID,
+    )
+    json_stats = JsonReadStats()
+
+    proceedings_by_docket: dict[str, set[str]] = defaultdict(set)
+    proceedings_by_fr_document: dict[str, set[str]] = defaultdict(set)
+    for row in iter_parquet_rows(paths["proceedings"]):
+        proceeding_id = str(row.get("proceeding_id") or "").strip()
+        if not proceeding_id:
+            continue
+        dockets = parse_json_list(
+            row.get("docket_ids_json"),
+            stats=json_stats,
+            table="proceedings",
+            row_id=proceeding_id,
+            column="docket_ids_json",
+        )
+        if dockets is not None:
+            for value in dockets:
+                if docket := normalize_regsgov_identifier(value):
+                    proceedings_by_docket[docket].add(proceeding_id)
+        fr_documents = parse_json_list(
+            row.get("fr_document_numbers_json"),
+            stats=json_stats,
+            table="proceedings",
+            row_id=proceeding_id,
+            column="fr_document_numbers_json",
+        )
+        if fr_documents is not None:
+            for value in fr_documents:
+                proceedings_by_fr_document[str(value)].add(proceeding_id)
+
+    observed_rins: set[str] = set()
+    seen_dates: dict[str, set[str]] = defaultdict(set)
+    observation_keys: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    latest_agenda: dict[str, dict] = {}
+    relationships: dict[tuple[str, str, str, str], dict] = {}
+
+    def observe(rin: str, *dates: object) -> None:
+        observed_rins.add(rin)
+        seen_dates[rin].update(str(value)[:10] for value in dates if value)
+
+    def add_relationship(
+        *,
+        rin: str,
+        proceeding_id: str,
+        source: str,
+        evidence_id: object,
+        evidence_date: object,
+    ) -> None:
+        evidence = str(evidence_id or "").strip()
+        if source not in SOURCES or not evidence or not proceeding_id:
+            return
+        key = (rin, proceeding_id, source, evidence)
+        date = _source_date(evidence_date)
+        relationships.setdefault(
+            key,
+            {
+                "relationship_id": stable_id(
+                    "agenda_proceeding_relationship",
+                    *key,
+                ),
+                "agenda_item_id": _agenda_item_id(rin),
+                "rin": rin,
+                "proceeding_id": proceeding_id,
+                "relationship_role": "agenda_tracks_proceeding",
+                "source": source,
+                "evidence_id": evidence,
+                "evidence_uri": _source_uri(source, evidence),
+                "evidence_date": date,
+                **relationship_provenance,
+            },
+        )
+        if date:
+            seen_dates[rin].add(date)
+
+    for row in iter_parquet_rows(paths["dockets"]):
+        rin = normalize_rin(row.get("rin"))
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        if not rin:
+            continue
+        observe(rin, row.get("modify_date"))
+        if docket is None:
+            continue
+        targets = proceedings_by_docket.get(docket, set())
+        if len(targets) == 1:
+            add_relationship(
+                rin=rin,
+                proceeding_id=next(iter(targets)),
+                source="docket_rin",
+                evidence_id=docket,
+                evidence_date=row.get("modify_date"),
+            )
+
+    for row in iter_parquet_rows(paths["documents"]):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        raw_rins = parse_json_list(
+            row.get("additional_rins"),
+            stats=json_stats,
+            table="documents",
+            row_id=row.get("document_id"),
+            column="additional_rins",
+        )
+        if raw_rins is None:
+            continue
+        for value in raw_rins:
+            rin = normalize_rin(value)
+            if not rin:
+                continue
+            evidence_date = _source_date(
+                row.get("modify_date"),
+                row.get("posted_date"),
+            )
+            observe(rin, evidence_date)
+            if docket is None:
+                continue
+            targets = proceedings_by_docket.get(docket, set())
+            if len(targets) == 1:
+                add_relationship(
+                    rin=rin,
+                    proceeding_id=next(iter(targets)),
+                    source="document_rin",
+                    evidence_id=row.get("document_id"),
+                    evidence_date=evidence_date,
+                )
+
+    for row in iter_parquet_rows(paths["federal_register"]):
+        document_number = str(row.get("document_number") or "").strip()
+        raw_rins = parse_json_list(
+            row.get("regulation_id_numbers_json"),
+            stats=json_stats,
+            table="federal_register",
+            row_id=document_number,
+            column="regulation_id_numbers_json",
+        )
+        if raw_rins is None:
+            continue
+        for value in raw_rins:
+            rin = normalize_rin(value)
+            if not rin:
+                continue
+            observe(rin, row.get("publication_date"))
+            targets = proceedings_by_fr_document.get(document_number, set())
+            if len(targets) == 1:
+                add_relationship(
+                    rin=rin,
+                    proceeding_id=next(iter(targets)),
+                    source="federal_register_rin",
+                    evidence_id=document_number,
+                    evidence_date=row.get("publication_date"),
+                )
+
+    for row in iter_parquet_rows(paths["unified_agenda"]):
+        rin = normalize_rin(row.get("rin"))
+        if not rin:
+            continue
+        edition = str(row.get("agenda_edition") or "").strip()
+        url = str(row.get("url") or "").strip()
+        edition_date = _agenda_date(edition)
+        observe(
+            rin,
+            edition_date,
+            row.get("first_action_date"),
+            row.get("next_action_date"),
+        )
+        observation_keys[rin].add((edition, url))
+        if rin not in latest_agenda or edition > str(latest_agenda[rin].get("agenda_edition") or ""):
+            latest_agenda[rin] = row
+
+    linked_proceedings: dict[str, set[str]] = defaultdict(set)
+    for row in relationships.values():
+        linked_proceedings[row["rin"]].add(row["proceeding_id"])
+
+    item_rows: list[dict] = []
+    for rin in sorted(observed_rins):
+        linked_count = len(linked_proceedings.get(rin, ()))
+        latest = latest_agenda.get(rin, {})
+        priority = " ".join(str(latest.get("priority_category") or "").casefold().split())
+        if priority == "routine and frequent":
+            scope_status = "recurring"
+            scope_basis = "latest_agenda_priority_routine_and_frequent"
+        elif linked_count == 1:
+            scope_status = "single_observed"
+            scope_basis = "one_evidence_linked_proceeding"
+        elif linked_count == 0:
+            scope_status = "unresolved"
+            scope_basis = "zero_evidence_linked_proceedings"
+        else:
+            scope_status = "unresolved"
+            scope_basis = "multiple_evidence_linked_proceedings"
+        dates = sorted(seen_dates.get(rin, ()))
+        item_rows.append(
+            {
+                "agenda_item_id": _agenda_item_id(rin),
+                "rin": rin,
+                "scope_status": scope_status,
+                "scope_basis": scope_basis,
+                "linked_proceeding_count": str(linked_count),
+                "observation_count": str(len(observation_keys.get(rin, ()))),
+                "latest_agenda_edition": latest.get("agenda_edition"),
+                "first_seen": dates[0] if dates else None,
+                "last_seen": dates[-1] if dates else None,
+                **item_provenance,
+            }
+        )
+
+    relationship_rows = sorted(
+        relationships.values(),
+        key=lambda row: (
+            row["rin"],
+            row["proceeding_id"],
+            row["source"],
+            row["evidence_id"],
+        ),
+    )
+    items_file = write_parquet_rows(
+        output_dir / ITEMS_OUTPUT,
+        columns=ITEM_COLUMNS,
+        rows=item_rows,
+    )
+    relationships_file = write_parquet_rows(
+        output_dir / RELATIONSHIPS_OUTPUT,
+        columns=RELATIONSHIP_COLUMNS,
+        rows=relationship_rows,
+    )
+    json_stats.log("regulatory_agenda")
+    logger.info(
+        "Regulatory agenda: {:,} items ({:,} recurring; {:,} unresolved), {:,} action relationships",
+        len(item_rows),
+        sum(row["scope_status"] == "recurring" for row in item_rows),
+        sum(row["scope_status"] == "unresolved" for row in item_rows),
+        len(relationship_rows),
+    )
+    assert pq.ParquetFile(items_file).schema_arrow.names == list(ITEM_COLUMNS)
+    assert pq.ParquetFile(relationships_file).schema_arrow.names == list(RELATIONSHIP_COLUMNS)
+    assert all(row["scope_status"] in SCOPE_STATUSES for row in item_rows)
+    return items_file, relationships_file

--- a/src/spicy_regs/transforms/build_rule_targets.py
+++ b/src/spicy_regs/transforms/build_rule_targets.py
@@ -1,0 +1,260 @@
+"""Transform: build the normalized docket ↔ CFR ↔ RIN rule-identity spine."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+import pyarrow.parquet as pq
+from loguru import logger
+
+from spicy_regs.ontology.citations import (
+    CfrCitation,
+    normalize_regsgov_identifier,
+    normalize_rin,
+    parse_cfr_citation,
+)
+from spicy_regs.ontology.common import (
+    ATTESTATION_COLUMNS,
+    JsonReadStats,
+    RunContext,
+    iter_parquet_rows,
+    parse_json_list,
+    write_parquet_rows,
+)
+
+OUTPUT = "rule_targets.parquet"
+ACTOR_ID = "spicy-regs:rule-targets:v1"
+
+COLUMNS = (
+    "docket_id",
+    "cfr_ref",
+    "cfr_title",
+    "cfr_part",
+    "cfr_section",
+    "rin",
+    "source",
+    "evidence_id",
+    "first_seen",
+    "last_seen",
+    *ATTESTATION_COLUMNS,
+)
+
+SOURCES = frozenset(
+    {
+        "fr_cfr_ref",
+        "docket_rin",
+        "document_rin",
+        "document_fr_doc",
+    }
+)
+
+
+def _date_bounds(*values: object) -> tuple[str | None, str | None]:
+    dates = sorted(str(value) for value in values if value)
+    return (dates[0], dates[-1]) if dates else (None, None)
+
+
+def _require_inputs(output_dir: Path, names: tuple[str, ...]) -> dict[str, Path]:
+    paths = {name: output_dir / f"{name}.parquet" for name in names}
+    missing = [path.name for path in paths.values() if not path.exists()]
+    if missing:
+        raise FileNotFoundError(f"rule_targets inputs missing from {output_dir}: {', '.join(missing)}")
+    return paths
+
+
+def build_rule_targets(
+    output_dir: Path,
+    *,
+    run_id: str | None = None,
+    asserted_at: str | None = None,
+) -> Path:
+    """Build action-specific docket-to-RIN and docket-to-CFR evidence.
+
+    Unified Agenda values describe an editioned observation of a durable
+    agenda item. They are deliberately absent here: equality on a RIN does not
+    authorize projecting an agenda-level CFR reference onto every docket that
+    happens to carry that RIN.
+    """
+    paths = _require_inputs(
+        output_dir,
+        ("dockets", "documents", "federal_register", "fr_docket_links"),
+    )
+    context = RunContext.resolve(run_id=run_id, asserted_at=asserted_at, prefix="rule-targets")
+    provenance = context.provenance(method="deterministic", actor_id=ACTOR_ID)
+    json_stats = JsonReadStats()
+
+    # The table's specified logical key deliberately retains corroborating
+    # sources while folding repeated evidence from the same source into a date
+    # span. ``evidence_id`` remains one concrete (lexicographically stable)
+    # source row that can be inspected.
+    edges: dict[tuple[str, str | None, str | None, str], dict] = {}
+    trusted_dockets: set[str] = set()
+
+    def add_edge(
+        *,
+        docket_id: object,
+        citation: CfrCitation | None,
+        rin: object,
+        source: str,
+        evidence_id: object,
+        first_seen: object = None,
+        last_seen: object = None,
+    ) -> None:
+        docket = normalize_regsgov_identifier(docket_id)
+        if docket is None or docket not in trusted_dockets or source not in SOURCES:
+            return
+        normalized_rin = normalize_rin(rin)
+        cfr_ref = citation.cfr_ref if citation else None
+        key = (docket, cfr_ref, normalized_rin, source)
+        first, last = _date_bounds(first_seen, last_seen)
+        candidate = {
+            "docket_id": docket,
+            "cfr_ref": cfr_ref,
+            "cfr_title": citation.title if citation else None,
+            "cfr_part": citation.part if citation else None,
+            "cfr_section": citation.section if citation else None,
+            "rin": normalized_rin,
+            "source": source,
+            "evidence_id": None if evidence_id is None else str(evidence_id),
+            "first_seen": first,
+            "last_seen": last,
+            **provenance,
+        }
+        existing = edges.get(key)
+        if existing is None:
+            edges[key] = candidate
+            return
+        existing["first_seen"], existing["last_seen"] = _date_bounds(
+            existing.get("first_seen"),
+            existing.get("last_seen"),
+            first,
+            last,
+        )
+        evidence = sorted(value for value in (existing.get("evidence_id"), candidate.get("evidence_id")) if value)
+        existing["evidence_id"] = evidence[0] if evidence else None
+
+    for row in iter_parquet_rows(paths["dockets"]):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        if docket is None:
+            continue
+        trusted_dockets.add(docket)
+        rin = normalize_rin(row.get("rin"))
+        if rin:
+            add_edge(
+                docket_id=docket,
+                citation=None,
+                rin=rin,
+                source="docket_rin",
+                evidence_id=docket,
+                first_seen=row.get("modify_date"),
+                last_seen=row.get("modify_date"),
+            )
+
+    documents_by_fr_doc: dict[str, list[dict]] = defaultdict(list)
+    for row in iter_parquet_rows(paths["documents"]):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        if docket is not None:
+            # Documents are themselves sourced from Regulations.gov. They can
+            # legitimately arrive before the corresponding docket record.
+            trusted_dockets.add(docket)
+        document_id = row.get("document_id")
+        raw_rins = parse_json_list(
+            row.get("additional_rins"),
+            stats=json_stats,
+            table="documents",
+            row_id=document_id,
+            column="additional_rins",
+        )
+        if raw_rins is not None:
+            for raw_rin in raw_rins:
+                rin = normalize_rin(raw_rin)
+                if docket is None or not rin:
+                    continue
+                add_edge(
+                    docket_id=docket,
+                    citation=None,
+                    rin=rin,
+                    source="document_rin",
+                    evidence_id=document_id,
+                    first_seen=row.get("posted_date"),
+                    last_seen=row.get("modify_date") or row.get("posted_date"),
+                )
+        fr_doc_num = row.get("fr_doc_num")
+        if fr_doc_num and docket is not None:
+            documents_by_fr_doc[str(fr_doc_num)].append({**row, "docket_id": docket})
+
+    linked_dockets_by_fr_doc: dict[str, set[str]] = defaultdict(set)
+    for row in iter_parquet_rows(paths["fr_docket_links"], columns=("document_number", "docket_id")):
+        docket = normalize_regsgov_identifier(row.get("docket_id"))
+        if row.get("document_number") and docket in trusted_dockets:
+            linked_dockets_by_fr_doc[str(row["document_number"])].add(docket)
+
+    for row in iter_parquet_rows(paths["federal_register"]):
+        document_number = row.get("document_number")
+        if not document_number:
+            continue
+        raw_cfr = parse_json_list(
+            row.get("cfr_references_json"),
+            stats=json_stats,
+            table="federal_register",
+            row_id=document_number,
+            column="cfr_references_json",
+        )
+        raw_rins = parse_json_list(
+            row.get("regulation_id_numbers_json"),
+            stats=json_stats,
+            table="federal_register",
+            row_id=document_number,
+            column="regulation_id_numbers_json",
+        )
+        if raw_cfr is None or raw_rins is None:
+            continue
+        citations = [citation for raw in raw_cfr for citation in parse_cfr_citation(raw)]
+        citations = list(dict.fromkeys(citations))
+        rins = list(dict.fromkeys(rin for value in raw_rins if (rin := normalize_rin(value))))
+        publication_date = row.get("publication_date")
+
+        linked_dockets = linked_dockets_by_fr_doc.get(str(document_number), set())
+        for docket in linked_dockets:
+            for citation in citations:
+                for rin in rins or (None,):
+                    add_edge(
+                        docket_id=docket,
+                        citation=citation,
+                        rin=rin,
+                        source="fr_cfr_ref",
+                        evidence_id=document_number,
+                        first_seen=publication_date,
+                        last_seen=publication_date,
+                    )
+
+        # A regulations.gov document's frDocNum is independent corroboration of
+        # the same target, so it intentionally receives a different source value.
+        for document in documents_by_fr_doc.get(str(document_number), ()):
+            for citation in citations or (None,):
+                for rin in rins or (None,):
+                    add_edge(
+                        docket_id=document.get("docket_id"),
+                        citation=citation,
+                        rin=rin,
+                        source="document_fr_doc",
+                        evidence_id=document.get("document_id"),
+                        first_seen=document.get("posted_date") or publication_date,
+                        last_seen=document.get("modify_date") or publication_date,
+                    )
+
+    rows = sorted(
+        edges.values(),
+        key=lambda row: (
+            row["docket_id"] or "",
+            row["cfr_ref"] or "",
+            row["rin"] or "",
+            row["source"] or "",
+        ),
+    )
+    out_file = write_parquet_rows(output_dir / OUTPUT, columns=COLUMNS, rows=rows)
+    json_stats.log("rule_targets")
+    logger.info("Rule targets: {:,} rows across {:,} dockets", len(rows), len({r["docket_id"] for r in rows}))
+    assert pq.ParquetFile(out_file).schema_arrow.names == list(COLUMNS)
+    return out_file

--- a/tests/test_materialized_pipeline.py
+++ b/tests/test_materialized_pipeline.py
@@ -1,0 +1,656 @@
+"""Materialized-dataset DAG and atomic-publication contract tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from spicy_regs.ontology.common import RunContext
+from spicy_regs.pipelines.materialized import DatasetStage, MaterializedDatasetPipeline
+from spicy_regs.sources import r2
+
+
+def _write_parquet(path: Path, values: list[str]) -> None:
+    pq.write_table(pa.table({"value": values}), path)
+
+
+def _emit_two_tables(output_dir: Path, _context: RunContext) -> None:
+    pq.write_table(pa.table({"a": [1]}), output_dir / "public.parquet")
+    pq.write_table(pa.table({"a": [2]}), output_dir / "private.parquet")
+
+
+def test_materialized_stages_are_topologically_ordered(tmp_path) -> None:
+    calls: list[str] = []
+
+    def source(output_dir: Path, context: RunContext) -> None:
+        calls.append(f"source:{context.run_id}")
+        _write_parquet(output_dir / "source.parquet", ["source"])
+
+    def derived(output_dir: Path, context: RunContext) -> None:
+        calls.append(f"derived:{context.run_id}")
+        assert (output_dir / "source.parquet").exists()
+        _write_parquet(output_dir / "derived.parquet", ["derived"])
+
+    class ExampleDataset(MaterializedDatasetPipeline):
+        name = "example-dataset"
+        dataset_name = "example"
+        published_outputs = ("derived.parquet",)
+
+        def stages(self):
+            # Intentionally declared in reverse order: the DAG owns execution.
+            return (
+                DatasetStage("derived", ("source",), ("derived.parquet",), derived),
+                DatasetStage("source", (), ("source.parquet",), source),
+            )
+
+    ExampleDataset(
+        output_dir=tmp_path,
+        run_id="dag-test",
+        asserted_at="2026-07-23T12:00:00Z",
+    ).run()
+
+    assert calls == ["source:dag-test", "derived:dag-test"]
+    manifest = json.loads((tmp_path / "example-dataset-manifest.json").read_text())
+    assert [stage["name"] for stage in manifest["stages"]] == ["source", "derived"]
+    assert manifest["artifacts"]["derived.parquet"]["sha256"]
+    assert manifest["artifacts"]["derived.parquet"]["rows"] == 1
+
+
+def test_materialized_stage_cycle_fails_before_build(tmp_path) -> None:
+    class CyclicDataset(MaterializedDatasetPipeline):
+        name = "cyclic-dataset"
+        dataset_name = "cyclic"
+        published_outputs = ("a.parquet",)
+
+        def stages(self):
+            def noop(output_dir, context):
+                del output_dir, context
+
+            return (
+                DatasetStage("a", ("b",), ("a.parquet",), noop),
+                DatasetStage("b", ("a",), ("b.parquet",), noop),
+            )
+
+    with pytest.raises(RuntimeError, match="stage cycle"):
+        CyclicDataset(output_dir=tmp_path).run()
+
+
+def test_materialized_publication_commits_pointer_last(tmp_path, monkeypatch) -> None:
+    def build(output_dir: Path, context: RunContext) -> None:
+        del context
+        _write_parquet(output_dir / "one.parquet", ["one"])
+        _write_parquet(output_dir / "two.parquet", ["two"])
+
+    class PublishedDataset(MaterializedDatasetPipeline):
+        name = "published-dataset"
+        dataset_name = "published"
+        published_outputs = ("one.parquet", "two.parquet")
+
+        def stages(self):
+            return (
+                DatasetStage(
+                    "build",
+                    (),
+                    ("one.parquet", "two.parquet"),
+                    build,
+                ),
+            )
+
+    uploads: list[str] = []
+
+    def record_upload(path, remote_key=None):
+        assert path.exists()
+        uploads.append(remote_key or path.name)
+
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setenv("R2_ENDPOINT", "https://test.r2.example")
+    monkeypatch.setattr(r2, "upload_file", record_upload)
+    PublishedDataset(
+        output_dir=tmp_path,
+        skip_upload=False,
+        run_id="publish-test",
+        asserted_at="2026-07-23T12:00:00Z",
+    ).run()
+
+    assert uploads[-1] == "materialized/published/latest.json"
+    assert uploads[-2].endswith("/manifest.json")
+    assert uploads[0].endswith("/one.parquet")
+    assert uploads[1].endswith("/two.parquet")
+    snapshot_prefixes = {key.rsplit("/", 1)[0] for key in uploads[:-1]}
+    assert len(snapshot_prefixes) == 1
+
+
+def test_internal_artifact_is_generation_bound_but_not_public(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    def build(output_dir: Path, context: RunContext) -> None:
+        del context
+        _write_parquet(output_dir / "public.parquet", ["public"])
+        _write_parquet(output_dir / "internal.parquet", ["internal"])
+
+    class InternalDataset(MaterializedDatasetPipeline):
+        name = "internal-dataset"
+        dataset_name = "internal"
+        published_outputs = ("public.parquet",)
+        internal_outputs = ("internal.parquet",)
+
+        def stages(self):
+            return (
+                DatasetStage(
+                    "build",
+                    (),
+                    ("public.parquet", "internal.parquet"),
+                    build,
+                ),
+            )
+
+    uploads: list[str] = []
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setenv("R2_ENDPOINT", "https://test.r2.example")
+    monkeypatch.setattr(
+        r2,
+        "upload_file",
+        lambda path, remote_key=None: uploads.append(str(remote_key or path.name)),
+    )
+
+    InternalDataset(
+        output_dir=tmp_path,
+        skip_upload=False,
+        run_id="internal-test",
+        asserted_at="2026-07-24T12:00:00Z",
+    ).run()
+
+    manifest = json.loads((tmp_path / "internal-dataset-manifest.json").read_text())
+    assert InternalDataset.published_outputs == ("public.parquet",)
+    assert set(InternalDataset.generation_outputs()) == {
+        "public.parquet",
+        "internal.parquet",
+    }
+    assert manifest["artifacts"]["public.parquet"]["visibility"] == ("public")
+    assert manifest["artifacts"]["internal.parquet"]["visibility"] == ("internal")
+    assert any(key.endswith("/internal.parquet") for key in uploads)
+
+
+def test_materialized_publication_validates_before_first_upload(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    def build(output_dir: Path, context: RunContext) -> None:
+        del context
+        _write_parquet(output_dir / "result.parquet", ["result"])
+
+    class ValidatedDataset(MaterializedDatasetPipeline):
+        name = "validated-dataset"
+        dataset_name = "validated"
+        published_outputs = ("result.parquet",)
+
+        def stages(self):
+            return (
+                DatasetStage(
+                    "build",
+                    (),
+                    ("result.parquet",),
+                    build,
+                ),
+            )
+
+        def validate_before_publish(self, manifest_path: Path) -> None:
+            assert manifest_path.exists()
+            raise RuntimeError("semantic gate failed")
+
+    uploads: list[Path] = []
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test-key")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test-secret")
+    monkeypatch.setenv("R2_ENDPOINT", "https://test.r2.example")
+    monkeypatch.setattr(
+        r2,
+        "upload_file",
+        lambda path, remote_key=None: uploads.append(path),
+    )
+
+    with pytest.raises(RuntimeError, match="semantic gate failed"):
+        ValidatedDataset(output_dir=tmp_path, skip_upload=False).run()
+
+    assert uploads == []
+
+
+def test_local_publication_runs_the_semantic_gate_in_position(tmp_path) -> None:
+    """A skip-upload run must execute validate_before_publish, not bypass it."""
+
+    def build(output_dir: Path, context: RunContext) -> None:
+        del context
+        _write_parquet(output_dir / "result.parquet", ["result"])
+
+    gate_calls: list[Path] = []
+
+    class LocallyValidatedDataset(MaterializedDatasetPipeline):
+        name = "locally-validated-dataset"
+        dataset_name = "locally-validated"
+        published_outputs = ("result.parquet",)
+
+        def stages(self):
+            return (
+                DatasetStage(
+                    "build",
+                    (),
+                    ("result.parquet",),
+                    build,
+                ),
+            )
+
+        def validate_before_publish(self, manifest_path: Path) -> None:
+            assert manifest_path.exists()
+            gate_calls.append(manifest_path)
+
+    LocallyValidatedDataset(output_dir=tmp_path, skip_upload=True).run()
+    assert len(gate_calls) == 1
+
+    class LocallyFailingDataset(LocallyValidatedDataset):
+        name = "locally-failing-dataset"
+        dataset_name = "locally-failing"
+
+        def validate_before_publish(self, manifest_path: Path) -> None:
+            raise RuntimeError("semantic gate failed locally")
+
+    with pytest.raises(RuntimeError, match="semantic gate failed locally"):
+        LocallyFailingDataset(output_dir=tmp_path / "failing", skip_upload=True).run()
+
+
+def test_materialized_publication_requires_complete_r2_configuration(tmp_path, monkeypatch) -> None:
+    class PublishedDataset(MaterializedDatasetPipeline):
+        name = "published-dataset"
+        dataset_name = "published"
+
+        def stages(self):
+            return ()
+
+    for name in (
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+        "R2_ENDPOINT",
+        "R2_PUBLIC_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(RuntimeError, match="missing R2 configuration"):
+        PublishedDataset(output_dir=tmp_path, skip_upload=False).run()
+
+
+def test_publishing_refreshes_existing_local_source(tmp_path, monkeypatch) -> None:
+    class SourceDataset(MaterializedDatasetPipeline):
+        name = "source-dataset"
+        dataset_name = "source"
+        source_inputs = ("source.parquet",)
+
+        def stages(self):
+            return ()
+
+    source = tmp_path / "source.parquet"
+    source.write_bytes(b"stale")
+    downloads: list[str] = []
+
+    def download(remote_key, local_path):
+        downloads.append(remote_key)
+        local_path.write_bytes(b"remote")
+        return True
+
+    monkeypatch.setattr(r2, "download", download)
+    SourceDataset(output_dir=tmp_path, skip_upload=False)._prime_sources(tmp_path)
+
+    assert downloads == ["source.parquet"]
+    assert source.read_bytes() == b"remote"
+
+
+def test_dry_run_may_reuse_existing_local_source(tmp_path, monkeypatch) -> None:
+    class SourceDataset(MaterializedDatasetPipeline):
+        name = "source-dataset"
+        dataset_name = "source"
+        source_inputs = ("source.parquet",)
+
+        def stages(self):
+            return ()
+
+    source = tmp_path / "source.parquet"
+    source.write_bytes(b"fixture")
+
+    def unexpected_download(remote_key, local_path):
+        pytest.fail(f"unexpected download of {remote_key} to {local_path}")
+
+    monkeypatch.setattr(r2, "download", unexpected_download)
+    SourceDataset(output_dir=tmp_path)._prime_sources(tmp_path)
+
+    assert source.read_bytes() == b"fixture"
+
+
+def test_materialized_source_schema_must_include_declared_columns(tmp_path) -> None:
+    class SourceDataset(MaterializedDatasetPipeline):
+        name = "source-dataset"
+        dataset_name = "source"
+        source_inputs = ("source.parquet",)
+
+        def stages(self):
+            return ()
+
+        def source_column_requirements(self):
+            return {"source.parquet": ("id", "required_value")}
+
+    pq.write_table(
+        pa.table({"id": ["one"]}),
+        tmp_path / "source.parquet",
+    )
+
+    with pytest.raises(RuntimeError, match="required_value"):
+        SourceDataset(output_dir=tmp_path)._validate_source_schemas(tmp_path)
+
+
+def test_snapshot_id_changes_when_artifact_bytes_change(tmp_path) -> None:
+    payload = ["first"]
+
+    def build(output_dir: Path, context: RunContext) -> None:
+        del context
+        _write_parquet(output_dir / "result.parquet", [payload[0]])
+
+    class ContentAddressedDataset(MaterializedDatasetPipeline):
+        name = "content-addressed-dataset"
+        dataset_name = "content-addressed"
+        published_outputs = ("result.parquet",)
+
+        def stages(self):
+            return (DatasetStage("build", (), ("result.parquet",), build),)
+
+    pipeline = ContentAddressedDataset(
+        output_dir=tmp_path,
+        run_id="same-run",
+        asserted_at="2026-07-23T12:00:00Z",
+    )
+    pipeline.run()
+    first = json.loads((tmp_path / "content-addressed-dataset-manifest.json").read_text())["snapshot_id"]
+
+    payload[0] = "second"
+    pipeline.run()
+    second = json.loads((tmp_path / "content-addressed-dataset-manifest.json").read_text())["snapshot_id"]
+
+    assert second != first
+
+
+def test_unknown_materialized_dependency_is_rejected() -> None:
+    stage = DatasetStage(
+        "known",
+        ("missing",),
+        ("known.parquet",),
+        lambda output_dir, context: None,
+    )
+    with pytest.raises(RuntimeError, match="unknown stage dependencies"):
+        MaterializedDatasetPipeline._ordered_stages((stage,))
+
+
+def test_prior_generation_artifact_hash_is_verified(tmp_path) -> None:
+    class StatefulDataset(MaterializedDatasetPipeline):
+        name = "stateful-dataset"
+        dataset_name = "stateful"
+        prior_outputs = (("state.parquet", "_state_prior.parquet"),)
+
+        def stages(self):
+            return ()
+
+    snapshot_id = "snapshot_prior"
+    prefix = f"materialized/stateful/snapshots/{snapshot_id}"
+    (tmp_path / "_stateful_latest.json").write_text(
+        json.dumps(
+            {
+                "format_version": 1,
+                "dataset": "stateful",
+                "snapshot_id": snapshot_id,
+                "manifest_key": f"{prefix}/manifest.json",
+            }
+        )
+    )
+    prior = tmp_path / "_state_prior.parquet"
+    prior.write_bytes(b"prior-state")
+    (tmp_path / "_stateful_previous_manifest.json").write_text(
+        json.dumps(
+            {
+                "format_version": 1,
+                "dataset": "stateful",
+                "snapshot_id": snapshot_id,
+                "artifacts": {
+                    "state.parquet": {
+                        "remote_key": f"{prefix}/state.parquet",
+                        "sha256": hashlib.sha256(b"different-state").hexdigest(),
+                    }
+                },
+            }
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="SHA-256"):
+        StatefulDataset(output_dir=tmp_path)._prime_previous_generation(tmp_path)
+    assert not prior.exists()
+
+
+def test_publishing_refreshes_cached_prior_generation(tmp_path, monkeypatch) -> None:
+    class StatefulDataset(MaterializedDatasetPipeline):
+        name = "stateful-dataset"
+        dataset_name = "stateful"
+        prior_outputs = (("state.parquet", "_state_prior.parquet"),)
+
+        def stages(self):
+            return ()
+
+    snapshot_id = "snapshot_remote"
+    prefix = f"materialized/stateful/snapshots/{snapshot_id}"
+    pointer_path = tmp_path / "_stateful_latest.json"
+    manifest_path = tmp_path / "_stateful_previous_manifest.json"
+    prior_path = tmp_path / "_state_prior.parquet"
+    pointer_path.write_text("{}")
+    manifest_path.write_text("{}")
+    prior_path.write_bytes(b"stale")
+    remote_prior = b"remote-prior"
+    downloads: list[str] = []
+
+    def download(remote_key, local_path):
+        downloads.append(remote_key)
+        if remote_key == "materialized/stateful/latest.json":
+            value = {
+                "format_version": 1,
+                "dataset": "stateful",
+                "snapshot_id": snapshot_id,
+                "manifest_key": f"{prefix}/manifest.json",
+            }
+            local_path.write_text(json.dumps(value))
+        elif remote_key == f"{prefix}/manifest.json":
+            value = {
+                "format_version": 1,
+                "dataset": "stateful",
+                "snapshot_id": snapshot_id,
+                "artifacts": {
+                    "state.parquet": {
+                        "remote_key": f"{prefix}/state.parquet",
+                        "sha256": hashlib.sha256(remote_prior).hexdigest(),
+                    }
+                },
+            }
+            local_path.write_text(json.dumps(value))
+        elif remote_key == f"{prefix}/state.parquet":
+            local_path.write_bytes(remote_prior)
+        else:
+            pytest.fail(f"unexpected download: {remote_key}")
+        return True
+
+    monkeypatch.setattr(r2, "download", download)
+    manifest = StatefulDataset(
+        output_dir=tmp_path,
+        skip_upload=False,
+    )._prime_previous_generation(tmp_path)
+
+    assert downloads == [
+        "materialized/stateful/latest.json",
+        f"{prefix}/manifest.json",
+        f"{prefix}/state.parquet",
+    ]
+    assert manifest is not None
+    assert manifest["snapshot_id"] == snapshot_id
+    assert prior_path.read_bytes() == remote_prior
+
+
+def test_publishing_discards_cached_prior_when_remote_has_none(tmp_path, monkeypatch) -> None:
+    class StatefulDataset(MaterializedDatasetPipeline):
+        name = "stateful-dataset"
+        dataset_name = "stateful"
+        prior_outputs = (("state.parquet", "_state_prior.parquet"),)
+
+        def stages(self):
+            return ()
+
+    pointer_path = tmp_path / "_stateful_latest.json"
+    manifest_path = tmp_path / "_stateful_previous_manifest.json"
+    prior_path = tmp_path / "_state_prior.parquet"
+    pointer_path.write_text("{}")
+    manifest_path.write_text("{}")
+    prior_path.write_bytes(b"stale")
+
+    monkeypatch.setattr(r2, "download", lambda remote_key, local_path: False)
+    manifest = StatefulDataset(
+        output_dir=tmp_path,
+        skip_upload=False,
+        allow_bootstrap=True,
+    )._prime_previous_generation(tmp_path)
+
+    assert manifest is None
+    assert not pointer_path.exists()
+    assert not manifest_path.exists()
+    assert not prior_path.exists()
+
+
+def test_publishing_refuses_implicit_state_reset(tmp_path, monkeypatch) -> None:
+    class StatefulDataset(MaterializedDatasetPipeline):
+        name = "stateful-dataset"
+        dataset_name = "stateful"
+        prior_outputs = (("state.parquet", "_state_prior.parquet"),)
+
+        def stages(self):
+            return ()
+
+    monkeypatch.setattr(r2, "download", lambda remote_key, local_path: False)
+
+    with pytest.raises(RuntimeError, match="refusing an implicit state reset"):
+        StatefulDataset(
+            output_dir=tmp_path,
+            skip_upload=False,
+        )._prime_previous_generation(tmp_path)
+
+
+# The snapshot schema version bump. Version 2 makes ``visibility`` required on
+# every artifact record; version 1 predates the field and stays readable, so a
+# dataset whose last generation was sealed at version 1 can still restore.
+
+
+def test_the_build_writes_the_current_snapshot_version_and_declares_visibility(tmp_path) -> None:
+    class VisibleDataset(MaterializedDatasetPipeline):
+        name = "visible-dataset"
+        dataset_name = "visible"
+        published_outputs = ("public.parquet",)
+        internal_outputs = ("private.parquet",)
+
+        def stages(self):
+            return (
+                DatasetStage(
+                    name="emit",
+                    depends_on=(),
+                    outputs=("public.parquet", "private.parquet"),
+                    build=_emit_two_tables,
+                ),
+            )
+
+    VisibleDataset(output_dir=tmp_path).run()
+
+    manifest = json.loads((tmp_path / "visible-dataset-manifest.json").read_text())
+    pointer = json.loads((tmp_path / "visible-dataset-latest.json").read_text())
+
+    assert manifest["format_version"] == 2
+    assert pointer["format_version"] == 2
+    assert manifest["artifacts"]["public.parquet"]["visibility"] == "public"
+    assert manifest["artifacts"]["private.parquet"]["visibility"] == "internal"
+    prefix = f"materialized/visible/snapshots/{manifest['snapshot_id']}/"
+    assert manifest["artifacts"]["public.parquet"]["remote_key"] == f"{prefix}public.parquet"
+
+
+def _stateful_generation(tmp_path, *, format_version: int, artifact: dict) -> tuple[type, Path]:
+    class StatefulDataset(MaterializedDatasetPipeline):
+        name = "stateful-dataset"
+        dataset_name = "stateful"
+        prior_outputs = (("state.parquet", "_state_prior.parquet"),)
+
+        def stages(self):
+            return ()
+
+    snapshot_id = "snapshot_versioned"
+    prefix = f"materialized/stateful/snapshots/{snapshot_id}"
+    (tmp_path / "_stateful_latest.json").write_text(
+        json.dumps(
+            {
+                "format_version": format_version,
+                "dataset": "stateful",
+                "snapshot_id": snapshot_id,
+                "manifest_key": f"{prefix}/manifest.json",
+            }
+        )
+    )
+    prior = tmp_path / "_state_prior.parquet"
+    prior.write_bytes(b"prior-state")
+    (tmp_path / "_stateful_previous_manifest.json").write_text(
+        json.dumps(
+            {
+                "format_version": format_version,
+                "dataset": "stateful",
+                "snapshot_id": snapshot_id,
+                "artifacts": {"state.parquet": {"remote_key": f"{prefix}/state.parquet", **artifact}},
+            }
+        )
+    )
+    return StatefulDataset, prior
+
+
+def test_a_version_2_generation_missing_visibility_is_refused(tmp_path) -> None:
+    dataset, _ = _stateful_generation(
+        tmp_path,
+        format_version=2,
+        artifact={"sha256": hashlib.sha256(b"prior-state").hexdigest()},
+    )
+
+    with pytest.raises(RuntimeError, match=r"format version 2 is missing \['visibility'\]"):
+        dataset(output_dir=tmp_path)._prime_previous_generation(tmp_path)
+
+
+def test_a_version_1_generation_restores_without_the_field(tmp_path) -> None:
+    """Restoring state from a generation sealed before the field existed."""
+    dataset, prior = _stateful_generation(
+        tmp_path,
+        format_version=1,
+        artifact={"sha256": hashlib.sha256(b"prior-state").hexdigest()},
+    )
+
+    manifest = dataset(output_dir=tmp_path)._prime_previous_generation(tmp_path)
+
+    assert manifest is not None
+    assert manifest["format_version"] == 1
+    assert prior.read_bytes() == b"prior-state"
+
+
+def test_a_generation_at_an_unknown_version_is_refused(tmp_path) -> None:
+    dataset, _ = _stateful_generation(
+        tmp_path,
+        format_version=99,
+        artifact={"sha256": hashlib.sha256(b"prior-state").hexdigest(), "visibility": "internal"},
+    )
+
+    with pytest.raises(RuntimeError, match="Unsupported stateful pointer snapshot format version 99"):
+        dataset(output_dir=tmp_path)._prime_previous_generation(tmp_path)

--- a/tests/test_ontology_citations.py
+++ b/tests/test_ontology_citations.py
@@ -1,0 +1,1072 @@
+"""Fixture coverage for CFR/U.S.C./Public-Law citation grammars."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from spicy_regs.ontology.citations import (
+    USC_CHAPTER_IDENTIFIER_SCHEME,
+    AuthorityCitation,
+    CfrCitation,
+    ExecutiveOrderCompilation,
+    UscChapterCitation,
+    canonical_cfr_iri,
+    canonical_frdoc_iri,
+    canonical_pl_iri,
+    canonical_regsgov_iri,
+    canonical_rin_iri,
+    canonical_usc_chapter_iri,
+    canonical_usc_iri,
+    docket_reference_as_stated,
+    federal_register_identifier,
+    find_act_relative_citations,
+    normalize_docket_id,
+    normalize_popular_name,
+    normalize_docket_reference,
+    normalize_regsgov_identifier,
+    normalize_rin,
+    parse_authority_citation,
+    parse_cfr_citation,
+    parse_eo_compilation_citation,
+    parse_usc_chapter_citation,
+    usc_section_covers,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ({"title": 40, "part": 60}, [CfrCitation("40", "60")]),
+        ({"title": "40", "part": "60", "section": "1"}, [CfrCitation("40", "60", "1")]),
+        ("40-60.1", [CfrCitation("40", "60", "1")]),
+        ("40-60.5375a", [CfrCitation("40", "60", "5375a")]),
+        ("40 C.F.R. § 60.5375a(a)(1)", [CfrCitation("40", "60", "5375a")]),
+        ("40 CFR 60", [CfrCitation("40", "60")]),
+        ("40 C.F.R. § 60.1", [CfrCitation("40", "60", "1")]),
+        ("Title 40, Part 60", [CfrCitation("40", "60")]),
+        ("40 CFR Parts 60 and 63", [CfrCitation("40", "60"), CfrCitation("40", "63")]),
+        ("not a CFR citation", []),
+    ],
+)
+def test_parse_cfr_fixture_forms(raw, expected):
+    assert parse_cfr_citation(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # The measured false positive. docs/evidence/citation-bakeoff-2026-08-02.md,
+        # "False positives — the safety half": one string in 620 drew a citation
+        # from a project grammar that has none, and this is it. The compact
+        # branch matched greedily and published title 5401, part 5405.
+        "5401-5405",
+        # The same branch on a Federal Register document number, recorded as a
+        # known overlap in tests/test_run_citation_bakeoff.py.
+        "2026-13078",
+        # One past the last title the CFR has.
+        "51-1",
+    ],
+)
+def test_the_compact_key_refuses_a_title_the_cfr_does_not_have(raw):
+    """Regression: ``'5401-5405'`` published ``urn:rkaf:us:cfr:5401:5405``.
+
+    The bound is the CFR's own and every branch now carries it. It was applied
+    here first, on the reasoning that the anchored branches were held in place
+    by the literal "CFR" or the word "part". That reasoning was wrong — see
+    ``test_an_anchored_branch_is_bounded_by_the_same_titles``, where an anchored
+    branch reached ``urn:rkaf:us:cfr:2300:2336`` on a publishing path. An
+    implausible title is implausible whatever anchored it.
+    """
+    assert parse_cfr_citation(raw) == []
+
+
+# The five Title 3 compilation strings, verbatim from
+# output/citation-bakeoff-2026-08-02 (detection.json, cell citeurl_only). They
+# are the identity half of the bakeoff's 14 in-scope wins.
+_EO_COMPILATION_STRINGS = (
+    ("3 CFR, 1949-1953 Comp, p. 1002", ExecutiveOrderCompilation("1949", "1953", "1002")),
+    ("3 CFR, 1959-1963 Comp.", ExecutiveOrderCompilation("1959", "1963", None)),
+    ("3 CFR, 1977 Comp., p. 123", ExecutiveOrderCompilation("1977", None, "123")),
+    ("3 CFR, 1977 Comp., p. 123.", ExecutiveOrderCompilation("1977", None, "123")),
+    ("3 CFR, 1980 Comp., p. 298", ExecutiveOrderCompilation("1980", None, "298")),
+)
+
+
+@pytest.mark.parametrize(("raw", "expected"), _EO_COMPILATION_STRINGS)
+def test_a_title_3_compilation_locator_is_recognized_as_what_it_is(raw, expected):
+    """The form locates an Executive Order by compilation page, not a CFR section."""
+    assert parse_eo_compilation_citation(raw) == [expected]
+
+
+@pytest.mark.parametrize(("raw", "_expected"), _EO_COMPILATION_STRINGS)
+def test_a_compilation_locator_never_becomes_a_cfr_citation(raw, _expected):
+    """Regression: there is no 3 CFR § 1977, and reading one is the wrong parse.
+
+    This is the reading the bakeoff found in CiteURL (`title=3, section=1977`,
+    with the page — the part that identifies the order — discarded). These five
+    spellings carry a comma the project's CFR expressions could not cross, so
+    they were undetected rather than misread; the sibling test below covers the
+    spellings that *were* misread.
+    """
+    assert parse_cfr_citation(raw) == []
+
+
+@pytest.mark.parametrize(
+    ("raw", "phantom"),
+    [
+        # Every string is verbatim from the sealed corpus, beside the CFR
+        # citation `_CFR_STANDARD` drew from it before the refusal existed. The
+        # comma is what had been holding the wrong reading off: "3 CFR, 1977"
+        # does not match, "3 CFR 1977" does, and the corpus writes it both ways.
+        ("3 C.F.R. 1978 Comp. p. 142", CfrCitation("3", "1978")),
+        ("3 CFR 1949-1953 Comp., p. 970, as amended by E.O. 12038", CfrCitation("3", "1949")),
+        ("3 CFR 1977 Comp., p. 158)", CfrCitation("3", "1977")),
+        ("3 CFR 1978 Comp. p. 142", CfrCitation("3", "1978")),
+        ("3 CFR 1978 Comp., p. 142.", CfrCitation("3", "1978")),
+        ("3 CFR 1979 Comp. p. 435", CfrCitation("3", "1979")),
+        ("E.O. 12600 (3 CFR 1987 Comp. p. 235)", CfrCitation("3", "1987")),
+        # Found by adversarial review of the first fix, in exactly the class it
+        # closed. A comma may also fall *before* "Comp", and the volume range
+        # may be spelled "to" rather than dashed -- neither of which the first
+        # expression could cross, so both still minted a phantom part.
+        ("3 CFR 1949 to 1953, Comp, p. 1002", CfrCitation("3", "1949")),
+        ("3 CFR 1979, Comp. p. 435", CfrCitation("3", "1979")),
+    ],
+)
+def test_the_compilation_year_was_being_published_as_a_cfr_part(raw, phantom):
+    """Regression: the year in a compilation locator read as a part number.
+
+    `urn:rkaf:us:cfr:3:1978` is not a part of the CFR; 1978 is the compilation
+    volume.
+
+    An earlier version of this docstring said the class was reachable only from
+    free text "because both production callers read `cfr_references_json`, which
+    carries structured objects". False for the Unified Agenda: `rkaf_projection`
+    feeds this function 3,998 distinct bare free-text values from
+    `unified_agenda.cfr_references_json`, on a publishing path — see
+    `test_an_anchored_branch_is_bounded_by_the_same_titles`. These particular
+    strings are Federal Register authority prose and are not in that column, so
+    they stay latent; the general claim was wrong.
+    """
+    assert phantom not in parse_cfr_citation(raw)
+    assert parse_cfr_citation(raw) == []
+    assert parse_eo_compilation_citation(raw)
+
+
+def test_one_string_may_locate_two_compilations():
+    raw = (
+        "E.O. 12372 (July 14, 1982), 47 FR 30959, 3 CFR, 1982 Comp., p. 197, "
+        "as amended by E.O. 12416 (April 8, 1983), 48 FR 15887, 3 CFR, 1983 Comp., p. 186."
+    )
+    assert parse_eo_compilation_citation(raw) == [
+        ExecutiveOrderCompilation("1982", None, "197"),
+        ExecutiveOrderCompilation("1983", None, "186"),
+    ]
+
+
+def test_a_compilation_locator_carries_no_identifier():
+    """A typed recognition, deliberately not an identifier.
+
+    The repo has no index from a Title 3 compilation page to an Executive Order
+    number, so the honest output is the located page — never an EO number the
+    parser would have to invent, and never a CFR section that does not exist.
+    """
+    (located,) = parse_eo_compilation_citation("3 CFR, 1977 Comp., p. 123")
+    assert not hasattr(located, "iri")
+    assert not hasattr(located, "canonical_iri")
+    assert (located.compilation_start, located.compilation_end, located.page) == ("1977", None, "123")
+
+
+def test_a_compilation_volume_without_a_page_locates_no_single_order():
+    """A multi-year volume with no page names a volume, not an order.
+
+    "3 CFR, 1959-1963 Comp." locates five years of presidential documents. The
+    page is what would narrow it to one, and there is none.
+    """
+    (located,) = parse_eo_compilation_citation("3 CFR, 1959-1963 Comp.")
+    assert located.page is None
+
+
+def test_only_title_3_compiles_presidential_documents():
+    """The annual compilation that carries Executive Orders is Title 3's.
+
+    Another title's "Comp." would be a form this parser has never seen and has
+    no meaning to give, so it is refused rather than recognized emptily.
+    """
+    assert parse_eo_compilation_citation("40 CFR, 1977 Comp., p. 123") == []
+    assert parse_eo_compilation_citation("3 CFR 1977") == []
+    assert parse_eo_compilation_citation("40 CFR 60") == []
+
+
+def test_a_real_cfr_citation_beside_a_compilation_locator_survives():
+    """The refusal covers the locator's own span and nothing else."""
+    raw = "E.O. 11246, 3 CFR, 1964-1965 Comp., p. 339, implemented at 41 CFR 60"
+    assert parse_cfr_citation(raw) == [CfrCitation("41", "60")]
+    assert parse_eo_compilation_citation(raw) == [ExecutiveOrderCompilation("1964", "1965", "339")]
+
+
+# The two boundary defects PLAN.md section 3 names, one test each, both exact.
+# Neither asserts "at least these citations": the whole point of a boundary
+# defect is the extra or missing item at the edge, so an assertion that admits
+# extras cannot see either one.
+
+
+def test_two_unspaced_citations_do_not_mint_a_third():
+    """Regression: ``'1CFR9,10CFR1'`` published a phantom 1 CFR 1.
+
+    The list expansion after a citation guards against swallowing the next
+    citation with a negative lookahead for "CFR", and a bare ``\\d+`` walked
+    out from under it: the engine gave back the "0" of "10" and matched the
+    leading "1", inventing a part under the *first* citation's title. Both
+    real citations were already found by the primary expression; the third
+    was arithmetic on a backtrack.
+    """
+    assert parse_cfr_citation("1CFR9,10CFR1") == [CfrCitation("1", "9"), CfrCitation("10", "1")]
+
+
+def test_a_sentence_final_period_is_punctuation_and_not_part_of_the_section():
+    """Regression: ``'49 CFR 900.42.'`` returned nothing at all.
+
+    The greedy section capture read "900.42." including the period; that is
+    not a section, and a citation whose written section cannot be read is
+    dropped whole rather than truncated. So every question typed as a
+    sentence lost its citation, silently. The same string without the period
+    always worked, which is how the defect stayed invisible.
+    """
+    assert parse_cfr_citation("49 CFR 900.42.") == [CfrCitation("49", "900", "42")]
+    assert parse_cfr_citation("49 CFR 900.42") == [CfrCitation("49", "900", "42")]
+    # An interior dot or hyphen is still the section's own name.
+    assert parse_cfr_citation("40 CFR 60.5-1.") == [CfrCitation("40", "60", "5-1")]
+
+
+# Every string below is verbatim from output/citation-bakeoff-2026-08-02
+# (detection.json, cell `neither`) — the largest well-defined slice of the
+# shared-miss cell no evaluated package addresses. 31 of the 32 strings that
+# cell spells with "chapter" name a title; the 32nd is a bare "Chapter 33".
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("5 U.S.C. Ch. 131", UscChapterCitation("5", "131")),
+        ("5 U.S.C. Ch. 63", UscChapterCitation("5", "63")),
+        ("49 U.S.C. ch. 311", UscChapterCitation("49", "311")),
+        ("49 U.S.C. ch. 301", UscChapterCitation("49", "301")),
+        # Every separator spelling the corpus uses: no space after the
+        # abbreviation, no trailing dot, no dot at all, the word written out.
+        ("41 U.S.C. ch.13", UscChapterCitation("41", "13")),
+        ("31 U.S.C. Ch 38", UscChapterCitation("31", "38")),
+        ("40 USC ch 10", UscChapterCitation("40", "10")),
+        ("5 U.S.C. chapter 43", UscChapterCitation("5", "43")),
+        ("54 U.S.C Chapter 3041", UscChapterCitation("54", "3041")),
+        # A lettered chapter, normalized like a U.S.C. section suffix.
+        ("42 U.S.C. chapter 13A", UscChapterCitation("42", "13a")),
+        # Trailing prose is not part of the chapter number.
+        ("22 USC Ch. 34- The Peace Corps Act", UscChapterCitation("22", "34")),
+        ("10 U.S.C. ch. 137 legacy provisions", UscChapterCitation("10", "137")),
+    ],
+)
+def test_a_usc_chapter_citation_is_read_from_the_corpus_spelling(raw, expected):
+    assert parse_usc_chapter_citation(raw) == [expected]
+
+
+def test_a_chapter_list_is_expanded_under_the_title_that_introduces_it():
+    """ "47 U.S.C. chs. 2, 5, 9, 13" names four chapters, not one.
+
+    Same expression and same stop rule the section list expansion uses, so a
+    number that leads a different citation is not swept in as a chapter.
+    """
+    assert parse_usc_chapter_citation("47 U.S.C. chs. 2, 5, 9, 13") == [
+        UscChapterCitation("47", "2"),
+        UscChapterCitation("47", "5"),
+        UscChapterCitation("47", "9"),
+        UscChapterCitation("47", "13"),
+    ]
+    assert parse_usc_chapter_citation("46 U.S.C. ch. 553, 49 CFR 1.93(a)") == [UscChapterCitation("46", "553")]
+    assert parse_usc_chapter_citation("5 U.S.C. ch. 10 and E.O. 12024 (42 FR 61445") == [UscChapterCitation("5", "10")]
+
+
+@pytest.mark.parametrize("raw", ["46 U.S.C. chs. 301 to 309", "46 U.S.C. chs. 301-309"])
+def test_a_chapter_range_publishes_its_endpoints_and_not_its_members(raw):
+    """The rule sections already follow: two endpoints, never the interval.
+
+    A chapter number never contains a hyphen, so unlike a section the plain
+    hyphen is unambiguously a separator here. Whether the pair is a range is
+    still decided by the ordering rule.
+    """
+    (parsed,) = parse_usc_chapter_citation(raw)
+    assert (parsed.chapter, parsed.chapter_end) == ("301", "309")
+    assert parsed.iri == "urn:spicy-regs:usc-chapter:46:301"
+
+
+def test_a_dash_before_a_title_is_not_a_chapter_range():
+    """ "22 USC Ch. 34- The Peace Corps Act" cites chapter 34 and stops there."""
+    assert parse_usc_chapter_citation("22 USC Ch. 34- The Peace Corps Act") == [UscChapterCitation("22", "34")]
+
+
+def test_an_unordered_chapter_pair_is_not_read_as_a_range():
+    (parsed,) = parse_usc_chapter_citation("46 U.S.C. chs. 309 to 301")
+    assert (parsed.chapter, parsed.chapter_end) == ("309", None)
+
+
+def test_a_chapter_needs_the_code_that_gives_it_a_number():
+    """ "Chapter 33" of what? Without a title there is nothing to identify.
+
+    The bare form is the one string in the measured chapter population that
+    names no code, and it stays unread rather than being attached to whatever
+    title happened to appear nearby.
+    """
+    assert parse_usc_chapter_citation("Chapter 33") == []
+    assert parse_usc_chapter_citation("chapter 13A") == []
+    assert parse_usc_chapter_citation("40 CFR chapter I") == []
+
+
+@pytest.mark.parametrize(("title", "number"), [("5", "10"), ("10", "55"), ("46", "701"), ("49", "301")])
+def test_a_chapter_is_not_the_section_that_shares_its_number(title, number):
+    """The reason the chapter identifier cannot live in the `us-usc` URN space.
+
+    These four pairs are not hypothetical. Each is attested in
+    output/citation-bakeoff-2026-08-02: the same corpus cites title 49 chapter
+    301 *and* title 49 section 301, title 10 chapter 55 *and* section 55, and so
+    on for all four. They are different provisions. Minting
+    `urn:rkaf:us:usc:49:301` for the chapter would publish one identifier for
+    two objects — the worst available outcome, because it is indistinguishable
+    from a correct citation downstream.
+    """
+    (chapter,) = parse_usc_chapter_citation(f"{title} U.S.C. ch. {number}")
+    (section,) = parse_authority_citation(f"{title} U.S.C. {number}")
+    assert section.canonical_iri == f"urn:rkaf:us:usc:{title}:{number}"
+    assert chapter.iri == f"urn:spicy-regs:usc-chapter:{title}:{number}"
+    assert chapter.iri != section.canonical_iri
+
+
+def test_a_chapter_citation_is_not_read_as_a_section():
+    """The section grammar must stay silent on a chapter, in both directions."""
+    for raw in ("5 U.S.C. Ch. 131", "49 U.S.C. ch. 311", "42 U.S.C. chapter 13A"):
+        assert parse_authority_citation(raw) == [AuthorityCitation("other", "failed")]
+    assert parse_usc_chapter_citation("42 U.S.C. 7401") == []
+
+
+def test_the_chapter_identifier_declares_the_scheme_that_can_express_it():
+    """`rkaf:us-usc` is a section space, so a chapter uses the partner escape.
+
+    The compiled Rulespec profile constrains `rkaf:us-usc` to
+    `^urn:rkaf:us:usc:[1-9][0-9]*:[1-9][0-9]*[a-z]*(-[0-9a-z]+)*$` — a title and
+    a *section*. A chapter is not expressible there, so it takes the same route
+    `federal_register_identifier` takes for legacy FR numbers: Rulespec's
+    `partner-defined` escape hatch, under this repo's own URN prefix, until the
+    scheme is broadened.
+    """
+    assert USC_CHAPTER_IDENTIFIER_SCHEME == "rkaf:partner-defined"
+    assert canonical_usc_chapter_iri("49", "311") == "urn:spicy-regs:usc-chapter:49:311"
+    assert canonical_usc_chapter_iri(42, "13A") == "urn:spicy-regs:usc-chapter:42:13a"
+
+
+@pytest.mark.parametrize("chapter", ["", None, "I", "13-A", "0", "chapter"])
+def test_an_unexpressible_chapter_is_refused_rather_than_spelled(chapter):
+    with pytest.raises(ValueError):
+        canonical_usc_chapter_iri("5", chapter)
+
+
+@pytest.mark.parametrize(
+    ("raw", "phantom"),
+    [
+        # LIVE, on a publishing path. `rkaf_projection` feeds
+        # `parse_cfr_citation` free text from `unified_agenda.cfr_references_json`
+        # -- 3,998 distinct bare values -- and this one published a title the
+        # CFR does not have, in 14 generations. `_CFR_TITLE_PART` reads
+        # "<N>, Part <M>" and was never bounded, so "of 2 CFR" at the end of the
+        # sentence did not save it: the expression matched "2300, Part 2336".
+        ("Part 2300, Part 2336, and Part 2339 of 2 CFR", "urn:rkaf:us:cfr:2300:2336"),
+        ("Title 2300, Part 2336", "urn:rkaf:us:cfr:2300:2336"),
+    ],
+)
+def test_an_anchored_branch_is_bounded_by_the_same_titles(raw, phantom):
+    """The anchor was never the guarantee; the title range is.
+
+    The compact-key fix assumed a branch anchored on "CFR" or "part" could only
+    read a title the source text called one. It can read a *part* number as one
+    instead, which is how a real Unified Agenda value minted title 2300.
+    """
+    assert phantom not in [citation.iri for citation in parse_cfr_citation(raw)]
+
+
+def test_a_real_title_beside_an_out_of_range_number_still_parses():
+    """Bounding refuses the phantom without refusing the citation beside it."""
+    assert parse_cfr_citation("2 CFR Part 2336") == [CfrCitation("2", "2336")]
+    assert parse_cfr_citation("Title 40, Part 60") == [CfrCitation("40", "60")]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # The separator set, closed rather than enumerated. "through" is the
+        # ordinary legal spelling of the range "to" was added for.
+        "3 CFR 1949 through 1953 Comp.",
+        "3 CFR 1949 thru 1953 Comp.",
+        "3 CFR 1949 and 1953 Comp.",
+        "3 CFR 1949/1953 Comp.",
+        "3 CFR 1949 to 1953, Comp, p. 1002",
+        "3 CFR, 1949-1953 Comp, p. 1002",
+    ],
+)
+def test_every_spelling_of_a_compilation_volume_range_is_refused(raw):
+    """Whatever joins two years in a compilation citation, it is not a part."""
+    assert parse_cfr_citation(raw) == []
+    assert parse_eo_compilation_citation(raw)
+
+
+def test_the_compact_key_still_reads_every_title_the_cfr_has():
+    """The bound is the CFR's own, so no real compact key is refused by it."""
+    assert parse_cfr_citation("1-1") == [CfrCitation("1", "1")]
+    assert parse_cfr_citation("50-17") == [CfrCitation("50", "17")]
+    assert parse_cfr_citation("50-17.11") == [CfrCitation("50", "17", "11")]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "42 U.S.C. 7401 et seq.",
+            AuthorityCitation("usc", "ok", usc_title="42", usc_section="7401"),
+        ),
+        (
+            "sec. 553 of title 5",
+            AuthorityCitation("usc", "ok", usc_title="5", usc_section="553"),
+        ),
+        (
+            "Pub. L. No. 117-58",
+            AuthorityCitation("public_law", "ok", pl_number="117-58"),
+        ),
+        (
+            "117 Stat. 429",
+            AuthorityCitation("statute_at_large", "ok", statute_at_large="117-429"),
+        ),
+        (
+            "Executive Order 14094",
+            AuthorityCitation("eo", "ok", executive_order="14094"),
+        ),
+        (
+            "Authority delegated under 42 USC 7411",
+            AuthorityCitation("usc", "partial", usc_title="42", usc_section="7411"),
+        ),
+        (
+            "Clean Air Act",
+            AuthorityCitation("other", "failed"),
+        ),
+    ],
+)
+def test_parse_authority_fixture_forms(raw, expected):
+    assert parse_authority_citation(raw) == [expected]
+
+
+# Every string below is verbatim from output/citation-bakeoff-2026-08-02
+# (detection.json, cell citeurl_only) — the regex half of the 14 in-scope wins
+# in docs/evidence/citation-bakeoff-2026-08-02.md, corrected Recommendation 1.
+# They are spellings of forms the project already parses, so each one must reach
+# the identity the standard spelling already mints and no other.
+@pytest.mark.parametrize(
+    ("raw", "iris"),
+    [
+        # "U.S. Code" written out rather than abbreviated.
+        ("49 U.S. Code 106", ["urn:rkaf:us:usc:49:106"]),
+        ("49 U.S. Code 44715", ["urn:rkaf:us:usc:49:44715"]),
+        # U.S.C. *Annotated* — a publisher's edition of the same code.
+        ("50 U.S.C.A. 4701(a)", ["urn:rkaf:us:usc:50:4701"]),
+        # The Internal Revenue Code is title 26, so naming it states a title.
+        ("I.R.C. 337(d)", ["urn:rkaf:us:usc:26:337"]),
+        ("IRC 382(m)", ["urn:rkaf:us:usc:26:382"]),
+        # The literal spelling "Pub. Law". The en dash was never the gap —
+        # _PUBLIC_LAW already accepts [-–—], and 119-21 uses a plain hyphen.
+        ("Pub. Law 111–296", ["urn:rkaf:us:pl:111-296"]),
+        (
+            "Pub. Law 119-21, sec. 70301 and 70434(g), One Big Beautiful Bill Act",
+            ["urn:rkaf:us:pl:119-21"],
+        ),
+    ],
+)
+def test_a_bakeoff_spelling_variant_mints_the_standard_identity(raw, iris):
+    assert [citation.canonical_iri for citation in parse_authority_citation(raw)] == iris
+
+
+@pytest.mark.parametrize(
+    ("variant", "standard"),
+    [
+        ("49 U.S. Code 106", "49 U.S.C. 106"),
+        ("49 U.S. Code 44715", "49 U.S.C. 44715"),
+        ("50 U.S.C.A. 4701(a)", "50 U.S.C. 4701(a)"),
+        ("I.R.C. 337(d)", "26 U.S.C. 337(d)"),
+        ("IRC 382(m)", "26 U.S.C. 382(m)"),
+        ("Pub. Law 111–296", "Pub. L. No. 111–296"),
+    ],
+)
+def test_a_spelling_variant_parses_to_exactly_what_the_standard_spelling_does(variant, standard):
+    """Not merely the same identity: the same citation, status and all.
+
+    A variant that parsed to a *different* status would be a second reading of
+    one citation, and the two spellings would stop being interchangeable.
+    """
+    assert parse_authority_citation(variant) == parse_authority_citation(standard)
+
+
+def test_the_named_code_grammar_does_not_fire_without_a_section():
+    """Naming a code is not citing one; the section is what identifies.
+
+    The abbreviation is short enough to appear by accident, so it publishes
+    nothing unless a section follows it.
+    """
+    for raw in ("I.R.C.", "the IRC", "IRCA 1986", "circ 12"):
+        assert parse_authority_citation(raw) == [AuthorityCitation("other", "failed")]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            "42 U.S.C. 1395, 1396, 1397",
+            [("42", "1395"), ("42", "1396"), ("42", "1397")],
+        ),
+        ("42 U.S.C. 7401 and 7412", [("42", "7401"), ("42", "7412")]),
+        ("42 U.S.C. 7401, 7412, and 7413 et seq.", [("42", "7401"), ("42", "7412"), ("42", "7413")]),
+        # A later title governs its own list rather than the first one.
+        (
+            "5 U.S.C. 553 and 42 U.S.C. 7401, 7412",
+            [("5", "553"), ("42", "7401"), ("42", "7412")],
+        ),
+        # Section suffixes survive the expansion.
+        ("42 U.S.C. 1395w-4, 1395x", [("42", "1395w-4"), ("42", "1395x")]),
+    ],
+)
+def test_usc_section_lists_yield_one_citation_per_section(raw, expected):
+    parsed = parse_authority_citation(raw)
+    assert [(item.usc_title, item.usc_section) for item in parsed] == expected
+    assert {item.authority_type for item in parsed} == {"usc"}
+    # No member of a list covers the whole string, so none of them is ``ok``.
+    assert {item.parse_status for item in parsed} == {"partial"}
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # A range stays one citation and publishes its two endpoints.
+        (
+            "42 U.S.C. 1395-1397",
+            [AuthorityCitation("usc", "ok", usc_title="42", usc_section="1395", usc_section_end="1397")],
+        ),
+        # A number leading a different citation form is not a section.
+        (
+            "42 U.S.C. 7401, 117 Stat. 429",
+            [
+                AuthorityCitation("usc", "partial", usc_title="42", usc_section="7401"),
+                AuthorityCitation("statute_at_large", "partial", statute_at_large="117-429"),
+            ],
+        ),
+        (
+            "42 U.S.C. 7401 and 40 CFR 60",
+            [AuthorityCitation("usc", "partial", usc_title="42", usc_section="7401")],
+        ),
+        # Malformed lists keep whatever parsed and never invent a section.
+        (
+            "42 U.S.C. 1395, , and",
+            [AuthorityCitation("usc", "partial", usc_title="42", usc_section="1395")],
+        ),
+        ("42 U.S.C., 1396", [AuthorityCitation("other", "failed")]),
+        ("42 U.S.C.", [AuthorityCitation("other", "failed")]),
+    ],
+)
+def test_usc_list_expansion_stays_fail_closed(raw, expected):
+    assert parse_authority_citation(raw) == expected
+
+
+# The five RINs that "every active rulemaking depending on 42 U.S.C. 7401"
+# missed (recall 0.8125) all carry this exact string, and the `to` spelling
+# below reached the right answer only because the old expression stopped at
+# 7401 and ignored the tail. Both are now read as the same range.
+# docs/evidence/discovery-slice-2026-07-28.md
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "42 U.S.C. 7401-7671q.",  # 2060-AS32, -AU01, -AV95, -AW70, -AW96
+        "42 U.S.C. 7401 to 7671q.",
+        "42 U.S.C. 7401–7671q.",  # en dash
+        "42 U.S.C. 7401 through 7671q.",
+    ],
+)
+def test_clean_air_act_range_publishes_both_endpoints(raw):
+    assert parse_authority_citation(raw) == [
+        AuthorityCitation("usc", "ok", usc_title="42", usc_section="7401", usc_section_end="7671q")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # A hyphen that names one section is not a range: the suffix is an
+        # ordinal below the stem, never a later section.
+        ("42 U.S.C. 1395w-4", ("1395w-4", None)),
+        ("12 U.S.C. 1831p-1", ("1831p-1", None)),
+        ("42 U.S.C. 300j-9", ("300j-9", None)),
+        ("26 U.S.C. 1400Z-2", ("1400z-2", None)),
+        # Equal endpoints are not a range either.
+        ("42 U.S.C. 2000d-2000d", ("2000d-2000d", None)),
+        # A lettered endpoint under the same stem is.
+        ("15 U.S.C. 717-717w", ("717", "717w")),
+        ("16 U.S.C. 620-620j", ("620", "620j")),
+        # Abbreviated ranges name no second section, so nothing is invented:
+        # "1484-86" is neither 1484-to-86 nor, without guessing, 1484-to-1486.
+        ("42 U.S.C. 1484-86", ("1484-86", None)),
+        ("5 U.S.C. 571 to 83", ("571", None)),
+        # A transposed source range stays one opaque token rather than an
+        # empty interval.
+        ("50 U.S.C. 4801 to 4582", ("4801", None)),
+        # A compound start with a range tail: the start is not a single
+        # section token, so the pair is not readable as an interval.
+        ("47 U.S.C. 615a-1 through 615b", ("615a-1", None)),
+    ],
+)
+def test_usc_hyphen_is_a_range_only_when_the_endpoints_are_ordered(raw, expected):
+    parsed = parse_authority_citation(raw)
+    assert [(item.usc_section, item.usc_section_end) for item in parsed] == [expected]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["12 U.S.C. 1831p–1", "42 U.S.C. 1395w–3", "15 U.S.C. 1261 to 62"],
+)
+def test_declined_range_tail_is_not_reported_as_covered(raw):
+    """A tail the ordering rule refuses is uncovered text, so the parse is partial."""
+    (parsed,) = parse_authority_citation(raw)
+    assert parsed.parse_status == "partial"
+    assert parsed.usc_section_end is None
+
+
+def test_listed_range_member_is_split_like_a_leading_one():
+    assert parse_authority_citation("42 U.S.C. 7401, 7671a-7671q") == [
+        AuthorityCitation("usc", "partial", usc_title="42", usc_section="7401"),
+        AuthorityCitation("usc", "partial", usc_title="42", usc_section="7671a", usc_section_end="7671q"),
+    ]
+
+
+def test_range_row_expands_to_its_first_named_section_and_no_other():
+    """The published identifier is a section the source text names."""
+    (parsed,) = parse_authority_citation("42 U.S.C. 7401-7671q.")
+    assert parsed.canonical_iri == "urn:rkaf:us:usc:42:7401"
+    assert canonical_usc_iri(parsed.usc_title, parsed.usc_section_end) == "urn:rkaf:us:usc:42:7671q"
+
+
+@pytest.mark.parametrize(
+    ("section", "covered"),
+    [
+        ("7401", True),  # start
+        ("7671q", True),  # end, lettered suffix
+        ("7412", True),  # inside
+        ("7671", True),  # inside, bare stem sorts before its lettered members
+        ("7671a", True),  # inside, lettered
+        ("7400", False),  # below
+        ("7672", False),  # above
+        ("7671r", False),  # above, lettered
+        ("", False),
+        ("seven", False),
+    ],
+)
+def test_usc_section_covers_reads_a_range_as_a_closed_interval(section, covered):
+    assert usc_section_covers(section, start="7401", end="7671q") is covered
+
+
+@pytest.mark.parametrize(
+    ("section", "covered"),
+    [("7401", True), ("7401(a)", True), ("7412", False), ("7671q", False)],
+)
+def test_usc_section_covers_without_an_end_is_exact(section, covered):
+    assert usc_section_covers(section, start="7401", end=None) is covered
+
+
+def test_parse_multiple_authorities_returns_one_partial_edge_each():
+    parsed = parse_authority_citation("42 U.S.C. 7401; Public Law 117-58")
+    assert {(item.authority_type, item.parse_status) for item in parsed} == {
+        ("usc", "partial"),
+        ("public_law", "partial"),
+    }
+
+
+def test_rulespec_identifier_expansion():
+    assert canonical_cfr_iri("40", "60") == "urn:rkaf:us:cfr:40:60"
+    assert canonical_cfr_iri("40", "60", "1") == "urn:rkaf:us:cfr:40:60.1"
+    assert canonical_cfr_iri("40", "60", "5375A(a)(1)") == "urn:rkaf:us:cfr:40:60.5375a"
+    assert canonical_usc_iri("42", "7401(a)") == "urn:rkaf:us:usc:42:7401"
+    assert canonical_rin_iri("2060-av16") == "urn:rkaf:us:rin:2060-AV16"
+    assert canonical_frdoc_iri("2024-00366") == "urn:rkaf:us:frdoc:2024-00366"
+    assert canonical_regsgov_iri("epa-hq-oar-2021-0317") == "urn:rkaf:us:regsgov:EPA-HQ-OAR-2021-0317"
+    assert canonical_pl_iri("117–58") == "urn:rkaf:us:pl:117-58"
+
+
+def test_regulations_gov_identifier_normalization_matches_repaired_grammar():
+    assert normalize_regsgov_identifier(" epa-hq-oar-2021-0317 ") == "EPA-HQ-OAR-2021-0317"
+    assert normalize_regsgov_identifier("epa_frdoc_0001") == "EPA_FRDOC_0001"
+    assert normalize_regsgov_identifier("EPA") == "EPA"
+    assert normalize_regsgov_identifier("Sequence No. 1") is None
+    assert normalize_regsgov_identifier(None) is None
+
+
+@pytest.mark.parametrize(
+    ("stated", "expected"),
+    [
+        # The measured decorated forms from
+        # docs/corpus-edge-coverage-findings-2026-07-24.md §1: the label is
+        # presentation, the remainder is identity.
+        ("Doc. No. AMS-SC-24-0046", "AMS-SC-24-0046"),
+        ("Docket No. FAA-2026-3485", "FAA-2026-3485"),
+        ("Docket Number USCG-2026-0762", "USCG-2026-0762"),
+        ("Docket No. OSM-2025-0007", "OSM-2025-0007"),
+        ("Docket No.CPSC-2010-0075", "CPSC-2010-0075"),
+        ("  docket id phmsa-2025-0118  ", "PHMSA-2025-0118"),
+        # The label may name its own department first. "DHS Docket No." is still
+        # label: USCIS-2025-0004 is the docket dockets.parquet carries.
+        ("DHS Docket No. USCIS-2025-0004", "USCIS-2025-0004"),
+        # An undecorated identifier is already identity.
+        ("FSIS-2025-0012", "FSIS-2025-0012"),
+        # An agency code the label grammar would otherwise eat. Commerce dockets
+        # are DOC-YYYY-NNNN; stripping "DOC" would destroy a real identifier, so
+        # a value that already parses is never rewritten.
+        ("DOC-2010-0001", "DOC-2010-0001"),
+        ("DOCKET-2026-0001", "DOCKET-2026-0001"),
+        # Non-regulations.gov references. Those whose shape the scheme cannot
+        # express are refused here; the rest are syntactically expressible and
+        # are quarantined downstream by source-of-record evidence, never by
+        # force-matching them to a docket.
+        ("Special Conditions No. 25-893-SC", None),
+        ("Amendment 39-21234", None),
+        ("REG-103193-26", "REG-103193-26"),
+        ("CMS-9897-F", "CMS-9897-F"),
+        ("FRL-12765-02-OCSPP", "FRL-12765-02-OCSPP"),
+        ("not a docket id", None),
+        ("Docket No.", None),
+        # A separator is source, not decoration. "FSIS 2025-0009" is one space
+        # away from a real docket and is still refused, because supplying the
+        # hyphen would be writing the identifier rather than reading it.
+        ("Docket No. FSIS 2025-0009", None),
+        # No label to strip, so nothing is stripped.
+        ("EPA HQ OAR 2021 0317", None),
+        ("", None),
+        (None, None),
+        # Measured on output/rin-ontology-revision-candidate: the label that
+        # names its department first still uncovers the docket dockets.parquet
+        # carries, and a docket-type letter between the year and the sequence
+        # (FDA's busiest docket, 144 references) is part of the identifier.
+        ("DOT Docket No. DOT-OST-2010-0074", "DOT-OST-2010-0074"),
+        ("FHWA Docket No. FHWA-2005-23112", "FHWA-2005-23112"),
+        ("CPSC Docket No. CPSC-2010-0075", "CPSC-2010-0075"),
+        ("Docket No. FDA-2011-N-0002", "FDA-2011-N-0002"),
+        ("Docket No. FSIS-2025-0012", "FSIS-2025-0012"),
+        ("Docket No. PHMSA-2025-0118", "PHMSA-2025-0118"),
+        ("Docket No. OSHA-V05-2-2006-0785", "OSHA-V05-2-2006-0785"),
+    ],
+)
+def test_the_docket_label_is_presentation_and_the_identifier_survives_it(stated, expected):
+    assert normalize_docket_reference(stated) == expected
+
+
+@pytest.mark.parametrize(
+    ("stated", "fragment"),
+    [
+        # Every string below is a reference measured on
+        # output/rin-ontology-revision-candidate, beside the docket-number
+        # fragment the label rule alone would have published for it. Stripping
+        # the label uncovered no identifier there — it exposed the number the
+        # label was numbering, and that number is not a Regulations.gov docket.
+        ("MM Docket No. 98-213", "98-213"),
+        ("WT Docket No. 17-17", "17-17"),
+        ("Docket No. 17-17", "17-17"),
+        ("EOIR Docket No. 176", "176"),
+        ("FE Docket No. 96-99-LNG", "96-99-LNG"),
+        ("CPSC Docket No. 08-C0004", "08-C0004"),
+    ],
+)
+def test_a_stripped_label_may_uncover_a_docket_but_never_manufacture_one(stated, fragment):
+    """Regression: 5,506 references were mutilated into docket-number fragments.
+
+    Measured on ``output/rin-ontology-revision-candidate``, the leading agency
+    token added by bfc9f8e turned 5,506 distinct non-regulations.gov references
+    into bare numbers against 1,011 real recoveries. What the fragments have in
+    common is that they do not name an organization: a Regulations.gov docket
+    id states organization, year, then sequence, so a remainder that opens on a
+    number is the label's subject matter, not an identifier hiding behind it.
+    """
+    assert normalize_regsgov_identifier(fragment) == fragment, "the fragment is what the scheme would have accepted"
+    assert normalize_docket_reference(stated) is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2060-AV16", "2060-AV16"),
+        ("2060-av16", "2060-AV16"),
+        ("  2060-av16  ", "2060-AV16"),
+        ("2060AV16", None),
+        ("2060-A16", None),
+        ("2060-AV1", None),
+        ("RIN 2060-AV16", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_rin_normalization(value, expected):
+    assert normalize_rin(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("stated", "key"),
+    [
+        # The variant shapes docs/corpus-edge-coverage-findings-2026-07-24.md §1
+        # measured, and the three rules named in DOCKET_NORMALIZATION_RULES:
+        # strip the leading decoration, repair whitespace that split a real
+        # identifier, upper-case.
+        ("Docket No. FAA-2026-3485", "FAA-2026-3485"),
+        ("Doc. No. AMS-SC-24-0046", "AMS-SC-24-0046"),
+        ("Docket Number USCG-2026-0762", "USCG-2026-0762"),
+        ("Docket No: OSM-2025-0007", "OSM-2025-0007"),
+        ("docket no. phmsa-2025-0118", "PHMSA-2025-0118"),
+        ("Docket No. Docket No. FSIS-2025-0012", "FSIS-2025-0012"),
+        ("  FAA - 2026 - 3485  ", "FAA-2026-3485"),
+        ("FSIS-2025-0012", "FSIS-2025-0012"),
+        # The strict separator. A decoration must be followed by whitespace or a
+        # colon, so a real identifier whose organization spells one cannot be
+        # truncated into a false match.
+        ("DOC-2005-0010", "DOC-2005-0010"),
+        ("DOCKET-2020-0001", "DOCKET-2020-0001"),
+        ("", ""),
+        ("   ", ""),
+        (None, ""),
+    ],
+)
+def test_the_docket_join_key_strips_decoration_repairs_and_upper_cases(stated, key):
+    assert normalize_docket_id(stated) == key
+
+
+def test_a_bare_label_leaves_a_key_that_is_not_a_docket():
+    """ "Docket No." keys to "NO." — which is why the build drops it first.
+
+    The decoration expression needs whitespace or a colon after the label, and
+    at the end of a bare "Docket No." there is none, so only "Docket " strips.
+    The residue matches no docket and never has (zero collisions across the
+    276,326 dockets in the 54f07a6 pin), but a key made of decoration should not
+    reach a link table at all — so `build_fr_docket_links` drops a reference
+    that states nothing *before* keying it, using
+    :func:`docket_reference_as_stated`, and this asserts why that ordering
+    matters rather than that the residue is harmless.
+    """
+    assert normalize_docket_id("Docket No.") == "NO."
+    assert docket_reference_as_stated("Docket No.") == ""
+
+
+def test_the_docket_join_key_is_a_key_and_not_an_identifier():
+    """Two functions, two jobs, and the difference is load-bearing.
+
+    :func:`normalize_docket_reference` answers "what docket does this reference
+    state?" and refuses anything that is not a Regulations.gov docket.
+    :func:`normalize_docket_id` answers "what do I compare this against?" and
+    refuses nothing — it reduces whatever it is given to a comparison key. A key
+    that matches no docket is simply a key that matches no docket; it never
+    licenses a join on its own.
+    """
+    foreign = "Special Conditions No. 25-893-SC"
+    assert normalize_docket_reference(foreign) is None
+    assert normalize_docket_id(foreign) == "SPECIALCONDITIONSNO.25-893-SC"
+
+    # A shape the identifier grammar refuses because supplying the separator
+    # would be writing the id rather than reading it. As a comparison key the
+    # same string is expressible, and still matches no real docket.
+    assert normalize_docket_reference("Docket No. FSIS 2025-0009") is None
+    assert normalize_docket_id("Docket No. FSIS 2025-0009") == "FSIS2025-0009"
+
+
+def test_the_docket_decoration_grammar_has_one_definition():
+    """The crosswalk tool defined it; the links build needs it; so it moved.
+
+    Same reasoning as the RIN grammar below. A pattern restated in a tool and a
+    transform drifts the moment either is corrected, and this one decides
+    whether 88,073 link rows join.
+    """
+    restating = sorted(
+        str(path.relative_to(REPO_ROOT))
+        for directory in ("src", "tools")
+        for path in (REPO_ROOT / directory).rglob("*.py")
+        if r"(?:docket\s*(?:no|number)?|doc\.?\s*no)" in path.read_text()
+    )
+
+    assert restating == ["src/spicy_regs/ontology/citations.py"]
+
+
+def test_the_rin_grammar_has_one_definition():
+    """A grammar copied into five modules drifts; a grammar imported cannot.
+
+    The RIN shape was restated in four transforms and one discovery tool, each
+    beside its own private ``_rin`` wrapper, so a correction to any one of them
+    left the other four saying something different about the same identifier.
+    """
+    restating = sorted(
+        str(path.relative_to(REPO_ROOT))
+        for directory in ("src", "tools")
+        for path in (REPO_ROOT / directory).rglob("*.py")
+        if r"\d{4}-[A-Z]{2}\d{2}" in path.read_text()
+    )
+
+    assert restating == ["src/spicy_regs/ontology/citations.py"]
+
+
+def test_invalid_cfr_suffix_is_rejected():
+    with pytest.raises(ValueError):
+        canonical_cfr_iri("40", "60", "appendix-a")
+
+
+@pytest.mark.parametrize(
+    ("document_number", "expected"),
+    [
+        ("2024-00366", ("rkaf:us-frdoc", "urn:rkaf:us:frdoc:2024-00366")),
+        ("E7-21559", ("rkaf:partner-defined", "urn:spicy-regs:frdoc:E7-21559")),
+        (
+            "C1-2026-13078",
+            ("rkaf:partner-defined", "urn:spicy-regs:frdoc:C1-2026-13078"),
+        ),
+    ],
+)
+def test_federal_register_identifier_uses_partner_fallback(document_number, expected):
+    assert federal_register_identifier(document_number) == expected
+
+
+@pytest.mark.parametrize(
+    ("function", "value"),
+    [
+        (canonical_rin_iri, "Not Assigned"),
+        (canonical_frdoc_iri, "2024-42"),
+        (canonical_regsgov_iri, "no-spaces allowed"),
+        (canonical_pl_iri, "0-58"),
+    ],
+)
+def test_invalid_identifier_expansion_fails(function, value):
+    with pytest.raises(ValueError):
+        function(value)
+
+
+# The act-relative grammar is dictionary-driven: recognition is a longest match
+# against the Popular Name Tool's 13,627 names, not a shape heuristic. A generic
+# "capitalised words then Act" expression run over the 4,777 sealed authority
+# strings matches "U.S.C." 108 times, which is why the index is the grammar.
+_ACT_NAMES = frozenset(
+    normalize_popular_name(name)
+    for name in (
+        "Clean Air Act",
+        "Clean Air Act Amendments of 1977",
+        "Employee Retirement Income Security Act",
+        "ERISA",
+        "Federal Food, Drug, and Cosmetic Act",
+        "Modernization of Cosmetics Regulation Act of 2022",
+        "Social Security Act",
+        "Toxic Substances Control Act",
+    )
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # The minimal pair the bakeoff drew opposite verdicts on. Both are the
+        # same citation and both now read the same way.
+        ("Clean Air Act sec. 112", [("Clean Air Act", "112")]),
+        ("Clean Air Act Section 112", [("Clean Air Act", "112")]),
+        ("Clean Air Act section 111", [("Clean Air Act", "111")]),
+        # Subsection detail is excluded, exactly as a U.S.C. section's is.
+        ("Clean Air Act sec. 111(b)(1)(B)", [("Clean Air Act", "111")]),
+        ("Clean Air Act §112", [("Clean Air Act", "112")]),
+        # The act name may be introduced by prose.
+        ("promulgated under the Clean Air Act sec. 112", [("Clean Air Act", "112")]),
+        # An alias is a name like any other; resolving it is the index's job.
+        ("ERISA sec. 803", [("ERISA", "803")]),
+        # The inverted spelling the corpus also uses.
+        (
+            "sec. 3505 of the Modernization of Cosmetics Regulation Act of 2022",
+            [("Modernization of Cosmetics Regulation Act of 2022", "3505")],
+        ),
+    ],
+)
+def test_an_act_relative_citation_is_read_from_the_index(raw, expected):
+    found = find_act_relative_citations(raw, act_names=_ACT_NAMES)
+    assert [(c.act_name, c.section) for c in found] == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "act"),
+    [
+        # Forward scan, `_longest_name_before`.
+        ("Clean Air Act Amendments of 1977 sec. 5", "Clean Air Act Amendments of 1977"),
+        # Inverted scan, `_longest_name_after`. This is the case that actually
+        # discriminates: the shorter name is a *prefix* here, so a shortest-match
+        # rule reads "Clean Air Act" and cites the parent statute instead of the
+        # amending one. Pinning only the forward scan left this free to shorten.
+        ("sec. 5 of the Clean Air Act Amendments of 1977", "Clean Air Act Amendments of 1977"),
+        ("section 5 of Clean Air Act Amendments of 1977", "Clean Air Act Amendments of 1977"),
+    ],
+)
+def test_the_longest_known_name_wins(raw, act):
+    """ "Clean Air Act Amendments of 1977" is a different act from "Clean Air Act".
+
+    The two share a Table III key today, so no identity moves yet — but that is
+    an accident of the data, not a property of the rule, which is why the rule
+    is pinned rather than left to the corpus to enforce.
+    """
+    (found,) = find_act_relative_citations(raw, act_names=_ACT_NAMES)
+    assert found.act_name == act
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # No section: naming an act is not citing a provision of one.
+        "Clean Air Act",
+        "authority under the Clean Air Act, as amended",
+        # A name the index does not carry. The corpus writes these and they stay
+        # unread: guessing that "INA" means the Immigration and Nationality Act
+        # is exactly the inference the identity fence exists to stop.
+        "INA sec. 103(a)(1)",
+        "PHS Act secs. 2791(b)(5) and 2792",
+        "ACA sec. 1557",
+        # The 108 false positives a shape heuristic produced.
+        "42 U.S.C. 7401",
+        "42 U.S.C. sec. 7401",
+        "5 U.S.C. sec. 553",
+        # A section marker with nothing in front of it.
+        "sec. 112",
+        "",
+    ],
+)
+def test_an_act_the_index_does_not_name_is_not_read(raw):
+    assert find_act_relative_citations(raw, act_names=_ACT_NAMES) == []
+
+
+def test_one_string_may_cite_two_acts():
+    found = find_act_relative_citations(
+        "Clean Air Act sec. 112 and Toxic Substances Control Act section 6",
+        act_names=_ACT_NAMES,
+    )
+    assert [(c.act_name, c.section) for c in found] == [
+        ("Clean Air Act", "112"),
+        ("Toxic Substances Control Act", "6"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("stated", "key"),
+    [
+        ("Clean Air Act", "clean air act"),
+        ("  Clean   Air  Act  ", "clean air act"),
+        ("Clean Air Act.", "clean air act"),
+        ("Federal Food, Drug, and Cosmetic Act", "federal food, drug, and cosmetic act"),
+        # The tool writes a curly apostrophe; prose usually writes a straight one.
+        ("Workers’ Compensation Act", "workers' compensation act"),
+        ("Wagner–Peyser Act", "wagner-peyser act"),
+    ],
+)
+def test_a_popular_name_joins_on_one_normalized_key(stated, key):
+    assert normalize_popular_name(stated) == key

--- a/tests/test_proceedings.py
+++ b/tests/test_proceedings.py
@@ -1,0 +1,805 @@
+"""Golden reference-corpus test for proceedings and reopened comment periods."""
+
+from __future__ import annotations
+
+import json
+
+import pyarrow.parquet as pq
+import pytest
+
+from spicy_regs.ontology.common import write_parquet_rows
+from spicy_regs.transforms.build_comment_periods import (
+    COLUMNS as COMMENT_PERIOD_COLUMNS,
+    build_comment_periods,
+)
+from spicy_regs.transforms.build_proceedings import (
+    COLUMNS as PROCEEDING_COLUMNS,
+    _current_stage_from_events,
+    build_proceedings,
+)
+
+
+def _write(path, columns, rows):
+    write_parquet_rows(path, columns=columns, rows=rows)
+
+
+def test_current_stage_requires_unique_latest_stage_family_event():
+    events = [
+        {"stage": "proposed", "event_kind": "proceedingProposed", "effective_date": "2026-01-01"},
+        {"stage": "final", "event_kind": "proceedingFinal", "effective_date": "2026-02-01"},
+    ]
+    assert _current_stage_from_events(events) == "final"
+
+    events.append({"stage": "withdrawn", "event_kind": "proceedingWithdrawn", "effective_date": "2026-02-01"})
+    assert _current_stage_from_events(events) is None
+    assert (
+        _current_stage_from_events([{"stage": "final", "event_kind": "proceedingFinal", "effective_date": None}])
+        is None
+    )
+    with pytest.raises(ValueError, match="disagrees"):
+        _current_stage_from_events(
+            [{"stage": "final", "event_kind": "proceedingProposed", "effective_date": "2026-02-01"}]
+        )
+
+
+def test_reference_proceeding_threads_rinless_docket_and_preserves_reopening(tmp_path):
+    docket_id = "EPA-HQ-OAR-2021-0044"
+    rin = "2060-AV16"
+    _write(
+        tmp_path / "dockets.parquet",
+        ("docket_id", "rin", "docket_type", "title", "agency_code", "modify_date"),
+        [
+            {
+                "docket_id": docket_id,
+                "rin": None,
+                "docket_type": "Rulemaking",
+                "title": "Methane Emissions Standards",
+                "agency_code": "EPA",
+                "modify_date": "2024-03-08",
+            }
+        ],
+    )
+    _write(
+        tmp_path / "documents.parquet",
+        (
+            "document_id",
+            "docket_id",
+            "additional_rins",
+            "document_type",
+            "title",
+            "agency_code",
+            "posted_date",
+            "comment_start_date",
+            "comment_end_date",
+        ),
+        [
+            {
+                "document_id": "D-PROPOSAL",
+                "docket_id": docket_id,
+                "additional_rins": "[]",
+                "document_type": "Proposed Rule",
+                "title": "Standards proposal",
+                "agency_code": "EPA",
+                "posted_date": "2021-11-15",
+                "comment_start_date": "2021-11-15",
+                "comment_end_date": "2022-01-14",
+            },
+            {
+                "document_id": "D-EXTENSION",
+                "docket_id": docket_id,
+                "additional_rins": "[]",
+                "document_type": "Notice",
+                "title": "Comment period extension",
+                "agency_code": "EPA",
+                "posted_date": "2021-12-17",
+                "comment_start_date": "2021-12-17",
+                "comment_end_date": "2022-01-31",
+            },
+            {
+                "document_id": "D-SUPPLEMENTAL",
+                "docket_id": docket_id,
+                "additional_rins": f'["{rin}"]',
+                "document_type": "Proposed Rule",
+                "title": "Supplemental proposal",
+                "agency_code": "EPA",
+                "posted_date": "2022-12-06",
+                "comment_start_date": "2022-12-06",
+                "comment_end_date": "2023-01-05",
+            },
+            {
+                "document_id": "D-FINAL",
+                "docket_id": docket_id,
+                "additional_rins": f'["{rin}"]',
+                "document_type": "Rule",
+                "title": "Final standards",
+                "agency_code": "EPA",
+                "posted_date": "2024-03-08",
+                "comment_start_date": None,
+                "comment_end_date": None,
+            },
+        ],
+    )
+    _write(
+        tmp_path / "federal_register.parquet",
+        (
+            "document_number",
+            "regulation_id_numbers_json",
+            "document_type",
+            "title",
+            "publication_date",
+            "comments_close_on",
+        ),
+        [
+            {
+                "document_number": "2021-24202",
+                "regulation_id_numbers_json": f'["{rin}"]',
+                "document_type": "Proposed Rule",
+                "title": "Standards proposal",
+                "publication_date": "2021-11-15",
+                "comments_close_on": "2022-01-14",
+            },
+            {
+                "document_number": "2021-27312",
+                "regulation_id_numbers_json": f'["{rin}"]',
+                "document_type": "Notice",
+                "title": "Comment period extension",
+                "publication_date": "2021-12-17",
+                "comments_close_on": "2022-01-31",
+            },
+            {
+                "document_number": "2022-24675",
+                "regulation_id_numbers_json": f'["{rin}"]',
+                "document_type": "Proposed Rule",
+                "title": "Supplemental proposal",
+                "publication_date": "2022-12-06",
+                "comments_close_on": "2023-01-05",
+            },
+            {
+                "document_number": "2024-00366",
+                "regulation_id_numbers_json": f'["{rin}"]',
+                "document_type": "Rule",
+                "title": "Final standards",
+                "publication_date": "2024-03-08",
+                "comments_close_on": None,
+            },
+        ],
+    )
+    _write(
+        tmp_path / "unified_agenda.parquet",
+        ("rin", "agenda_edition", "title", "agency_code", "rule_stage", "first_action_date"),
+        [
+            {
+                "rin": rin,
+                "agenda_edition": "202404",
+                "title": "Methane Emissions Standards",
+                "agency_code": "EPA",
+                "rule_stage": "Final Rule Stage",
+                "first_action_date": "2021-11-15",
+            }
+        ],
+    )
+    _write(
+        tmp_path / "fr_docket_links.parquet",
+        ("document_number", "docket_id"),
+        [
+            {"document_number": number, "docket_id": docket_id}
+            for number in ("2021-24202", "2021-27312", "2022-24675", "2024-00366")
+        ],
+    )
+    _write(
+        tmp_path / "rule_targets.parquet",
+        ("docket_id", "rin", "cfr_ref", "cfr_title", "cfr_part", "cfr_section"),
+        [
+            {
+                "docket_id": docket_id,
+                "rin": rin,
+                "cfr_ref": "40-60",
+                "cfr_title": "40",
+                "cfr_part": "60",
+                "cfr_section": None,
+            }
+        ],
+    )
+    _write(
+        tmp_path / "authority_edges.parquet",
+        ("rin", "usc_title", "usc_section", "pl_number", "authority_raw"),
+        [{"rin": rin, "usc_title": "42", "usc_section": "7401", "pl_number": None}],
+    )
+
+    proceedings_file = build_proceedings(
+        tmp_path,
+        run_id="reference-corpus",
+        asserted_at="2026-07-23T12:00:00Z",
+    )
+    proceedings = pq.read_table(proceedings_file).to_pylist()
+    assert pq.ParquetFile(proceedings_file).schema_arrow.names == list(PROCEEDING_COLUMNS)
+    assert len(proceedings) == 1
+    proceeding = proceedings[0]
+    assert proceeding["rin"] == rin
+    assert json.loads(proceeding["docket_ids_json"]) == [docket_id]
+    assert proceeding["current_stage"] == "final"
+    assert json.loads(proceeding["cfr_refs_json"]) == ["40-60"]
+    assert json.loads(proceeding["cfr_target_iris_json"]) == ["urn:rkaf:us:cfr:40:60"]
+    assert json.loads(proceeding["authority_refs_json"]) == []
+    stages = {event["stage"] for event in json.loads(proceeding["stage_events_json"])}
+    assert {"proposed", "supplemental", "final"} <= stages
+
+    periods_file = build_comment_periods(
+        tmp_path,
+        run_id="reference-corpus",
+        asserted_at="2026-07-23T12:00:00Z",
+    )
+    periods = pq.read_table(periods_file).to_pylist()
+    assert pq.ParquetFile(periods_file).schema_arrow.names == list(COMMENT_PERIOD_COLUMNS)
+    assert [(row["open_date"], row["close_date"]) for row in periods] == [
+        ("2021-11-15", "2022-01-31"),
+        ("2022-12-06", "2023-01-05"),
+    ]
+    assert all(json.loads(row["proceeding_ids_json"]) == [proceeding["proceeding_id"]] for row in periods)
+    assert all(json.loads(row["docket_ids_json"]) == [docket_id] for row in periods)
+    assert json.loads(periods[0]["opened_by_artifact_ids_json"]) == [
+        "https://www.federalregister.gov/d/2021-24202",
+        "https://www.regulations.gov/document/D-PROPOSAL",
+    ]
+    assert "D-EXTENSION" in json.loads(periods[0]["evidence_ids_json"])
+    assert "https://www.regulations.gov/document/D-EXTENSION" not in json.loads(
+        periods[0]["opened_by_artifact_ids_json"]
+    )
+    assert all(row["method"] == "deterministic" for row in periods)
+    assert all(row["actor_id"] == "spicy-regs:comment-periods:v2" for row in periods)
+
+
+def test_reused_rin_does_not_collapse_or_cross_assign_distinct_dockets(tmp_path):
+    rin = "2120-AA64"
+    dockets = ("FAA-2025-0001", "FAA-2026-0002")
+    _write(
+        tmp_path / "dockets.parquet",
+        ("docket_id", "rin", "docket_type", "title", "agency_code", "modify_date"),
+        [
+            {
+                "docket_id": docket,
+                "rin": rin,
+                "docket_type": "Rulemaking",
+                "title": f"Airworthiness directive {index}",
+                "agency_code": "FAA",
+                "modify_date": f"202{index + 4}-01-01",
+            }
+            for index, docket in enumerate(dockets, start=1)
+        ],
+    )
+    _write(
+        tmp_path / "documents.parquet",
+        (
+            "document_id",
+            "docket_id",
+            "additional_rins",
+            "document_type",
+            "title",
+            "agency_code",
+            "posted_date",
+            "comment_start_date",
+            "comment_end_date",
+        ),
+        [
+            {
+                "document_id": f"DOC-{index}",
+                "docket_id": docket,
+                "additional_rins": f'["{rin}"]',
+                "document_type": "Proposed Rule",
+                "title": f"Proposal {index}",
+                "agency_code": "FAA",
+                "posted_date": f"202{index + 4}-01-01",
+                "comment_start_date": f"202{index + 4}-01-01",
+                "comment_end_date": f"202{index + 4}-02-01",
+            }
+            for index, docket in enumerate(dockets, start=1)
+        ],
+    )
+    _write(
+        tmp_path / "federal_register.parquet",
+        (
+            "document_number",
+            "regulation_id_numbers_json",
+            "document_type",
+            "title",
+            "publication_date",
+            "comments_close_on",
+        ),
+        [
+            {
+                "document_number": f"202{index + 4}-0000{index}",
+                "regulation_id_numbers_json": f'["{rin}"]',
+                "document_type": "Proposed Rule",
+                "title": f"Proposal {index}",
+                "publication_date": f"202{index + 4}-01-01",
+                "comments_close_on": f"202{index + 4}-02-01",
+            }
+            for index in range(1, 3)
+        ],
+    )
+    _write(
+        tmp_path / "unified_agenda.parquet",
+        ("rin", "agenda_edition", "title", "agency_code", "rule_stage", "first_action_date"),
+        [],
+    )
+    _write(
+        tmp_path / "fr_docket_links.parquet",
+        ("document_number", "docket_id"),
+        [
+            {"document_number": f"202{index + 4}-0000{index}", "docket_id": docket}
+            for index, docket in enumerate(dockets, start=1)
+        ],
+    )
+    _write(
+        tmp_path / "rule_targets.parquet",
+        ("docket_id", "rin", "cfr_ref"),
+        [{"docket_id": docket, "rin": rin, "cfr_ref": "14-39"} for docket in dockets],
+    )
+    _write(
+        tmp_path / "authority_edges.parquet",
+        ("rin", "usc_title", "usc_section", "pl_number", "authority_raw"),
+        [],
+    )
+
+    proceeding_rows = pq.read_table(
+        build_proceedings(
+            tmp_path,
+            run_id="reused-rin",
+            asserted_at="2026-07-23T12:00:00Z",
+        )
+    ).to_pylist()
+    assert len(proceeding_rows) == 2
+    assert {tuple(json.loads(row["docket_ids_json"])) for row in proceeding_rows} == {
+        (dockets[0],),
+        (dockets[1],),
+    }
+
+    period_rows = pq.read_table(
+        build_comment_periods(
+            tmp_path,
+            run_id="reused-rin",
+            asserted_at="2026-07-23T12:00:00Z",
+        )
+    ).to_pylist()
+    assert len(period_rows) == 2
+    assert {tuple(json.loads(row["docket_ids_json"])) for row in period_rows} == {(dockets[0],), (dockets[1],)}
+
+
+def test_untrusted_fr_administrative_labels_do_not_become_proceeding_dockets(tmp_path):
+    valid_docket = "EPA-HQ-OAR-2026-0001"
+    rin = "2060-ZZ01"
+    _write(
+        tmp_path / "dockets.parquet",
+        ("docket_id", "rin", "docket_type", "title", "agency_code", "modify_date"),
+        [
+            {
+                "docket_id": valid_docket,
+                "rin": rin,
+                "docket_type": "Rulemaking",
+                "title": "Valid proceeding",
+                "agency_code": "EPA",
+                "modify_date": "2026-01-01",
+            },
+        ],
+    )
+    _write(
+        tmp_path / "documents.parquet",
+        (
+            "document_id",
+            "docket_id",
+            "additional_rins",
+            "document_type",
+            "title",
+            "agency_code",
+            "posted_date",
+            "comment_start_date",
+            "comment_end_date",
+        ),
+        [
+            {
+                "document_id": f"{valid_docket}-0001",
+                "docket_id": valid_docket,
+                "additional_rins": f'["{rin}"]',
+                "document_type": "Proposed Rule",
+                "title": "Valid proposal",
+                "agency_code": "EPA",
+                "posted_date": "2026-01-02",
+                "comment_start_date": "2026-01-02",
+                "comment_end_date": "2026-02-02",
+            }
+        ],
+    )
+    _write(
+        tmp_path / "federal_register.parquet",
+        (
+            "document_number",
+            "regulation_id_numbers_json",
+            "document_type",
+            "title",
+            "publication_date",
+            "comments_close_on",
+        ),
+        [
+            {
+                "document_number": "2026-00001",
+                "regulation_id_numbers_json": f'["{rin}"]',
+                "document_type": "Proposed Rule",
+                "title": "Valid proposal",
+                "publication_date": "2026-01-02",
+                "comments_close_on": "2026-02-02",
+            }
+        ],
+    )
+    _write(
+        tmp_path / "unified_agenda.parquet",
+        ("rin", "agenda_edition", "title", "agency_code", "rule_stage"),
+        [],
+    )
+    _write(
+        tmp_path / "fr_docket_links.parquet",
+        ("document_number", "docket_id"),
+        [
+            {"document_number": "2026-00001", "docket_id": valid_docket},
+            {"document_number": "2026-00001", "docket_id": "AID_FRDOC_0001"},
+            {"document_number": "2026-00001", "docket_id": "Sequence No. 1"},
+            {"document_number": "2026-00001", "docket_id": "A-570-831"},
+        ],
+    )
+    _write(
+        tmp_path / "rule_targets.parquet",
+        ("docket_id", "rin", "cfr_ref"),
+        [{"docket_id": valid_docket, "rin": rin, "cfr_ref": "40-60"}],
+    )
+    _write(
+        tmp_path / "authority_edges.parquet",
+        ("rin", "usc_title", "usc_section", "pl_number", "authority_raw"),
+        [],
+    )
+
+    proceeding_rows = pq.read_table(
+        build_proceedings(
+            tmp_path,
+            run_id="fr-label-boundary",
+            asserted_at="2026-07-24T12:00:00Z",
+        )
+    ).to_pylist()
+    assert len(proceeding_rows) == 1
+    assert json.loads(proceeding_rows[0]["docket_ids_json"]) == [valid_docket]
+
+    period_rows = pq.read_table(
+        build_comment_periods(
+            tmp_path,
+            run_id="fr-label-boundary",
+            asserted_at="2026-07-24T12:00:00Z",
+        )
+    ).to_pylist()
+    assert len(period_rows) == 1
+    assert json.loads(period_rows[0]["docket_ids_json"]) == [valid_docket]
+
+
+def test_one_docket_remains_one_proceeding_when_it_reports_multiple_rins(
+    tmp_path,
+):
+    docket_id = "EPA-HQ-OAR-2026-9999"
+    rins = ("2060-AA01", "2060-BB02")
+    _write(
+        tmp_path / "dockets.parquet",
+        ("docket_id", "rin", "docket_type", "title", "agency_code", "modify_date"),
+        [
+            {
+                "docket_id": docket_id,
+                "rin": rins[0],
+                "docket_type": "Rulemaking",
+                "title": "Shared administrative docket",
+                "agency_code": "EPA",
+                "modify_date": "2026-01-01",
+            }
+        ],
+    )
+    _write(
+        tmp_path / "documents.parquet",
+        (
+            "document_id",
+            "docket_id",
+            "additional_rins",
+            "document_type",
+            "title",
+            "agency_code",
+            "posted_date",
+            "comment_start_date",
+            "comment_end_date",
+        ),
+        [
+            {
+                "document_id": "D-SECOND-RIN",
+                "docket_id": docket_id,
+                "additional_rins": f'["{rins[1]}"]',
+                "document_type": "Notice",
+                "title": "Second rulemaking",
+                "agency_code": "EPA",
+                "posted_date": "2026-01-02",
+                "comment_start_date": None,
+                "comment_end_date": None,
+            },
+            {
+                "document_id": "D-RINLESS-COMMENT",
+                "docket_id": docket_id,
+                "additional_rins": "[]",
+                "document_type": "Notice",
+                "title": "Unscoped comment notice",
+                "agency_code": "EPA",
+                "posted_date": "2026-02-01",
+                "comment_start_date": "2026-02-01",
+                "comment_end_date": "2026-03-01",
+            },
+        ],
+    )
+    _write(
+        tmp_path / "federal_register.parquet",
+        (
+            "document_number",
+            "regulation_id_numbers_json",
+            "document_type",
+            "title",
+            "publication_date",
+            "comments_close_on",
+        ),
+        [],
+    )
+    _write(
+        tmp_path / "unified_agenda.parquet",
+        ("rin", "agenda_edition", "title", "agency_code", "rule_stage", "first_action_date"),
+        [],
+    )
+    _write(
+        tmp_path / "fr_docket_links.parquet",
+        ("document_number", "docket_id"),
+        [],
+    )
+    _write(
+        tmp_path / "rule_targets.parquet",
+        ("docket_id", "rin", "cfr_ref"),
+        [{"docket_id": docket_id, "rin": rin, "cfr_ref": "40-60"} for rin in rins],
+    )
+    _write(
+        tmp_path / "authority_edges.parquet",
+        ("rin", "usc_title", "usc_section", "pl_number", "authority_raw"),
+        [],
+    )
+
+    proceeding_rows = pq.read_table(
+        build_proceedings(
+            tmp_path,
+            run_id="multi-proceeding-docket",
+            asserted_at="2026-07-23T12:00:00Z",
+        )
+    ).to_pylist()
+    assert len(proceeding_rows) == 1
+    assert proceeding_rows[0]["rin"] is None
+    assert proceeding_rows[0]["current_stage"] is None
+    assert json.loads(proceeding_rows[0]["stage_events_json"]) == []
+
+    period_rows = pq.read_table(
+        build_comment_periods(
+            tmp_path,
+            run_id="multi-proceeding-docket",
+            asserted_at="2026-07-23T12:00:00Z",
+        )
+    ).to_pylist()
+    assert len(period_rows) == 1
+    assert json.loads(period_rows[0]["proceeding_ids_json"]) == [proceeding_rows[0]["proceeding_id"]]
+    assert json.loads(period_rows[0]["docket_ids_json"]) == [docket_id]
+    assert json.loads(period_rows[0]["opened_by_artifact_ids_json"]) == [
+        "https://www.regulations.gov/document/D-RINLESS-COMMENT"
+    ]
+
+
+def test_proceeding_id_survives_new_earlier_docket_and_records_continuity(tmp_path):
+    rin = "2060-ZZ99"
+    original_docket = "ZZZ-2026-0001"
+    added_docket = "AAA-2025-0001"
+
+    def write_sources(dockets, links):
+        _write(
+            tmp_path / "dockets.parquet",
+            ("docket_id", "rin", "docket_type", "title", "agency_code", "modify_date"),
+            [
+                {
+                    "docket_id": docket,
+                    "rin": rin,
+                    "docket_type": "Rulemaking",
+                    "title": "Stable identity fixture",
+                    "agency_code": "EPA",
+                    "modify_date": "2026-01-01",
+                }
+                for docket in dockets
+            ],
+        )
+        _write(
+            tmp_path / "documents.parquet",
+            (
+                "document_id",
+                "docket_id",
+                "additional_rins",
+                "document_type",
+                "title",
+                "agency_code",
+                "posted_date",
+            ),
+            [],
+        )
+        _write(
+            tmp_path / "federal_register.parquet",
+            (
+                "document_number",
+                "regulation_id_numbers_json",
+                "document_type",
+                "title",
+                "publication_date",
+            ),
+            [
+                {
+                    "document_number": "2026-00001",
+                    "regulation_id_numbers_json": f'["{rin}"]',
+                    "document_type": "Proposed Rule",
+                    "title": "Stable identity fixture",
+                    "publication_date": "2026-01-01",
+                }
+            ],
+        )
+        _write(
+            tmp_path / "unified_agenda.parquet",
+            ("rin", "agenda_edition", "title", "agency_code", "rule_stage"),
+            [],
+        )
+        _write(
+            tmp_path / "fr_docket_links.parquet",
+            ("document_number", "docket_id"),
+            [{"document_number": "2026-00001", "docket_id": docket} for docket in links],
+        )
+        _write(
+            tmp_path / "rule_targets.parquet",
+            ("docket_id", "rin", "cfr_ref"),
+            [{"docket_id": docket, "rin": rin, "cfr_ref": "40-60"} for docket in dockets],
+        )
+        _write(
+            tmp_path / "authority_edges.parquet",
+            ("rin", "usc_title", "usc_section", "pl_number", "authority_raw"),
+            [],
+        )
+
+    write_sources((original_docket,), (original_docket,))
+    first = pq.read_table(
+        build_proceedings(
+            tmp_path,
+            run_id="identity-first",
+            asserted_at="2026-07-23T12:00:00Z",
+        )
+    ).to_pylist()
+    assert len(first) == 1
+    stable_proceeding_id = first[0]["proceeding_id"]
+
+    # The new docket sorts before the original and would change a stateless
+    # min-docket hash. One FR document explicitly links both into one component.
+    write_sources(
+        (added_docket, original_docket),
+        (added_docket, original_docket),
+    )
+    second = pq.read_table(
+        build_proceedings(
+            tmp_path,
+            run_id="identity-second",
+            asserted_at="2026-07-24T12:00:00Z",
+        )
+    ).to_pylist()
+
+    assert len(second) == 1
+    assert second[0]["proceeding_id"] == stable_proceeding_id
+    assert json.loads(second[0]["docket_ids_json"]) == [
+        added_docket,
+        original_docket,
+    ]
+    assert json.loads(second[0]["identity_predecessors_json"]) == []
+    assert second[0]["supersedes_id"] == stable_proceeding_id
+
+
+def test_unscoped_rin_keeps_identity_when_one_docket_becomes_known(tmp_path):
+    rin = "2060-YY98"
+    docket_id = "EPA-HQ-OAR-2026-0098"
+
+    def write_sources(*, include_docket: bool) -> None:
+        _write(
+            tmp_path / "dockets.parquet",
+            ("docket_id", "rin", "docket_type", "title", "agency_code"),
+            (
+                [
+                    {
+                        "docket_id": docket_id,
+                        "rin": rin,
+                        "docket_type": "Rulemaking",
+                        "title": "Scope transition fixture",
+                        "agency_code": "EPA",
+                    }
+                ]
+                if include_docket
+                else []
+            ),
+        )
+        _write(
+            tmp_path / "documents.parquet",
+            (
+                "document_id",
+                "docket_id",
+                "additional_rins",
+                "document_type",
+                "title",
+                "agency_code",
+                "posted_date",
+            ),
+            [],
+        )
+        _write(
+            tmp_path / "federal_register.parquet",
+            (
+                "document_number",
+                "regulation_id_numbers_json",
+                "document_type",
+                "title",
+                "publication_date",
+            ),
+            [
+                {
+                    "document_number": "2026-00098",
+                    "regulation_id_numbers_json": f'["{rin}"]',
+                    "document_type": "Proposed Rule",
+                    "title": "Scope transition fixture",
+                    "publication_date": "2026-01-01",
+                }
+            ],
+        )
+        _write(
+            tmp_path / "unified_agenda.parquet",
+            ("rin", "agenda_edition", "title", "agency_code", "rule_stage"),
+            [],
+        )
+        _write(
+            tmp_path / "fr_docket_links.parquet",
+            ("document_number", "docket_id"),
+            ([{"document_number": "2026-00098", "docket_id": docket_id}] if include_docket else []),
+        )
+        _write(
+            tmp_path / "rule_targets.parquet",
+            ("docket_id", "rin", "cfr_ref"),
+            ([{"docket_id": docket_id, "rin": rin, "cfr_ref": "40-98"}] if include_docket else []),
+        )
+        _write(
+            tmp_path / "authority_edges.parquet",
+            ("rin", "usc_title", "usc_section", "pl_number", "authority_raw"),
+            [],
+        )
+
+    write_sources(include_docket=False)
+    first = pq.read_table(
+        build_proceedings(
+            tmp_path,
+            run_id="unscoped-first",
+            asserted_at="2026-07-23T12:00:00Z",
+        )
+    ).to_pylist()
+    assert len(first) == 1
+    stable_id = first[0]["proceeding_id"]
+    assert json.loads(first[0]["docket_ids_json"]) == []
+
+    write_sources(include_docket=True)
+    second = pq.read_table(
+        build_proceedings(
+            tmp_path,
+            run_id="unscoped-second",
+            asserted_at="2026-07-24T12:00:00Z",
+        )
+    ).to_pylist()
+    assert len(second) == 1
+    assert second[0]["proceeding_id"] == stable_id
+    assert json.loads(second[0]["docket_ids_json"]) == [docket_id]
+    assert json.loads(second[0]["identity_predecessors_json"]) == []
+    assert second[0]["supersedes_id"] == stable_id

--- a/tests/test_regulatory_agenda.py
+++ b/tests/test_regulatory_agenda.py
@@ -1,0 +1,178 @@
+"""Agenda-item identity and qualified Proceeding relationship tests."""
+
+from __future__ import annotations
+
+import json
+
+import pyarrow.parquet as pq
+
+from spicy_regs.ontology.common import write_parquet_rows
+from spicy_regs.transforms.build_regulatory_agenda import (
+    ITEM_COLUMNS,
+    RELATIONSHIP_COLUMNS,
+    build_regulatory_agenda,
+)
+
+
+def _write(path, columns, rows):
+    write_parquet_rows(path, columns=columns, rows=rows)
+
+
+def test_agenda_items_classify_scope_without_using_rin_as_action_identity(
+    tmp_path,
+):
+    recurring_rin = "2120-AA64"
+    ordinary_rin = "2060-AV16"
+    ua_only_rin = "2070-AB27"
+    dockets = ("FAA-2025-0001", "FAA-2026-0002", "EPA-2026-0003")
+    proceedings = ("proceeding_faa_1", "proceeding_faa_2", "proceeding_epa")
+
+    _write(
+        tmp_path / "dockets.parquet",
+        ("docket_id", "rin", "modify_date"),
+        [
+            {
+                "docket_id": dockets[0],
+                "rin": recurring_rin,
+                "modify_date": "2025-01-01",
+            },
+            {
+                "docket_id": dockets[1],
+                "rin": recurring_rin,
+                "modify_date": "2026-01-01",
+            },
+            {
+                "docket_id": dockets[2],
+                "rin": ordinary_rin,
+                "modify_date": "2026-02-01",
+            },
+        ],
+    )
+    _write(
+        tmp_path / "documents.parquet",
+        (
+            "document_id",
+            "docket_id",
+            "additional_rins",
+            "posted_date",
+            "modify_date",
+        ),
+        [
+            {
+                "document_id": "EPA-2026-0003-0001",
+                "docket_id": dockets[2],
+                "additional_rins": f'["{ordinary_rin}"]',
+                "posted_date": "2026-02-02",
+                "modify_date": "2026-02-03",
+            }
+        ],
+    )
+    _write(
+        tmp_path / "federal_register.parquet",
+        (
+            "document_number",
+            "regulation_id_numbers_json",
+            "publication_date",
+        ),
+        [
+            {
+                "document_number": "2025-00001",
+                "regulation_id_numbers_json": f'["{recurring_rin}"]',
+                "publication_date": "2025-01-02",
+            },
+            {
+                "document_number": "2026-00002",
+                "regulation_id_numbers_json": f'["{recurring_rin}"]',
+                "publication_date": "2026-01-02",
+            },
+        ],
+    )
+    _write(
+        tmp_path / "unified_agenda.parquet",
+        (
+            "rin",
+            "agenda_edition",
+            "priority_category",
+            "url",
+            "first_action_date",
+            "next_action_date",
+        ),
+        [
+            {
+                "rin": recurring_rin,
+                "agenda_edition": "202404",
+                "priority_category": "Other Significant",
+                "url": "https://example.test/2120-AA64/202404",
+            },
+            {
+                "rin": recurring_rin,
+                "agenda_edition": "202510",
+                "priority_category": "Routine and Frequent",
+                "url": "https://example.test/2120-AA64/202510",
+            },
+            {
+                "rin": ordinary_rin,
+                "agenda_edition": "202510",
+                "priority_category": "Other Significant",
+                "url": "https://example.test/2060-AV16/202510",
+            },
+            {
+                "rin": ua_only_rin,
+                "agenda_edition": "202510",
+                "priority_category": "Other Significant",
+                "url": "https://example.test/2070-AB27/202510",
+            },
+        ],
+    )
+    _write(
+        tmp_path / "proceedings.parquet",
+        (
+            "proceeding_id",
+            "docket_ids_json",
+            "fr_document_numbers_json",
+        ),
+        [
+            {
+                "proceeding_id": proceedings[0],
+                "docket_ids_json": json.dumps([dockets[0]]),
+                "fr_document_numbers_json": '["2025-00001"]',
+            },
+            {
+                "proceeding_id": proceedings[1],
+                "docket_ids_json": json.dumps([dockets[1]]),
+                "fr_document_numbers_json": '["2026-00002"]',
+            },
+            {
+                "proceeding_id": proceedings[2],
+                "docket_ids_json": json.dumps([dockets[2]]),
+                "fr_document_numbers_json": "[]",
+            },
+        ],
+    )
+
+    items_file, relationships_file = build_regulatory_agenda(
+        tmp_path,
+        run_id="agenda-fixture",
+        asserted_at="2026-07-24T12:00:00Z",
+    )
+    items = {row["rin"]: row for row in pq.read_table(items_file).to_pylist()}
+    relationships = pq.read_table(relationships_file).to_pylist()
+
+    assert pq.ParquetFile(items_file).schema_arrow.names == list(ITEM_COLUMNS)
+    assert pq.ParquetFile(relationships_file).schema_arrow.names == list(RELATIONSHIP_COLUMNS)
+    assert items[recurring_rin]["agenda_item_id"] == (f"urn:rkaf:us:rin:{recurring_rin}")
+    assert items[recurring_rin]["scope_status"] == "recurring"
+    assert items[recurring_rin]["linked_proceeding_count"] == "2"
+    assert items[recurring_rin]["observation_count"] == "2"
+    assert items[ordinary_rin]["scope_status"] == "single_observed"
+    assert items[ua_only_rin]["scope_status"] == "unresolved"
+    assert items[ua_only_rin]["scope_basis"] == ("zero_evidence_linked_proceedings")
+    assert {row["proceeding_id"] for row in relationships if row["rin"] == recurring_rin} == set(proceedings[:2])
+    assert not any(row["rin"] == ua_only_rin for row in relationships)
+    assert {row["source"] for row in relationships} == {
+        "docket_rin",
+        "document_rin",
+        "federal_register_rin",
+    }
+    assert all(row["relationship_role"] == "agenda_tracks_proceeding" for row in relationships)
+    assert all(row["method"] == "deterministic" for row in relationships)

--- a/tests/test_rule_targets.py
+++ b/tests/test_rule_targets.py
@@ -1,0 +1,198 @@
+"""Golden-file-style fixture test for every rule-target evidence source."""
+
+from __future__ import annotations
+
+import pyarrow.parquet as pq
+
+from spicy_regs.ontology.common import write_parquet_rows
+from spicy_regs.transforms.build_rule_targets import COLUMNS, build_rule_targets
+
+
+def _write(path, columns, rows):
+    write_parquet_rows(path, columns=columns, rows=rows)
+
+
+def test_rule_target_spine_emits_only_action_specific_edges(tmp_path):
+    _write(
+        tmp_path / "dockets.parquet",
+        ("docket_id", "rin", "modify_date"),
+        [{"docket_id": "EPA-HQ-OAR-2024-0001", "rin": "2060-AV12", "modify_date": "2024-01-10"}],
+    )
+    _write(
+        tmp_path / "documents.parquet",
+        ("document_id", "docket_id", "additional_rins", "fr_doc_num", "posted_date", "modify_date"),
+        [
+            {
+                "document_id": "EPA-HQ-OAR-2024-0001-0001",
+                "docket_id": "EPA-HQ-OAR-2024-0001",
+                "additional_rins": '["2060-AV13"]',
+                "fr_doc_num": "2024-00001",
+                "posted_date": "2024-02-01",
+                "modify_date": "2024-02-02",
+            }
+        ],
+    )
+    _write(
+        tmp_path / "federal_register.parquet",
+        (
+            "document_number",
+            "cfr_references_json",
+            "regulation_id_numbers_json",
+            "publication_date",
+        ),
+        [
+            {
+                "document_number": "2024-00001",
+                "cfr_references_json": '[{"title": 40, "part": 60}]',
+                "regulation_id_numbers_json": '["2060-AV12"]',
+                "publication_date": "2024-02-01",
+            }
+        ],
+    )
+    _write(
+        tmp_path / "fr_docket_links.parquet",
+        ("document_number", "docket_id"),
+        [{"document_number": "2024-00001", "docket_id": "EPA-HQ-OAR-2024-0001"}],
+    )
+    _write(
+        tmp_path / "unified_agenda.parquet",
+        (
+            "rin",
+            "agenda_edition",
+            "cfr_references_json",
+            "first_action_date",
+            "next_action_date",
+        ),
+        [
+            {
+                "rin": "2060-AV12",
+                "agenda_edition": "202404",
+                "cfr_references_json": '["40 CFR 63"]',
+                "first_action_date": "2024-03-01",
+                "next_action_date": "2024-05-01",
+            },
+            {
+                "rin": "2060-AV13",
+                "agenda_edition": "202404",
+                "cfr_references_json": '["40 CFR 64"]',
+                "first_action_date": "2024-03-02",
+                "next_action_date": None,
+            },
+        ],
+    )
+
+    output = build_rule_targets(
+        tmp_path,
+        run_id="golden-run",
+        asserted_at="2026-07-23T12:00:00Z",
+    )
+    rows = pq.read_table(output).to_pylist()
+    observed = {(row["source"], row["cfr_ref"], row["rin"]) for row in rows}
+    assert observed == {
+        ("docket_rin", None, "2060-AV12"),
+        ("document_rin", None, "2060-AV13"),
+        ("fr_cfr_ref", "40-60", "2060-AV12"),
+        ("document_fr_doc", "40-60", "2060-AV12"),
+    }
+    assert pq.ParquetFile(output).schema_arrow.names == list(COLUMNS)
+    assert all(row["method"] == "deterministic" for row in rows)
+    assert all(row["actor_id"] == "spicy-regs:rule-targets:v1" for row in rows)
+    assert all(row["run_id"] == "golden-run" for row in rows)
+
+
+def test_rule_targets_skip_and_count_malformed_json_without_dropping_other_sources(tmp_path):
+    _write(
+        tmp_path / "dockets.parquet",
+        ("docket_id", "rin", "modify_date"),
+        [{"docket_id": "EPA-X", "rin": "2060-AV12", "modify_date": "2024-01-01"}],
+    )
+    _write(
+        tmp_path / "documents.parquet",
+        ("document_id", "docket_id", "additional_rins", "fr_doc_num", "posted_date", "modify_date"),
+        [{"document_id": "D1", "docket_id": "EPA-X", "additional_rins": "{bad", "fr_doc_num": None}],
+    )
+    _write(
+        tmp_path / "federal_register.parquet",
+        ("document_number", "cfr_references_json", "regulation_id_numbers_json", "publication_date"),
+        [],
+    )
+    _write(tmp_path / "fr_docket_links.parquet", ("document_number", "docket_id"), [])
+    _write(
+        tmp_path / "unified_agenda.parquet",
+        ("rin", "agenda_edition", "cfr_references_json", "first_action_date", "next_action_date"),
+        [],
+    )
+
+    rows = pq.read_table(
+        build_rule_targets(tmp_path, run_id="malformed", asserted_at="2026-07-23T12:00:00Z")
+    ).to_pylist()
+    assert [(row["source"], row["rin"]) for row in rows] == [("docket_rin", "2060-AV12")]
+
+
+def test_rule_targets_accept_source_backed_underscores_and_reject_untrusted_links(tmp_path):
+    valid_docket = "EPA-HQ-OAR-2026-0001"
+    underscore_docket = "EPA_FRDOC_0001"
+    rin = "2060-ZZ01"
+    _write(
+        tmp_path / "dockets.parquet",
+        ("docket_id", "rin", "modify_date"),
+        [
+            {"docket_id": valid_docket, "rin": rin, "modify_date": "2026-01-01"},
+            {"docket_id": underscore_docket, "rin": rin, "modify_date": "2026-01-01"},
+        ],
+    )
+    _write(
+        tmp_path / "documents.parquet",
+        ("document_id", "docket_id", "additional_rins", "fr_doc_num", "posted_date"),
+        [
+            {
+                "document_id": f"{valid_docket}-0001",
+                "docket_id": valid_docket,
+                "additional_rins": f'["{rin}"]',
+                "fr_doc_num": "2026-00001",
+                "posted_date": "2026-01-02",
+            }
+        ],
+    )
+    _write(
+        tmp_path / "federal_register.parquet",
+        ("document_number", "cfr_references_json", "regulation_id_numbers_json", "publication_date"),
+        [
+            {
+                "document_number": "2026-00001",
+                "cfr_references_json": '[{"title": 40, "part": 60}]',
+                "regulation_id_numbers_json": f'["{rin}"]',
+                "publication_date": "2026-01-02",
+            }
+        ],
+    )
+    _write(
+        tmp_path / "fr_docket_links.parquet",
+        ("document_number", "docket_id"),
+        [
+            {"document_number": "2026-00001", "docket_id": valid_docket},
+            {"document_number": "2026-00001", "docket_id": underscore_docket},
+            {"document_number": "2026-00001", "docket_id": "AID_FRDOC_0001"},
+            {"document_number": "2026-00001", "docket_id": "Sequence No. 1"},
+            # Syntactically plausible, but an antidumping case number rather
+            # than a docket present in the Regulations.gov source corpus.
+            {"document_number": "2026-00001", "docket_id": "A-570-831"},
+        ],
+    )
+    _write(
+        tmp_path / "unified_agenda.parquet",
+        ("rin", "agenda_edition", "cfr_references_json"),
+        [],
+    )
+
+    rows = pq.read_table(
+        build_rule_targets(
+            tmp_path,
+            run_id="fr-label-boundary",
+            asserted_at="2026-07-24T12:00:00Z",
+        )
+    ).to_pylist()
+
+    assert rows
+    assert {row["docket_id"] for row in rows} == {valid_docket, underscore_docket}
+    assert ("fr_cfr_ref", "40-60") in {(row["source"], row["cfr_ref"]) for row in rows}


### PR DESCRIPTION
A rule is a RIN on reginfo, a docket on regulations.gov, a set of CFR parts in the Code, and a document number in the Federal Register. Today the platform pairs a proposed rule with its final rule and links Register documents to dockets, but nothing joins all four, so a user cannot follow one rule from the Unified Agenda through its docket, comment periods, and final rule under every name the government gives it. This adds four transforms that build that join — the docket-CFR-RIN spine, each rulemaking as a first-class proceeding with its actions, agenda items linked to those actions, and every comment period including reopenings — and a runner that publishes them atomically as one generation, so a reader never sees a spine from one run beside proceedings from another.

Run against the five live base tables as published on 2026-09-04: 87 seconds, 3.2 GB peak. `rule_targets` 41,994 rows across 12,360 dockets; `proceedings` 462,826 (185,551 Federal-Register-only, 263 multi-docket); `regulatory_agenda_items` 31,313 with 100,343 action links; `comment_periods` 285,954, of which 109,337 are reopenings. It refused 7,929 source intervals whose end precedes their start and 150,783 that resolve to no proceeding or docket, and says so in the log rather than repairing them. The five tables are not yet in the data dictionary or the MCP server; that follows as its own PR, the way #175 exposed the lifecycle rollups after they existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)