### PR TITLE
feat(courts): publish CourtListener opinion clusters and bodies

### DIFF
--- a/.github/workflows/rollup-court-opinion-bodies.yml
+++ b/.github/workflows/rollup-court-opinion-bodies.yml
@@ -4,7 +4,7 @@ on:
     # 05:40 UTC Mondays — after the cluster rollup, so opinion text lands
     # against decisions the cluster table already knows about. Each run takes a
     # bounded slice of the opinions dump; see the rollup module for the cap and
-    # docs/evidence/court-data-coverage.md for what that leaves uncovered.
+    # docs/evidence/court-data-coverage-2026-08-22.md for what that leaves uncovered.
     - cron: '40 5 * * 1'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/rollup-court-opinion-bodies.yml
+++ b/.github/workflows/rollup-court-opinion-bodies.yml
@@ -1,0 +1,22 @@
+name: Rollup — court_opinion_bodies
+on:
+  schedule:
+    # 05:40 UTC Mondays — after the cluster rollup, so opinion text lands
+    # against decisions the cluster table already knows about. Each run takes a
+    # bounded slice of the opinions dump; see the rollup module for the cap and
+    # docs/evidence/court-data-coverage.md for what that leaves uncovered.
+    - cron: '40 5 * * 1'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+jobs:
+  run:
+    uses: ./.github/workflows/_rollup.yml
+    secrets: inherit
+    with:
+      command: run-rollup-court-opinion-bodies
+      skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}

--- a/.github/workflows/rollup-court-opinion-clusters.yml
+++ b/.github/workflows/rollup-court-opinion-clusters.yml
@@ -1,0 +1,27 @@
+name: Rollup — court_opinion_clusters
+on:
+  schedule:
+    # 04:20 UTC Mondays — the bulk dumps are cut monthly to quarterly, so a
+    # weekly pass is enough to pick up a new one and run the search catch-up.
+    - cron: '20 4 * * 1'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+jobs:
+  run:
+    uses: ./.github/workflows/_rollup.yml
+    secrets: inherit
+    with:
+      command: run-rollup-court-opinion-clusters
+      skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}
+      # This rollup streams two bulk dumps, not one: opinion-clusters for the
+      # decisions (2.3 GiB, ~23 min) and dockets for the court each was decided
+      # in (4.67 GiB, ~46 min), because the cluster dump carries no court_id.
+      # The bucket serves one client about 1.75 MiB/s no matter how many
+      # connections it opens, so that is ~70 minutes of waiting on someone
+      # else's bandwidth. The default 30 would kill the job mid-stream.
+      timeout_minutes: 120

--- a/docs/evidence/court-data-coverage-2026-08-22.md
+++ b/docs/evidence/court-data-coverage-2026-08-22.md
@@ -1,0 +1,689 @@
+> Restored 2026-09-05 from `8d9e7a2` (the second-pass copy; `ee95a7b` is the
+> first pass). The rollup this describes ships in PR #195 with
+> `DEFAULT_MAX_RECORDS = 250_000` in `pipelines/rollups/court_opinion_bodies.py`;
+> the cluster table is the whole dump.
+
+# Court data coverage — what was captured, what was not, 2026-08-22
+
+**Verdict: the opinion-text seam is closed and the decision-to-docket join now
+exists. Opinion *text* coverage is a bounded slice, not a backfill, and the two
+things standing between here and full coverage are 8.6 hours of single-threaded
+bandwidth and a 100 GiB free-space floor — not missing code.**
+
+This is the verification section the court-data expansion owes. Every number is
+measured, and each check names the denominator it was measured against, because
+a coverage claim is worth exactly what its denominator is worth.
+
+> **Second pass, same day.** Four of the nine gaps below were worked after this
+> document was first written, and working them changed three of its findings.
+> The corrections are folded into the sections they belong to and summarised in
+> [What the second pass changed](#what-the-second-pass-changed) at the end. The
+> largest of them: the 12,666 "unexplained orphans" in section 2 were not
+> unexplained and were not orphans. They were an arithmetic error in this
+> document, and there are zero orphans.
+
+## Where the denominators come from
+
+| Question | Denominator | Authority |
+|---|---|---|
+| How much bulk data exists? | The bucket's own S3 listing | `storage.courtlistener.com`, captured 2026-08-22 and pinned in DocSpec at `fixtures/courtlistener-bulk-v1/` |
+| How many APA suits are there? | `court_dockets` on R2 | itself the complete result of a `nature_of_suit=899` search |
+| How many Supreme Court opinions? | the Court's term index pages | `supremecourt.gov/opinions/slipopinion/<term>` |
+
+The publisher's listing is not an index we assembled — it is CourtListener's own
+statement of what exists, which is why it is captured verbatim and pinned rather
+than summarized. Reproduce with `scripts/verify_court_coverage.py`.
+
+### Who owns the population, and who owns the read
+
+Worth stating explicitly, because the two were being conflated:
+
+* **DocSpec owns the population.** `fixtures/courtlistener-bulk-v1/` captures
+  the bucket's listing XML verbatim, digests every page, and — this is the part
+  spicy-regs has no equivalent of — distinguishes an object the publisher
+  *withdrew* (`DELETED`, a tombstone) from one *we* declined (`EXCLUDED`, our
+  decision, reviewable). A population that shrinks without saying so is
+  indistinguishable from a broken capture, and that is the failure DocSpec
+  exists to prevent.
+* **spicy-regs owns the read inside an object.** Streaming a 50.8 GiB bzip2 CSV,
+  the `\"` escape, the row filter, resuming a dropped socket. DocSpec builds
+  catalogs and acquires nothing, so none of that is duplicated.
+
+What *was* being duplicated is the enumeration: spicy-regs re-lists the bucket on
+every build and, until today, recorded none of the object identity it got back.
+A receipt that said "streamed the 2026-06-30 opinions dump" had named a
+filename, not a thing. Captures now pin the object by the publisher's own byte
+size and last-modified stamp, and can be held against DocSpec's capture as a
+*precondition* — which is the useful place to discover a re-cut file when
+reading it costs 8.6 hours.
+
+Checked today, live listing against DocSpec's 04:47Z capture:
+
+| | Live | DocSpec capture |
+|---|---:|---:|
+| objects enumerated | 1,076 | 1,076 |
+| `opinions-2026-06-30.csv.bz2` | 54,561,543,156 B, `2026-06-30T09:56:48Z` | identical |
+| `dockets-2026-06-30.csv.bz2` | 5,014,469,248 B, `2026-06-30T09:03:56Z` | identical |
+| `opinion-clusters-2026-06-30.csv.bz2` | 2,457,231,057 B, `2026-06-30T09:40:19Z` | identical |
+| `courts-2026-06-30.csv.bz2` | 81,180 B, `2026-06-30T09:00:26Z` | identical |
+
+Capture identity
+`urn:docspec:courtlistener-bulk-capture:v1:ccf4cd25…4774d`, pins digest
+`sha256:8c50ed18…a55cb`. The population has not moved since the capture, so the
+8.6-hour pass is reading the object DocSpec pinned.
+
+Two honest limits on that. Agreement here means "the listing has not changed
+since 04:47Z today" — both sides read the same publisher, so it is not
+independent evidence that the publisher is right. And spicy-regs still cannot
+*import* DocSpec; consuming its catalog rather than re-listing the bucket is a
+migration, not a patch, and is not attempted here.
+
+## What the publisher offers
+
+The listing holds **1,076 objects totalling 1,598.65 GiB across 46 datasets**.
+The newest dump of every dataset is dated **2026-06-30**. Exact sizes for the
+ones that matter here:
+
+| Dataset | Compressed | Ratio | Decompressed (est.) | Single-pass stream |
+|---|---:|---:|---:|---:|
+| `opinions` | **50.814 GiB** (54,561,543,156 B) | 8.31x | ~422 GiB | **8.6 h** |
+| `dockets` | 4.670 GiB (5,014,469,248 B) | 6.08x | ~28 GiB | 46 min |
+| `opinion-clusters` | 2.288 GiB (2,457,231,057 B) | 4.48x | ~10 GiB | 23 min |
+| `citation-map` | 0.490 GiB | — | — | 5 min |
+| `parentheticals` | 0.268 GiB | — | — | 3 min |
+| `citations` | 0.119 GiB | 13.72x | ~1.6 GiB | 72 s |
+| `courts` | 81,180 B | 9.43x | ~765 KiB | instant |
+
+Ratios are measured on the first megabytes of each dump, not assumed. Throughput
+is **1.74–1.79 MiB/s on a single connection**, measured three independent ways
+(raw `curl` range read, streamed decompression, and the real ingest). The bucket
+does not go faster for one client; the ingest takes that as given rather than
+opening parallel connections against a service that gives its data away free.
+
+**The cap is per client, not per connection.** Two concurrent streams (the
+`opinions` pass and the `dockets` pass, run side by side on 2026-08-22) settled
+at **1.03 and 0.74 MiB/s — 1.77 MiB/s together**, which is the same number one
+connection gets alone. So parallelism buys nothing here, and the total cost of
+reading two dumps is the sum of their sizes divided by 1.77 MiB/s no matter how
+they are scheduled. That is worth knowing before anyone tries to make the 8.6
+hours shorter by opening sockets.
+
+## The access facts that shaped every bound
+
+Verified 2026-08-22, keyless:
+
+| Endpoint | Status |
+|---|---|
+| `/api/rest/v4/search/?type=r` (dockets) | **200** |
+| `/api/rest/v4/search/?type=o` (opinion clusters) | **200** |
+| `/api/rest/v4/search/?type=rd` (RECAP documents) | **200** |
+| `/api/rest/v4/courts/` | **200** |
+| `/api/rest/v4/opinions/` | **401** |
+| `/api/rest/v4/clusters/` | **401** |
+| `/api/rest/v4/recap-documents/` | **401** |
+| `/api/rest/v4/recap-query/` | **401** |
+
+This corrects a premise the work started from. The REST opinions endpoint does
+**not** serve `html_with_citations` / `plain_text` keylessly — it does not answer
+keylessly at all. `/search/?type=o` is keyless but returns only a `snippet`, not
+a body. **The bulk dumps are therefore the sole keyless source of opinion text**,
+which is why the ingest is bulk-first by necessity rather than by preference, and
+why the 50.8 GiB figure above governs everything downstream.
+
+No `COURTLISTENER_API_TOKEN` is configured on this machine, so every number here
+is a keyless number.
+
+## What was ingested, with exact bounds
+
+Disk headroom at session start was **118 GiB free against a 100 GiB floor** — 18
+GiB of usable room, against an `opinions` dump that is 50.8 GiB compressed before
+it is decompressed at all. That single comparison decided the shape of the whole
+ingest.
+
+| Table | Bound | Result |
+|---|---|---|
+| `court_opinion_clusters` | **full** `opinion-clusters` dump, 2026-06-30, streamed in 23 min | **10,070,727 rows**, 3.94 GB parquet |
+| `court_opinion_bodies` | **250,000 opinions**, read from 1.242 GiB of the 2026-06-30 `opinions` dump | 250,000 rows, 1.74 GB parquet |
+| `courts` (reference read) | full dump | 3,361 courts — 397 federal (127 `F` appellate, 125 `FD` district, 95 `FB` bankruptcy, 8 `FBP` bankruptcy appellate panel, 42 `FS` special), 2,618 `ST` state |
+
+The `opinions` bound is the honest one to argue about, so here it is precisely.
+250,000 opinions came out of 1.242 GiB of a 50.814 GiB dump, which puts the dump
+at roughly **10.23M opinions** and this slice at **2.44%** of it.
+
+The slice is a cross-section, not a prefix: ingested `opinion_id` values run from
+**29 to 11,338,571**, essentially the full width of the corpus, because the dump
+is not ordered by id. That makes the sample usable and representative. It does
+not make it a backfill.
+
+### The full backfill: implemented, costed, not run
+
+`build_court_opinion_bodies` runs unbounded, and `check_headroom` refuses it
+before a byte moves when the arithmetic does not work. On this machine it does
+not work:
+
+* **Disk.** Landing the compressed dump alone takes 118 GiB free down to 67 GiB,
+  below the 100 GiB floor. Streaming avoids landing it, but the output table
+  would be roughly 45–55 GiB of parquet at the measured bytes-per-opinion.
+* **Time.** 8.6 hours of continuous transfer at the bucket's observed rate.
+
+That is a scheduled-job cost on a machine with room, not a workstation cost. It
+is refused here and recorded rather than half-attempted.
+
+## Coverage verification
+
+### 1. Bulk enumeration vs ingested rows
+
+| Dataset | Publisher offers | Ingested | Coverage |
+|---|---:|---:|---:|
+| `opinion-clusters` 2026-06-30 | 10,070,727 rows (whole file read) | 10,070,727 | **100%** |
+| `opinions` 2026-06-30 | ~10.23M rows (derived: 250,000 rows per 1.242 GiB over 50.814 GiB) | 250,000 | **2.44%** |
+| `courts` 2026-06-30 | 3,361 rows | 3,361 | **100%** |
+| `dockets` 2026-06-30 | not ingested | 0 | 0% — superseded by `court_dockets`, which is scoped to APA suits |
+
+The clusters denominator is the dump's own row count, established by reading the
+whole file rather than trusting a published figure, because CourtListener does
+not publish row counts.
+
+### 1a. What "has text" actually means
+
+Judging opinion-text coverage by `plain_text` would have been wrong by a factor
+of four, which is the single most useful thing this ingest measured:
+
+| Body column | Rows populated (of 250,000) |
+|---|---:|
+| **any** text rendering | 249,988 (**100.0%**) |
+| `html_with_citations` | 249,670 (**99.9%**) |
+| `plain_text` | 55,335 (**22.1%**) |
+
+CourtListener stores whichever rendering the upstream source supplied, and
+`html_with_citations` is the one it computes for nearly everything. `plain_text`
+is populated for under a quarter of opinions. A consumer that treated a null
+`plain_text` as "no text available" would discard 78% of a corpus that is in fact
+99.9% covered. That is why the table carries `available_text_fields` and
+`text_char_count`: they make "the publisher holds no text" distinguishable from
+"the publisher holds text, in a different column." The commonest combinations:
+
+| `available_text_fields` | Rows |
+|---|---:|
+| `html_with_citations,xml_harvard` | 131,824 |
+| `plain_text,html_with_citations` | 48,872 |
+| `html_anon_2020,html_with_citations` | 28,631 |
+| `html_lawbox,html_with_citations,xml_harvard` | 12,991 |
+
+By role, the slice is 120,258 lead opinions, 96,293 combined, 13,290 trial-court,
+10,182 dissents and 6,735 concurrences — so separately-authored opinions do come
+through as their own rows, which is the grain the table promises.
+
+### 2. APA docket set vs decisions matched
+
+The join this expansion existed to create works, and it is far sparser than the
+docket count suggests. Both facts are load-bearing.
+
+| Measure | Count | Share |
+|---|---:|---:|
+| clusters ingested | 10,070,727 | — |
+| clusters carrying a `cl_docket_id` | 10,070,727 | **100%** |
+| APA dockets in `court_dockets` | 7,698 | — |
+| **APA dockets with at least one decision** | **759** | **9.9%** |
+| APA dockets with no decision at all | 6,939 | 90.1% |
+| clusters sitting on an APA docket | 1,155 | 0.011% of all clusters |
+
+**90% of the APA docket set has no decision attached** — and the explanation
+first given for that was substantially wrong, so it is worth reading the
+correction rather than the original.
+
+The original reading: `court_dockets` is RECAP, sourced from PACER, and records
+that a suit exists; opinion clusters are sourced from court-website scrapers and
+reporters, and record that a decision was *published*. A challenge that settled,
+was dismissed, or ended in an unpublished order leaves a docket and no cluster.
+That mechanism is real and accounts for much of the 90%.
+
+What it does not account for is **D.D.C.**
+
+### 2a. The D.D.C. anomaly: same case, two docket records
+
+Once every cluster could say which court decided it (gap 8), the per-court
+decision rates became checkable, and one of them is not like the others:
+
+| Court | APA dockets | With ≥1 decision | Rate |
+|---|---:|---:|---:|
+| `dcd` (D.D.C.) | **1,571** | **0** | **0.0%** |
+| `nysd` (S.D.N.Y.) | 259 | 44 | 17.0% |
+| `cand` (N.D. Cal.) | 351 | 53 | 15.1% |
+
+D.D.C. is the **largest APA venue in the set** — 1,571 of 7,698 dockets, 20.4% —
+and it is the classic forum for agency-review litigation. A genuine 0.0%
+published-decision rate there, while its peers run 15–17%, is not credible.
+
+It is not a broken id, either: 1,516 of those 1,571 docket ids are present in the
+`dockets` dump and agree that the court is `dcd`. And D.D.C. is not missing from
+the corpus — **46,581 clusters sit on a D.D.C. docket.** The decisions exist.
+They are attached to a *different docket record for the same case*.
+
+CourtListener carries duplicate dockets: a RECAP/PACER-sourced one, which is
+what a `nature_of_suit=899` search returns, and a scraper-sourced one, which is
+what the opinion cluster hangs off. For most districts these coincide. For
+D.D.C. they frequently do not:
+
+| Case | RECAP docket | Cluster's docket |
+|---|---:|---:|
+| `HALBIG v. SEBELIUS` | 4,211,989 | 120,436 |
+| `PUBLIC CITIZEN HEALTH RESEARCH GROUP v. ACOSTA` | 14,523,291 | 16,255,289 |
+| `BLUE CROSS AND BLUE SHIELD OF FLORIDA v. DEPT…` | 69,500,499 | 70,282,519 |
+| `NORTH AMERICA'S BUILDING TRADES UNIONS v. DEPT…` | 69,864,612 | 70,284,623 |
+
+**Conservatively, at least 249 of the 6,939 "no decision" APA dockets do have a
+decision in this corpus**, reachable only through a different docket id — 184 of
+them D.D.C. That count requires a distinctive case name (≥30 characters), unique
+on both sides within the court, and a decision not predating the filing. Loosen
+the name match and D.D.C. alone yields 499, so 249 is a floor and not an
+estimate.
+
+*The remedy, not applied here:* the `dockets` dump carries `docket_number`, and
+two docket records for one case share it within a court. A `(court_id,
+docket_number)` join is exact where case-name matching is fuzzy, and capturing
+that column costs nothing extra because the dump is already being read for
+`court_id`. It is **deliberately not** folded into the in-flight APA capture: a
+fuzzy join has no business entering a capture silently, and restarting an
+8.6-hour pass at 10% to add ~250 clusters is a bad trade.
+
+So the ceiling is *partly* an upstream property and *partly* a join this ingest
+cannot yet make. Both halves are real; only the first was recorded before.
+
+Two smaller numbers worth stating rather than rounding away:
+
+* **17** of the 250,000 ingested opinion bodies land on an APA docket. That is
+  the arithmetic working exactly as it must — APA clusters are 0.011% of all
+  clusters, so a 2.44% sample would be expected to catch roughly 28 of the 1,155,
+  and it caught 17. It is not a defect; it is what a uniform sample of a corpus
+  buys you when the target is one part in ten thousand. **Targeting the APA set
+  specifically is a `cluster_ids` filter over the same dump**, which the builder
+  already supports — the cost is the full 8.6-hour pass, not new code.
+* **All 250,000 ingested opinions resolve to a cluster in the cluster table.
+  There are no orphans.** An earlier draft of this section reported 12,666
+  (5.1%) that did not, "most likely blocked or withdrawn clusters the two
+  exports treat differently", and recorded it as unexplained. That was an error
+  in this document, not a property of the data, and it is worth spelling out
+  because the shape of it is instructive.
+
+  The number came from subtracting **237,334 distinct clusters** from **250,000
+  opinion rows** — a count of clusters taken away from a count of opinions. The
+  two differ because opinions are not one per cluster:
+
+  | Opinions in the cluster | Clusters |
+  |---|---:|
+  | 1 | 226,487 |
+  | 2 | 9,466 |
+  | 3 | 1,061 |
+  | 4 | 229 |
+  | 5 | 73 |
+  | 6 | 11 |
+  | 7 | 5 |
+  | 8 | 2 |
+
+  The siblings beyond the first come to 9,466 + 2,122 + 687 + 292 + 55 + 30 + 14
+  = **12,666 exactly**. They are the separately-authored concurrences and
+  dissents that section 1a two pages up celebrates as "the grain the table
+  promises". The same fact was written down twice, once as a feature and once as
+  a defect.
+
+  Re-measured with rows on both sides: **250,000 of 250,000 opinions (100%)
+  resolve; 0 do not.** `scripts/verify_court_coverage.py` now reports
+  `opinions_not_resolving_to_a_cluster` alongside the distinct-cluster count and
+  names `sibling_opinions_sharing_a_cluster` as the reason they differ, and a
+  test pins both directions — siblings must not read as orphans, and a genuine
+  orphan must still be seen.
+
+### 3. Supreme Court term index vs captured opinions
+
+The Court's own index is the denominator:
+
+| Term | Slip opinions on the index |
+|---|---:|
+| OT2021 | 66 |
+| OT2022 | 58 |
+| OT2023 | 60 |
+| OT2024 | 67 |
+| OT2025 | 68 |
+| **total OT2021–OT2025** | **319** |
+
+**`court_opinions.parquet` returns 404 from R2.** The SCOTUS ingest exists, is
+tested, and has a rollup, a workflow, and a data-dictionary entry — but its table
+has never been published. Coverage against those 319 opinions is therefore **0%
+published**, and the only copies on this machine are 10-row samples inside sealed
+corpus artifacts. This was already visible in the freshness config, where
+`court_opinions` sits in `SKIPPED` for a different stated reason ("seasonal"),
+which masks the real one. That string is now corrected to say the table is
+unpublished.
+
+**And it is not the only one.** Checked against R2 directly on 2026-08-22:
+
+| Table | R2 |
+|---|---|
+| `court_dockets.parquet` | **200**, 1,450,249 B, 7,698 rows |
+| `court_opinions.parquet` | **404** |
+| `court_opinion_clusters.parquet` | **404** |
+| `court_opinion_bodies.parquet` | **404** |
+
+So three of the four court tables are local-only. `court_opinion_clusters` and
+`court_opinion_bodies` at least say so in the freshness config ("not yet
+published to R2"); publishing all three is one decision, and it is not this
+document's to make.
+
+### 3a. The pre-2021 terms, measured rather than assumed
+
+The gap list below said pre-2021 opinions were unreachable because
+`parse_term_index` refused their URL shape. That is true of *some* of them and
+the scope is smaller than it sounds in both directions. Measured against the
+Court's own indexes:
+
+| Term | Index rows | Slip PDFs | Rows pointing into a volume PDF |
+|---|---:|---:|---:|
+| ≤ OT2016 | **no slip index at all** — the URL redirects to `USReports.aspx` | — | — |
+| OT2017 | 56 | 0 | 56 |
+| OT2018 | 73 | 0 | 73 |
+| OT2019 | 63 | 0 | 63 |
+| OT2020 | 68 | **53** | 15 |
+| OT2021+ | 66 | 66 | 0 |
+
+Two corrections fall out of that table.
+
+* **OT2016 and earlier are not a parser gap.** The Court does not publish a slip
+  opinion index for them; the URL redirects to the bound-volume page. Reaching
+  those terms means reading a different source, not adding a branch.
+* **OT2020 was four-fifths parseable already.** 53 of its 68 rows are ordinary
+  `/opinions/20pdf/` slip PDFs. One refused row raised for the whole term, so
+  the term produced nothing and looked wholly unreachable.
+
+The 207 volume rows point into **16 distinct PDFs** totalling 43.7 MiB — a
+preliminary print or bound volume of the *U.S. Reports*, with the opinion
+located by a `#page=N` fragment. Of those 16, **4 answer 404 at the Court's own
+URL** (`584US1PP_final`, `584US2PP_final`, `585US1PP_final`, `585US2PP_final`),
+covering **56 index rows**. That is a broken upstream link, not a fetch that can
+be retried.
+
+**So OT2017–OT2020 holds 260 index rows, of which 204 (78.5%) are reachable**
+and 56 are not, for a reason nothing on this side can fix.
+
+## Named gaps, and what closing each costs
+
+1. **Opinion text is 2.44% covered.** ~9.98M of ~10.23M opinions unread.
+   *Cost:* 8.6 h of single-connection streaming plus ~45–55 GiB of output. Needs
+   a machine with ≥160 GiB free, or a partitioned run that publishes per-slice.
+   No new code — remove the bound.
+
+2. **`court_opinions` is unpublished** — and so are `court_opinion_clusters` and
+   `court_opinion_bodies`. 319 Supreme Court opinions across OT2021–OT2025 exist
+   upstream and zero are published.
+   *Cost:* one `run-rollup-supreme-court-opinions --no-skip-upload`. Minutes.
+   *Status:* **open, deliberately.** Publishing is a decision, not a task; the
+   `SKIPPED` reason string is corrected in the meantime, because "seasonal" read
+   as a policy when the truth was an absence.
+
+3. ~~**OT2020 and earlier cannot be parsed at all.**~~ **Closed for OT2017–OT2020;
+   OT2016 and earlier are a different source, not a parser branch.** See
+   [3a](#3a-the-pre-2021-terms-measured-rather-than-assumed) for the measurements.
+   `parse_term_index` now recognises `/opinions/preliminaryprint/` and
+   `/opinions/boundvolumes/` alongside the slip-opinion path, refusing everything
+   else exactly as before — including a volume link with no usable `#page=`
+   anchor, because a row that names a volume and claims to be one opinion is the
+   failure this branch exists to avoid.
+   *What the URL shape alone would have bought:* a volume of the *U.S. Reports*
+   stored as the text of each of its sixty opinions, each under a different case
+   name and each wrong. So the anchor is carried through as `source_page_start`,
+   closed against the next opinion in the same volume to give `source_page_end`,
+   and the transform slices the text to that range. Anchors were checked against
+   the real `591US2PP_web.pdf`: all twelve land on their opinion's first page,
+   case name matching the index.
+   *Also found while doing it:* the Court's site does not always serve
+   `/opinions/slipopinion/{code}` the term that code names — a client that had
+   already fetched one term got the **OT2023** index back from the OT2021 URL,
+   sixty real opinions about to be stamped `term_year=2021`. That is silent
+   mislabelling, not an error, and `parse_term_index` now refuses an index whose
+   decisions fall outside the term's date window.
+   *What was not done, and why:* **no end-to-end pre-2021 capture was run.**
+   Partway through measuring, `supremecourt.gov` began answering `403 Access
+   Denied` to this address — after roughly **80 requests over 25 minutes**,
+   about three a minute, across two user agents. Requests are now spaced two
+   seconds apart, but that is a mitigation and not a proof: the threshold is not
+   published, was not isolated, and may not be request rate at all. A full
+   OT2017–OT2025 capture is ~335 requests and **has never been run to
+   completion from this machine** — not before this change either. The parser,
+   the page-range slicing and the document caching are covered by hermetic
+   tests and by anchors checked against the real `591US2PP_web.pdf`; the
+   capture itself is still unproven at scale, and that is the honest state.
+
+4. **RECAP documents are not captured, and are the expensive one.** There is **no
+   `recap-documents` bulk dataset** — 46 datasets, and that is not among them —
+   and `/recap-documents/` and `/recap-query/` are both 401. The only keyless
+   path is `/search/?type=rd`.
+   *Measured on 12 sampled APA dockets:* 11 have at least one RECAP entry, mean
+   **47.7 documents per docket**, which projects to roughly **367,000 document
+   rows** for the 7,698 dockets. Cost is **1.41 s per docket**, so **~3.0 hours
+   for one page each** and materially more to paginate ~48 documents per docket —
+   call it 6–9 hours keyless.
+   The catch that decides it: only **4 of ~220 sampled document rows were marked
+   `is_available`**, meaning the PDF is actually in RECAP. So ~6–9 hours buys
+   mostly *docket-entry metadata*, and under 2% of it leads to a document.
+   *Verdict:* not cheap, so not implemented. Worth revisiting only with an API
+   token, and only if entry metadata alone is the goal.
+
+5. **Only 17 opinion bodies land on an APA docket.** The sample is uniform; the
+   target is 0.011% of the corpus. Nothing is wrong, but nobody should query
+   `court_opinion_bodies` expecting APA coverage today.
+   *Cost:* one targeted pass — `build_court_opinion_bodies(cluster_ids=...)` with
+   the 1,155 APA cluster ids, which the builder already accepts. It still reads
+   the whole 50.8 GiB dump to find them, so 8.6 hours; the *output* is tiny.
+   This is the single highest-value follow-up.
+   *Status:* **running.** `scripts/capture_apa_opinion_bodies.py` reproduces the
+   target set (1,155 clusters over 759 dockets, joined from the published
+   `court_dockets`) and streams the pass, writing a receipt with both inputs
+   digest-pinned and coverage stated against the 1,155.
+   Two things had to change before it could start, and neither was the filter.
+   The disk guard charged every unbounded pass the dump's 50.8 GiB, which is the
+   right stand-in when the output is the whole corpus and refuses a run that
+   costs 141 MiB when it is not — the dump is streamed and never landed, so the
+   volume pays for the parquet written. And a socket held open for 8.6 hours
+   gets dropped, which used to end the run with nothing; the reader now resumes
+   from the exact compressed offset with an HTTP `Range` (the bucket answers
+   206, verified) and counts the resumes.
+   *Where it is:* started 12:20 on 2026-08-22, detached, logging to
+   `logs/apa-opinion-bodies-2026-08-22.log`, writing to
+   `output/court-data-apa-2026-08-22/`. On completion it leaves
+   `court_opinion_bodies.parquet` and `apa_opinion_bodies_receipt.json`;
+   `source_pin.json` is already there, written out of band because the process
+   predates the receipt carrying that block.
+   **Read the receipt's `resumes` before trusting the output**: the running
+   process loaded the reader *before* the guard that refuses a resume the
+   server answered with a restarted stream rather than a range. `resumes: 0`
+   makes that moot, and is the expected case. Anything else, rerun.
+   *This slice does not replace the 250,000-row uniform sample* in
+   `output/court-data-2026-08-22/` — they are complementary and deliberately
+   left unmerged, because merging them runs the duckdb sort that already ran the
+   4 GiB budget out of memory once.
+   *Predicted result, written down before the pass finished so the receipt can
+   be judged rather than admired:* **roughly 1,200–1,300 opinion rows over close
+   to all 1,155 target clusters.** From the pass in flight, 73 kept out of
+   700,000 scanned at 2.92 GiB; the same ratio over the whole dump is ~1,270,
+   and 1,155 clusters at the measured 1.05 opinions per cluster is ~1,213. A
+   result far below that means the filter or the target set is wrong, not that
+   the APA docket set is emptier than section 2 says. Note also that the first
+   250,000 rows yielded 17 — the same 17 the bounded 2026-08-22 run found, from
+   the same 1.24 GiB, which is a free reproducibility check on the reader.
+   *A qualification the capture cannot fix:* **the 1,155-cluster target set is an
+   undercount.** It is every cluster reachable from an APA docket *by docket id*,
+   and [2a](#2a-the-ddc-anomaly-same-case-two-docket-records) shows at least 249
+   more APA decisions exist in this corpus behind a duplicate docket record, 184
+   of them D.D.C. The capture's coverage should therefore be read as a fraction
+   of *the clusters the docket-id join can see*, which is what its receipt says,
+   and not as a fraction of APA decisions in the corpus. Widening the target set
+   needs the `(court_id, docket_number)` join described in gap 7.
+
+6. ~~**12,666 ingested opinions (5.1%) name a cluster the cluster dump does not
+   contain.**~~ **Closed: there are none.** All 250,000 resolve. The 12,666 was
+   this document subtracting a cluster count from an opinion count; the
+   remainder is exactly the sibling concurrences and dissents. The arithmetic is
+   in [section 2](#2-apa-docket-set-vs-decisions-matched). *No reconciliation
+   against the publisher was needed, because there was nothing to reconcile.*
+
+7. **90.1% of APA dockets have no decision.** ~~This is an upstream property, not
+   a coverage failure.~~ **Partly wrong — reopened.** The upstream mechanism is
+   real and explains most of the 90%, but not all of it: at least **249 of the
+   6,939** do have a decision in this corpus, attached to a *duplicate docket
+   record for the same case*. D.D.C. is the concentration — 1,571 APA dockets,
+   the largest venue in the set, **0.0%** matched against peers at 15–17% — and
+   its 46,581 clusters are all hanging off scraper-sourced dockets rather than
+   the RECAP ones a nature-of-suit search returns. See
+   [2a](#2a-the-ddc-anomaly-same-case-two-docket-records).
+   *Cost to close:* capture `docket_number` alongside `court_id` in the
+   docket→court map — free, since the dump is already being read for the court —
+   and join on `(court_id, docket_number)`, which is exact where the case-name
+   match used to diagnose this is fuzzy. Not done here, and deliberately kept out
+   of the in-flight capture.
+   *What is still upstream:* the remainder. Most district-court APA suits really
+   do end without a published opinion, and no join recovers those.
+
+8. ~~**Clusters are the whole corpus, not just federal.**~~ **Closed.**
+   `court_opinion_clusters` now carries `court_id`, `court_jurisdiction` and
+   `court_is_federal`, resolved from the `dockets` dump through `cl_docket_id`.
+   Federal means the publisher's jurisdiction code begins with `F`, which
+   reproduces the 397 in the `courts` dump exactly; the raw code is published
+   next to the boolean so a consumer who disagrees can reclassify without
+   re-reading 4.67 GiB, and a court the dump does not describe is NULL rather
+   than `f` — this table is the whole corpus, so absence of evidence is recorded
+   as absence.
+   *What it cost:* the `dockets` read is one pass for two columns. Checked
+   against the publisher's listing of 46 datasets first: **there is no smaller
+   published docket→court map**, so the 4.67 GiB is the cheapest form the answer
+   comes in. **Measured: 71,677,647 dockets, 4.67 GiB read, 0 resumes, 111
+   minutes at 0.72 MiB/s** — not the predicted 46, because it shared the bucket's
+   per-client cap with the gap-5 pass the whole way. Output 317.1 MiB.
+   *What it found:*
+
+   | | Clusters | Share |
+   |---|---:|---:|
+   | placed in a court | **10,070,727** | **100.0%** |
+   | in a federal court | **3,397,753** | **33.7%** |
+   | not federal | 6,672,974 | 66.3% |
+   | **no court resolvable** | **0** | **0.0%** |
+
+   Federal splits `F` 1,905,145 / `FD` 1,197,191 / `FS` 216,549 / `FB` 72,078 /
+   `FBP` 6,790. The largest single bucket in the whole corpus is `SA` (state
+   appellate) at 3,719,508, then `S` at 2,473,927 — which is the point: **two
+   thirds of `court_opinion_clusters` is state-court output**, and until now
+   there was no way to say so, let alone exclude it.
+
+   *Zero unresolvable is the number worth pausing on.* Every one of the ten
+   million clusters names a docket, and every one of those dockets is in the
+   71.7M-row `dockets` dump. Given that this same document once reported 12,666
+   phantom orphans on the opinions side, a genuine 100% here was checked rather
+   than assumed, and it holds.
+   *And an independent correctness check fell out of it:* all **1,155** APA
+   clusters classify as `FD`, federal district — 100%, no exceptions. An APA
+   docket set derived from a `nature_of_suit=899` RECAP search *should* be
+   entirely federal district, so a join that placed any of them in a state court
+   would be visibly wrong. None are. Top venues: `cand` 126, `nysd` 75, `mdd` 55,
+   `mad` 50, `txnd` 50. The venue that is *missing* from that list is what opened
+   [2a](#2a-the-ddc-anomaly-same-case-two-docket-records).
+   *Artifacts:* `output/court-data-2026-08-22/court_cluster_scope.parquet` plus
+   `cluster_court_scope_receipt.json`, and the map with its own receipt. Written
+   as a side table rather than folded into `court_opinion_clusters.parquet`
+   because the rewrite needs a second copy of a 3.9 GB file and free space is
+   below the 100 GiB floor — and because another pass is currently digesting
+   that exact file.
+   *The design constraint worth recording:* the join happens while each row is
+   shaped, not afterwards. A duckdb join of ten million clusters against
+   seventy-odd million dockets would rewrite the whole 3.9 GB table, and the
+   first build's promote path exists precisely because this machine cannot hold
+   two copies of it. So the map is a dense array — one `unsigned short` per
+   docket id indexing a 3,361-entry court vocabulary, about 150 MB — rather than
+   seventy million Python string keys, which is gigabytes before a single value.
+   *What it costs from now on:* a scheduled cluster run reads two dumps instead
+   of one, about 70 minutes rather than 23. The map is cached by dump date, and
+   `skip_court_scope` opts out and leaves the columns NULL.
+
+9. **The search catch-up did not run.** `CourtListenerOpinionSearchReader` is
+   implemented and tested, but a local run was skipped: the window from the
+   2026-06-30 dump to today spans every court, and keyless cursor pagination over
+   it is a scheduled-job cost. Decisions filed after 2026-06-23 are therefore
+   absent from `court_opinion_clusters`.
+   *Cost:* it already runs in the workflow. Nothing to build.
+
+## One defect found and fixed
+
+The dumps escape an embedded quote as `\"`, not as the doubled `""` the stdlib
+CSV dialect assumes. That does not raise — it **desyncs**, silently. Measured on
+the first 3,000 rows of the 2026-06-30 `opinion-clusters` dump:
+
+| Dialect | Rows whose `id` is a prose fragment | Rows retaining `docket_id` |
+|---|---:|---:|
+| stdlib default | **1,987 / 3,000** | 1,001 / 3,000 |
+| `escapechar='\\'` | **0 / 3,000** | 3,000 / 3,000 |
+
+Two thirds of the join column — the one this entire ingest exists to create —
+would have gone missing in a way indistinguishable from CourtListener not having
+the data. It surfaced only because duckdb refused to cast
+`'<author id=\"b1326-17\">'` to an opinion id. Fixed in `6c7a654` and pinned by a
+regression test. Worth stating plainly: had the merge step been more forgiving,
+this would have shipped as a coverage number that was merely wrong.
+
+## What the second pass changed
+
+Gaps 3, 5, 6 and 8 were worked on 2026-08-22 after this document was first
+written. Three of its findings did not survive contact.
+
+| Was recorded as | Actually |
+|---|---|
+| 12,666 opinions (5.1%) orphaned, cause unexplained | **Zero orphaned.** The figure was a cluster count subtracted from an opinion count; the remainder is exactly the sibling concurrences and dissents |
+| 90.1% of APA dockets have no decision — "an upstream property, not a coverage failure" | **Partly a coverage failure.** At least 249 of the 6,939 have a decision here, behind a duplicate docket record — 184 of them D.D.C., a venue measured at **0.0%** against peers at 15–17% |
+| Pre-2021 unreachable for want of a URL shape | **OT2017–OT2020**: 204 of 260 rows reachable once the volume layout is read, 56 blocked by 404s at the Court's own URLs. **OT2016 and earlier**: no slip index exists — a different source, not a branch |
+| `court_opinions` unpublished | **Three** of the four court tables are unpublished; `court_opinion_clusters` and `court_opinion_bodies` are 404 on R2 too |
+
+The D.D.C. one is the entry that most deserves attention, because of *how* it
+was found. Nobody went looking for it. Gap 8 was closed for an unrelated reason —
+"restrict decisions to federal courts" — and giving every cluster a `court_id`
+made per-court decision rates computable for the first time, at which point a
+0.0% sitting beside two 15–17%s was impossible to miss. The verdict it overturned
+had been reached by reasoning about how the two upstream sources differ, which
+was a correct mechanism applied to a number it did not fully explain. A plausible
+mechanism is not a measurement, and this document had been treating one as the
+other.
+
+Three findings are new, and each is the kind that produces wrong data rather
+than an error:
+
+* **The Court's site serves the wrong term.** A client that had already fetched
+  one term got the OT2023 index back from `/opinions/slipopinion/21`. The rows
+  parse cleanly and `term_year` comes from the caller, so the table would simply
+  have said 2021 about sixty OT2023 opinions. Now refused by a date-window check.
+* **The Court's site blocks**, answering `403 Access Denied` after ~80 requests
+  in 25 minutes — about three a minute — across two user agents. A full
+  OT2017–OT2025 run is ~335 requests, so a capture at any pace is in doubt until
+  someone runs one. Requests are now spaced two seconds apart as a mitigation,
+  not as a solution.
+* **The bucket's throughput cap is per client, not per connection.** Two
+  concurrent streams totalled 1.77 MiB/s, the same as one alone.
+
+And one methodological note, because it is the second time the same shape of
+error has bitten this ingest. The `\"` CSV desync corrupted data without
+raising; the 12,666 was a unit mismatch that produced a plausible number without
+raising. Both were caught by something refusing to accept a value, not by a
+check that was looking for them. The coverage script now reports the orphan
+measure with rows on both sides of the comparison, which is the smallest change
+that makes the mistake impossible to repeat by reading.
+
+### Denominator note: how many opinions the dump actually holds
+
+The ~10.23M figure above is extrapolated from the first 1.242 GiB, and rows are
+not uniformly sized through the dump. Measured on the gap-5 pass as it ran:
+
+| Compressed read | Rows scanned | Implied dump total |
+|---:|---:|---:|
+| 0.35 GiB | 50,000 | 7.26M |
+| 0.61 GiB | 100,000 | 8.33M |
+| 1.06 GiB | 200,000 | 9.59M |
+| 1.24 GiB | 250,000 | 10.24M |
+
+The estimate is still climbing at the point the original sample stopped, so
+**10.23M is a floor derived from the first 2.4%, not a measurement**. The
+gap-5 pass reads the whole file and will settle it exactly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ docs = [
 ]
 
 [project.scripts]
+run-rollup-court-opinion-clusters = "spicy_regs.pipelines.rollups.court_opinion_clusters:app"
+run-rollup-court-opinion-bodies = "spicy_regs.pipelines.rollups.court_opinion_bodies:app"
 run-pipeline = "spicy_regs.pipelines.regulations:app"
 run-rollup-feed-summary = "spicy_regs.pipelines.rollups.feed_summary:app"
 run-rollup-agency-stats = "spicy_regs.pipelines.rollups.agency_stats:app"

--- a/scripts/backfill_cluster_court_scope.py
+++ b/scripts/backfill_cluster_court_scope.py
@@ -1,0 +1,226 @@
+"""Add the court scope to an already-built ``court_opinion_clusters`` table.
+
+``build_court_opinion_clusters`` resolves ``court_id`` / ``court_jurisdiction``
+/ ``court_is_federal`` while it shapes each row, so any table built from now on
+carries them. A table built before that does not, and re-streaming the 2.3 GiB
+dump to add three columns it already has the key for is 23 minutes of reading
+for no new facts.
+
+Two output modes, chosen by what the volume can afford rather than by taste:
+
+* ``scope`` writes a small ``(cluster_id, cl_docket_id, court_id,
+  court_jurisdiction, court_is_federal)`` table — four narrow columns over ten
+  million rows, tens of megabytes — which any query can join.
+* ``full`` rewrites the whole clusters table with the columns inline. That is
+  the better artifact and it costs a second copy of a 3.9 GB file, which is why
+  it is guarded by ``check_headroom`` rather than attempted hopefully.
+
+The default is whichever fits. A run that silently produced the lesser artifact
+would be the sort of quiet degradation this codebase keeps getting bitten by,
+so the mode actually used is logged and lands in the receipt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from loguru import logger
+
+from spicy_regs.transforms.build_court_opinion_bodies import DISK_HEADROOM_FLOOR, check_headroom
+from spicy_regs.transforms.court_scope import CourtScope, court_jurisdictions
+
+SCOPE_COLUMNS = (
+    "cluster_id",
+    "cl_docket_id",
+    "court_id",
+    "court_jurisdiction",
+    "court_is_federal",
+)
+_SCOPE_SCHEMA = pa.schema([(c, pa.string()) for c in SCOPE_COLUMNS])
+BATCH_ROWS = 250_000
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _fits(needed: int, path: Path) -> bool:
+    try:
+        check_headroom(needed, path=path)
+    except RuntimeError as exc:
+        logger.warning("Court scope backfill: {}", exc)
+        return False
+    return True
+
+
+def backfill(
+    *,
+    clusters: Path,
+    docket_court_map: Path,
+    courts_dump: Path,
+    output_dir: Path,
+    dump_date: date,
+    mode: str = "auto",
+) -> dict:
+    """Write the scoped table and return its receipt."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    source = pq.ParquetFile(clusters)
+    total_rows = source.metadata.num_rows
+
+    if mode == "auto":
+        mode = "full" if _fits(clusters.stat().st_size, output_dir) else "scope"
+    elif mode == "full":
+        check_headroom(clusters.stat().st_size, path=output_dir)
+    logger.info(
+        "Court scope backfill: {:,} clusters, mode={} (floor {:.0f} GiB)",
+        total_rows,
+        mode,
+        DISK_HEADROOM_FLOOR / 2**30,
+    )
+
+    args = argparse.Namespace(
+        clusters=clusters,
+        docket_court_map=docket_court_map,
+        courts_dump=courts_dump,
+        output_dir=output_dir,
+        dump_date=dump_date,
+    )
+    scope = CourtScope.from_map(args.docket_court_map, court_jurisdictions(local_file=args.courts_dump))
+
+    existing = [field.name for field in source.schema_arrow]
+    if mode == "full":
+        out_columns = list(existing)
+        # Keep the published order: the scope sits next to the join key it is
+        # derived from, not bolted onto the end. Inserted as one slice — three
+        # separate inserts at the same position reverse them.
+        missing = [
+            column for column in ("court_id", "court_jurisdiction", "court_is_federal") if column not in out_columns
+        ]
+        at = out_columns.index("cl_docket_id") + 1
+        out_columns[at:at] = missing
+        out_schema = pa.schema([(c, pa.string()) for c in out_columns])
+        out_file = args.output_dir / "court_opinion_clusters.parquet"
+    else:
+        out_columns = list(SCOPE_COLUMNS)
+        out_schema = _SCOPE_SCHEMA
+        out_file = args.output_dir / "court_cluster_scope.parquet"
+
+    staging = out_file.with_suffix(".partial.parquet")
+    writer = pq.ParquetWriter(staging, out_schema, compression="zstd")
+    jurisdictions: Counter[str] = Counter()
+    federal = unknown = 0
+    written = 0
+    # Scope mode needs two columns out of thirty-six, and the thirty-four it
+    # does not need include syllabus, headmatter and summary — kilobytes of
+    # prose per row. Materializing those as Python objects, 250,000 rows at a
+    # time, is gigabytes of memory to answer a question about docket ids.
+    # Full mode has to carry every column through, so its batches are a tenth
+    # the size for the same peak memory.
+    full = mode == "full"
+    read_columns = None if full else list(SCOPE_COLUMNS[:2])
+    batch_rows = BATCH_ROWS // 10 if full else BATCH_ROWS
+    try:
+        for batch in source.iter_batches(batch_size=batch_rows, columns=read_columns):
+            rows = batch.to_pylist()
+            shaped = []
+            for row in rows:
+                court_id, jurisdiction, is_fed = scope.for_docket(row.get("cl_docket_id"))
+                jurisdictions[jurisdiction or "<unknown>"] += 1
+                if is_fed == "t":
+                    federal += 1
+                elif is_fed is None:
+                    unknown += 1
+                enriched = {
+                    "court_id": court_id,
+                    "court_jurisdiction": jurisdiction,
+                    "court_is_federal": is_fed,
+                }
+                if mode == "full":
+                    shaped.append({**row, **enriched})
+                else:
+                    shaped.append(
+                        {
+                            "cluster_id": row.get("cluster_id"),
+                            "cl_docket_id": row.get("cl_docket_id"),
+                            **enriched,
+                        }
+                    )
+            writer.write_table(pa.Table.from_pylist(shaped, schema=out_schema))
+            written += len(shaped)
+            if written % (BATCH_ROWS * 8) == 0:
+                logger.info("Court scope backfill: {:,} / {:,} rows", written, total_rows)
+    finally:
+        writer.close()
+    staging.replace(out_file)
+
+    receipt = {
+        "artifact": out_file.name,
+        "mode": mode,
+        "written_at": datetime.now(UTC).isoformat(),
+        "inputs": {
+            "clusters": {"path": str(args.clusters), "sha256": _sha256(args.clusters)},
+            "docket_court_map": {
+                "path": str(args.docket_court_map),
+                "sha256": _sha256(args.docket_court_map),
+                "dockets": pq.ParquetFile(args.docket_court_map).metadata.num_rows,
+                "dump_date": args.dump_date.isoformat(),
+            },
+            "courts_dump": {
+                "path": str(args.courts_dump),
+                "sha256": _sha256(args.courts_dump),
+            },
+        },
+        "coverage": {
+            "denominator": "clusters in court_opinion_clusters",
+            "denominator_count": total_rows,
+            "rows_written": written,
+            "clusters_placed_in_a_court": total_rows - unknown,
+            "clusters_with_no_court": unknown,
+            "clusters_in_a_federal_court": federal,
+            "federal_share": round(federal / total_rows, 6) if total_rows else None,
+            "by_jurisdiction": dict(jurisdictions.most_common()),
+        },
+    }
+    receipt_path = args.output_dir / "cluster_court_scope_receipt.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2) + "\n")
+    logger.info("Receipt written to {}", receipt_path)
+    return receipt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--clusters", type=Path, required=True)
+    parser.add_argument("--docket-court-map", type=Path, required=True)
+    parser.add_argument("--courts-dump", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--dump-date", type=date.fromisoformat, default=date(2026, 6, 30))
+    parser.add_argument("--mode", choices=("auto", "scope", "full"), default="auto")
+    options = parser.parse_args()
+    print(
+        json.dumps(
+            backfill(
+                clusters=options.clusters,
+                docket_court_map=options.docket_court_map,
+                courts_dump=options.courts_dump,
+                output_dir=options.output_dir,
+                dump_date=options.dump_date,
+                mode=options.mode,
+            ),
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/spicy_regs/pipelines/rollups/court_opinion_bodies.py
+++ b/src/spicy_regs/pipelines/rollups/court_opinion_bodies.py
@@ -6,7 +6,7 @@ compressed and takes roughly 8.6 hours to stream end to end, which is not a
 sensible unit of work for a scheduled job that also has to leave the disk
 usable. ``DEFAULT_MAX_RECORDS`` caps a scheduled run; the full backfill is a
 deliberate, separately-invoked operation documented in
-``docs/evidence/court-data-coverage.md``.
+``docs/evidence/court-data-coverage-2026-08-22.md``.
 """
 
 from pathlib import Path

--- a/src/spicy_regs/pipelines/rollups/court_opinion_bodies.py
+++ b/src/spicy_regs/pipelines/rollups/court_opinion_bodies.py
@@ -1,0 +1,37 @@
+"""Rollup pipeline: court_opinion_bodies.parquet (CourtListener bulk opinion text).
+
+Ingests an external source, so ``inputs`` is empty. Unlike the other ingest
+rollups this one carries a **default bound**: the ``opinions`` dump is 50.8 GiB
+compressed and takes roughly 8.6 hours to stream end to end, which is not a
+sensible unit of work for a scheduled job that also has to leave the disk
+usable. ``DEFAULT_MAX_RECORDS`` caps a scheduled run; the full backfill is a
+deliberate, separately-invoked operation documented in
+``docs/evidence/court-data-coverage.md``.
+"""
+
+from pathlib import Path
+from typing import ClassVar
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.transforms import build_court_opinion_bodies
+
+#: Opinions kept by a scheduled run. Chosen so a run finishes in ~15 minutes at
+#: the bucket's observed ~1.8 MiB/s and leaves the free-space floor intact.
+DEFAULT_MAX_RECORDS = 250_000
+
+
+class CourtOpinionBodiesRollup(RollupPipeline):
+    """Court opinion text (plain_text, html_with_citations) from CourtListener bulk data."""
+
+    name: ClassVar[str] = "court-opinion-bodies"
+    inputs: ClassVar[tuple[str, ...]] = ()
+    output: ClassVar[str] = "court_opinion_bodies.parquet"
+
+    def build(self, output_dir: Path) -> Path:
+        return build_court_opinion_bodies(output_dir, max_records=DEFAULT_MAX_RECORDS)
+
+
+app = make_rollup_app(CourtOpinionBodiesRollup)
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/pipelines/rollups/court_opinion_clusters.py
+++ b/src/spicy_regs/pipelines/rollups/court_opinion_clusters.py
@@ -1,0 +1,38 @@
+"""Rollup pipeline: court_opinion_clusters.parquet (CourtListener bulk ingest).
+
+Like ``courtlistener``, this rollup *ingests* an external source rather than
+reading base tables from R2, so ``inputs`` is empty — the bulk read, the search
+catch-up, and the incremental merge with the prior published table all happen
+inside ``build_court_opinion_clusters``.
+
+**A run reads two dumps, not one.** The cluster dump says nothing about which
+court decided; that lives on the docket. So a scheduled run streams the 2.3 GiB
+``opinion-clusters`` dump *and* the 4.67 GiB ``dockets`` dump — about 70 minutes
+at the bucket's observed rate rather than 23. That is the whole price of the
+table being able to answer "what have the federal courts said", which is the
+first question anyone asks of ten million decisions from 3,361 courts. The
+docket map is cached by dump date, so re-running inside one quarter pays once.
+"""
+
+from pathlib import Path
+from typing import ClassVar
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.transforms import build_court_opinion_clusters
+
+
+class CourtOpinionClustersRollup(RollupPipeline):
+    """Federal and state court decisions (opinion clusters) from CourtListener bulk data."""
+
+    name: ClassVar[str] = "court-opinion-clusters"
+    inputs: ClassVar[tuple[str, ...]] = ()
+    output: ClassVar[str] = "court_opinion_clusters.parquet"
+
+    def build(self, output_dir: Path) -> Path:
+        return build_court_opinion_clusters(output_dir)
+
+
+app = make_rollup_app(CourtOpinionClustersRollup)
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/sources/courtlistener.py
+++ b/src/spicy_regs/sources/courtlistener.py
@@ -161,3 +161,87 @@ class CourtListenerReader(Reader):
                 )
                 time.sleep(backoff)
         return None
+
+
+class CourtListenerOpinionSearchReader(CourtListenerReader):
+    """Yields raw CourtListener *opinion* search results (``type=o``), keyless.
+
+    This is the incremental catch-up path for the opinion tables, whose bulk
+    dumps are published only every month or two. It reuses the parent's cursor
+    pagination and retry policy and changes only the query.
+
+    **Why search rather than the opinion endpoint.** ``/opinions/`` and
+    ``/clusters/`` both answer ``401`` without an API token (verified
+    2026-08-22), so neither is usable in the keyless posture the rest of this
+    connector assumes. ``/search/?type=o`` is keyless and returns one result per
+    *cluster*, carrying ``cluster_id``, ``docket_id``, the case-level metadata,
+    and a nested ``opinions`` array with each opinion's ``id``, ``type``,
+    ``sha1``, ``download_url``, ``local_path``, and a text ``snippet``.
+
+    What it does **not** carry is the full ``plain_text`` / ``html_with_citations``
+    body — those exist only in the bulk dumps. So this reader keeps cluster
+    metadata current between dumps; it cannot backfill opinion text, and callers
+    must not pretend otherwise.
+    """
+
+    def __init__(
+        self,
+        *,
+        since: date | None = None,
+        court: str | None = None,
+        max_records: int | None = None,
+        api_token: str | None = None,
+        verbose: bool = False,
+    ) -> None:
+        super().__init__(
+            since=since,
+            max_records=max_records,
+            api_token=api_token,
+            verbose=verbose,
+        )
+        self.court = court
+
+    def iter_records(self) -> Iterator[dict]:
+        keyed = "with API token" if self.api_token else "keyless (lower rate limit)"
+        logger.info(
+            "CourtListener: fetching opinion clusters {} (court={}, since={}, max_records={})",
+            keyed,
+            self.court or "all",
+            self.since or "the beginning",
+            self.max_records or "unbounded",
+        )
+        headers = {"Accept": "application/json"}
+        if self.api_token:
+            headers["Authorization"] = f"Token {self.api_token}"
+        with httpx.Client(timeout=_TIMEOUT, headers=headers) as client:
+            self._client = client
+            yield from self._paginate()
+        logger.info("CourtListener: yielded {:,} opinion clusters", self._seen)
+
+    def _paginate(self) -> Iterator[dict]:
+        """Follow the cursor ``next`` URL over ``type=o`` results."""
+        params: dict[str, object] = {
+            "type": "o",  # opinions (one result per cluster)
+            "order_by": "dateFiled asc",
+        }
+        if self.court is not None:
+            params["court"] = self.court
+        if self.since is not None:
+            params["filed_after"] = self.since.strftime("%m/%d/%Y")
+        url = f"{API_BASE}/search/"
+        first = True
+        while url:
+            payload = self._get(url, params if first else None)
+            first = False
+            if payload is None:
+                break
+            for cluster in payload.get("results") or []:
+                self._seen += 1
+                if self._seen % _PROGRESS_EVERY == 0:
+                    logger.info("CourtListener: {:,} opinion clusters so far...", self._seen)
+                yield cluster
+                if self.max_records is not None and self._seen >= self.max_records:
+                    if self.verbose:
+                        logger.debug("CourtListener: reached max_records {} — stopping", self.max_records)
+                    return
+            url = payload.get("next") or ""

--- a/src/spicy_regs/sources/courtlistener_bulk.py
+++ b/src/spicy_regs/sources/courtlistener_bulk.py
@@ -1,0 +1,519 @@
+"""Reader connector for the CourtListener bulk-data dumps (quarterly CSV exports).
+
+Complements :mod:`spicy_regs.sources.courtlistener`, which reads the v4
+``/search/`` endpoint for *docket* metadata. This module reads the other half of
+the publisher's surface: the periodic full-table CSV dumps at
+``storage.courtlistener.com/bulk-data/``, which are the **only keyless source of
+opinion text**. The REST ``/opinions/`` and ``/clusters/`` endpoints both answer
+``401`` without a token (verified 2026-08-22); ``/search/`` and ``/courts/`` do
+not. So a bulk read is not an optimization here, it is the only road.
+
+**The listing is the publisher's enumeration.** The bucket answers the S3 v2
+list API, so ``list_bulk_dumps`` recovers every published object with its exact
+byte size and last-modified stamp. That listing is what makes coverage
+*checkable*: a claim about how much of a dump we ingested is measured against
+the publisher's own row counts, not against our hopes.
+
+**Streaming, not landing.** The dumps are bzip2 and some are enormous — the
+2026-06-30 ``opinions`` dump is 50.8 GiB compressed and roughly 422 GiB
+decompressed at its observed 8.3x ratio. Landing that is not an option on a
+workstation, so the reader decompresses *as it downloads* and never holds more
+than a buffer in memory. ``max_records`` / ``max_compressed_bytes`` bound a run
+so a partial ingest is a deliberate, recorded slice rather than a timeout.
+
+**Politeness.** Every request carries an honest identifying User-Agent. The
+bucket serves at roughly 1.7-2.0 MiB/s per connection; the reader takes that as
+given rather than opening parallel connections to work around it.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import bz2
+import csv
+import io
+import sys
+import time
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+from loguru import logger
+
+from spicy_regs.sources.base import Reader
+
+#: Public read endpoint for the dumps themselves.
+BULK_BASE_URL = "https://storage.courtlistener.com/bulk-data"
+
+#: S3 REST endpoint for the same bucket. ``storage.courtlistener.com`` is a
+#: CloudFront-style alias that does not answer the list API; the bucket host
+#: does, so enumeration goes here and byte reads go to ``BULK_BASE_URL``.
+BULK_LIST_URL = "https://com-courtlistener-storage.s3.amazonaws.com/"
+BULK_PREFIX = "bulk-data/"
+
+_S3_NS = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
+
+#: Identify honestly. CourtListener publishes this data for public reuse; the
+#: least we owe them is a contactable agent string.
+USER_AGENT = "spicy-regs/0.1 (+https://spicy-regs.dev) courtlistener-bulk-ingest"
+
+_TIMEOUT = 180.0
+_MAX_RETRIES = 5
+_CHUNK = 4 << 20
+_PROGRESS_EVERY = 50_000
+
+#: Opinion text rows carry entire judicial opinions in one CSV field, which is
+#: far past the stdlib default. Raise once, at import, to the platform maximum.
+csv.field_size_limit(sys.maxsize)
+
+#: The dumps escape an embedded quote as ``\"``, not as the doubled ``""`` the
+#: stdlib assumes. Reading them with the default dialect does not fail — it
+#: *desyncs*: the reader treats the escaped quote as the end of the field, and
+#: the prose after it becomes the next record's first column. Measured on the
+#: 2026-06-30 ``opinion-clusters`` dump, the default dialect corrupts 1,987 of
+#: the first 3,000 rows and drops ``docket_id`` on two thirds of them, which
+#: would have quietly destroyed the join this whole ingest exists to make. With
+#: ``escapechar`` set, the same 3,000 rows parse clean and every one keeps its
+#: docket. ``doublequote`` stays True so a literal ``""`` empty field still reads.
+CSV_DIALECT: dict[str, Any] = {"escapechar": "\\", "doublequote": True}
+
+
+@dataclass(frozen=True)
+class BulkObject:
+    """One published object in the bulk-data prefix."""
+
+    key: str
+    size: int
+    last_modified: str
+
+    @property
+    def filename(self) -> str:
+        return self.key.rsplit("/", 1)[-1]
+
+    @property
+    def dataset(self) -> str | None:
+        """Dataset name with the dump date stripped (``opinions``, ``courts``...)."""
+        name = self.filename
+        for suffix in (".csv.bz2", ".sql", ".sh", ".csv", ".zip"):
+            if name.endswith(suffix):
+                name = name[: -len(suffix)]
+                break
+        if len(name) > 11 and name[-11] == "-":
+            stem, tail = name[:-11], name[-10:]
+            if _is_iso_date(tail):
+                return stem
+        return name or None
+
+    @property
+    def dump_date(self) -> date | None:
+        """The dump's date stamp, or None for the undated one-off exports."""
+        name = self.filename
+        for suffix in (".csv.bz2", ".sql", ".sh", ".csv", ".zip"):
+            if name.endswith(suffix):
+                name = name[: -len(suffix)]
+                break
+        tail = name[-10:]
+        return date.fromisoformat(tail) if _is_iso_date(tail) else None
+
+    @property
+    def url(self) -> str:
+        return f"{BULK_BASE_URL}/{self.filename}"
+
+
+def _is_iso_date(value: str) -> bool:
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _request(url: str, *, extra_headers: dict[str, str] | None = None):
+    headers = {"User-Agent": USER_AGENT}
+    if extra_headers:
+        headers.update(extra_headers)
+    return urllib.request.Request(url, headers=headers)
+
+
+def _open(url: str, *, extra_headers: dict[str, str] | None = None):
+    """Open a URL with bounded retries and exponential backoff."""
+    last: Exception | None = None
+    for attempt in range(1, _MAX_RETRIES + 1):
+        try:
+            return urllib.request.urlopen(_request(url, extra_headers=extra_headers), timeout=_TIMEOUT)
+        except Exception as exc:  # noqa: BLE001 - urllib raises a wide family
+            last = exc
+            if attempt == _MAX_RETRIES:
+                break
+            backoff = min(2**attempt, 60)
+            logger.warning(
+                "CourtListener bulk: {} (attempt {}/{}), retrying in {}s",
+                exc,
+                attempt,
+                _MAX_RETRIES,
+                backoff,
+            )
+            time.sleep(backoff)
+    raise RuntimeError(f"CourtListener bulk: giving up on {url}") from last
+
+
+def list_bulk_dumps(prefix: str = BULK_PREFIX) -> list[BulkObject]:
+    """Enumerate every object under the bulk-data prefix, with exact sizes.
+
+    This is the publisher's own enumeration of what exists. Coverage claims are
+    checked against it, so it is fetched rather than assumed.
+    """
+    found: list[BulkObject] = []
+    token: str | None = None
+    while True:
+        query = {"list-type": "2", "prefix": prefix, "max-keys": "1000"}
+        if token:
+            query["continuation-token"] = token
+        with _open(BULK_LIST_URL + "?" + urllib.parse.urlencode(query)) as response:
+            root = ET.fromstring(response.read())
+        for node in root.findall("s3:Contents", _S3_NS):
+            found.append(
+                BulkObject(
+                    key=node.findtext("s3:Key", "", _S3_NS),
+                    size=int(node.findtext("s3:Size", "0", _S3_NS)),
+                    last_modified=node.findtext("s3:LastModified", "", _S3_NS),
+                )
+            )
+        if root.findtext("s3:IsTruncated", "false", _S3_NS) != "true":
+            break
+        token = root.findtext("s3:NextContinuationToken", None, _S3_NS)
+        if not token:
+            break
+    logger.info("CourtListener bulk: listing has {:,} objects", len(found))
+    return found
+
+
+def published_object_pin(
+    dataset: str,
+    dump_date: date,
+    *,
+    objects: list[BulkObject] | None = None,
+    expect_bytes: int | None = None,
+    expect_last_modified: str | None = None,
+) -> dict[str, object]:
+    """Identify the published object a capture read, in receipt form.
+
+    A capture that says "streamed the 2026-06-30 opinions dump" has named a
+    filename, not a thing. The publisher's listing carries the object's exact
+    byte size and last-modified stamp, which is what makes two runs comparable
+    and what makes "the dump changed under us" a detectable event rather than an
+    unexplained difference in row counts.
+
+    **The population itself is DocSpec's to pin**, at
+    ``fixtures/courtlistener-bulk-v1/`` — it captures this listing verbatim,
+    digests it, and distinguishes an object the publisher withdrew from one we
+    declined. This function does not re-derive any of that. It records the one
+    object a run actually read, and ``expect_bytes`` / ``expect_last_modified``
+    let a caller hold that record against DocSpec's pin *before* spending 8.6
+    hours reading it.
+    """
+    listing = objects if objects is not None else list_bulk_dumps()
+    published = find_dump(listing, dataset, dump_date)
+    if published is None:
+        raise RuntimeError(f"CourtListener bulk: no {dataset} dump published for {dump_date}")
+    if expect_bytes is not None and published.size != expect_bytes:
+        raise RuntimeError(
+            f"CourtListener bulk: {published.filename} is {published.size} bytes, "
+            f"not the pinned {expect_bytes} — the publisher's object changed"
+        )
+    if expect_last_modified is not None and published.last_modified != expect_last_modified:
+        raise RuntimeError(
+            f"CourtListener bulk: {published.filename} was last modified "
+            f"{published.last_modified}, not the pinned {expect_last_modified} — "
+            f"the publisher's object changed"
+        )
+    return {
+        "dataset": dataset,
+        "dump_date": dump_date.isoformat(),
+        "filename": published.filename,
+        "url": published.url,
+        "bytes": published.size,
+        "last_modified": published.last_modified,
+        "listing_object_count": len(listing),
+        "listing_host": BULK_LIST_URL,
+    }
+
+
+def latest_dump_date(objects: list[BulkObject], dataset: str) -> date | None:
+    """Newest dump date published for ``dataset``, or None if it has none."""
+    dates = [o.dump_date for o in objects if o.dataset == dataset and o.dump_date]
+    return max(dates) if dates else None
+
+
+def find_dump(objects: list[BulkObject], dataset: str, dump_date: date) -> BulkObject | None:
+    """The published object for one dataset at one dump date."""
+    for obj in objects:
+        if obj.dataset == dataset and obj.dump_date == dump_date:
+            return obj
+    return None
+
+
+class _UnrangeableResume(RuntimeError):
+    """A resume the server answered with a whole new stream instead of a range."""
+
+
+class _StreamedResponse(Protocol):
+    """The slice of an HTTP response body this reader touches."""
+
+    def read(self, amt: int, /) -> bytes: ...
+    def close(self) -> None: ...
+
+
+class _CountingStream(io.RawIOBase):
+    """Adapt an HTTP response to a readable stream, decompressing bzip2 inline.
+
+    Tracks compressed bytes pulled so a caller can stop on a byte budget without
+    waiting for a row count.
+
+    **Resumable.** A full pass over the ``opinions`` dump is 8.6 hours on one
+    socket, and a socket held open that long will occasionally be dropped by
+    something between here and the bucket. Failing at hour seven with nothing to
+    show for it is the difference between this ingest being feasible and not, so
+    a read error reopens the transfer with an HTTP ``Range`` starting at the
+    exact compressed offset already consumed and keeps feeding the *same*
+    decompressor — bzip2 needs its compressed bytes in order, not in one socket.
+    ``reopen`` is the callable that performs that ranged re-request; without one
+    (a local file) a read error still propagates.
+
+    **Multi-stream aware.** ``bzip2`` writes one stream; ``pbzip2`` writes a
+    concatenation of them, and a plain ``BZ2Decompressor`` raises ``EOFError``
+    the moment it is fed a byte past the first stream's end. The publisher's
+    dumps read as single-stream today, but a compressor change upstream would
+    otherwise truncate a pass silently-ish at a stream boundary, so a finished
+    decompressor is replaced and its ``unused_data`` carried over.
+    """
+
+    def __init__(
+        self,
+        response: _StreamedResponse,
+        *,
+        max_compressed_bytes: int | None = None,
+        reopen: Callable[[int], _StreamedResponse] | None = None,
+    ) -> None:
+        self._response: _StreamedResponse = response
+        self._reopen = reopen
+        self._decompressor = bz2.BZ2Decompressor()
+        self._buffer = b""
+        self._max_compressed_bytes = max_compressed_bytes
+        self.compressed_bytes = 0
+        self.decompressed_bytes = 0
+        self.resumes = 0
+        self._exhausted = False
+
+    def readable(self) -> bool:
+        return True
+
+    def close(self) -> None:
+        """Close whichever response is current — after a resume it is not the first."""
+        try:
+            self._response.close()
+        except Exception:  # noqa: BLE001, S110 - closing a broken socket
+            pass
+        super().close()
+
+    def _read_chunk(self) -> bytes:
+        """Pull the next compressed chunk, reconnecting mid-stream if need be."""
+        try:
+            return self._response.read(_CHUNK)
+        except Exception as exc:  # noqa: BLE001 - urllib/ssl raise a wide family
+            if self._reopen is None:
+                raise
+            logger.warning(
+                "CourtListener bulk: transfer failed after {:.3f} GiB ({}); resuming",
+                self.compressed_bytes / 2**30,
+                exc,
+            )
+        for attempt in range(1, _MAX_RETRIES + 1):
+            try:
+                self._response.close()
+            except Exception:  # noqa: BLE001, S110 - closing a broken socket
+                pass
+            try:
+                resumed = self._reopen(self.compressed_bytes)
+                # A server that ignores Range answers 200 and starts over from
+                # byte zero. Feeding that to a decompressor already 30 GiB into
+                # the stream does not fail — it produces garbage rows that look
+                # like data, which is the one outcome worse than the dropped
+                # connection this is recovering from.
+                status = getattr(resumed, "status", None)
+                if self.compressed_bytes and status != 206:
+                    # Not retryable: a server that ignores Range will ignore it
+                    # again, and every retry is another chance to splice.
+                    raise _UnrangeableResume(
+                        f"CourtListener bulk: resume at byte {self.compressed_bytes} "
+                        f"answered {status}, not 206 — refusing to splice a restarted "
+                        f"stream onto a partial one"
+                    )
+                self._response = resumed
+                self.resumes += 1
+                return self._response.read(_CHUNK)
+            except _UnrangeableResume:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                if attempt == _MAX_RETRIES:
+                    raise RuntimeError(
+                        f"CourtListener bulk: could not resume at byte {self.compressed_bytes} after {attempt} attempts"
+                    ) from exc
+                backoff = min(2**attempt, 60)
+                logger.warning(
+                    "CourtListener bulk: resume attempt {}/{} failed ({}), retrying in {}s",
+                    attempt,
+                    _MAX_RETRIES,
+                    exc,
+                    backoff,
+                )
+                time.sleep(backoff)
+        return b""  # pragma: no cover - the loop either returns or raises
+
+    def _decompress(self, chunk: bytes) -> bytes:
+        """Decompress one chunk, rolling over a concatenated bzip2 stream."""
+        out = self._decompressor.decompress(chunk)
+        while self._decompressor.eof and self._decompressor.unused_data:
+            leftover = self._decompressor.unused_data
+            self._decompressor = bz2.BZ2Decompressor()
+            out += self._decompressor.decompress(leftover)
+        return out
+
+    def readinto(self, target) -> int:  # type: ignore[override]
+        while not self._buffer and not self._exhausted:
+            if self._max_compressed_bytes is not None and self.compressed_bytes >= self._max_compressed_bytes:
+                self._exhausted = True
+                break
+            chunk = self._read_chunk()
+            if not chunk:
+                self._exhausted = True
+                break
+            self.compressed_bytes += len(chunk)
+            self._buffer = self._decompress(chunk)
+            self.decompressed_bytes += len(self._buffer)
+        if not self._buffer:
+            return 0
+        size = min(len(target), len(self._buffer))
+        target[:size] = self._buffer[:size]
+        self._buffer = self._buffer[size:]
+        return size
+
+
+class CourtListenerBulkReader(Reader):
+    """Yield raw CSV rows from one CourtListener bulk dump, decompressed inline.
+
+    Pure source: rows are yielded as the publisher wrote them (all values are
+    strings; the empty string is normalized to ``None``). Shaping belongs to the
+    ``transforms/build_court_*`` builders.
+
+    ``local_file`` reads an already-downloaded ``.bz2`` instead of the network,
+    which is how the small dumps are handled once cached. ``max_records`` and
+    ``max_compressed_bytes`` bound a run; ``row_filter`` drops rows before they
+    are materialized, which is what keeps a filtered pass over a huge dump cheap.
+    """
+
+    def __init__(
+        self,
+        dataset: str,
+        *,
+        dump_date: date | None = None,
+        local_file: Path | None = None,
+        max_records: int | None = None,
+        max_compressed_bytes: int | None = None,
+        row_filter: Callable[[dict], bool] | None = None,
+    ) -> None:
+        self.dataset = dataset
+        self.dump_date = dump_date
+        self.local_file = local_file
+        self.max_records = max_records
+        self.max_compressed_bytes = max_compressed_bytes
+        self.row_filter = row_filter
+        #: Populated during iteration so a caller can record the exact bound hit.
+        self.rows_scanned = 0
+        self.rows_yielded = 0
+        self.compressed_bytes = 0
+        self.decompressed_bytes = 0
+        self.stopped_early = False
+        self.source_url: str | None = None
+        #: How many times the transfer had to be reconnected mid-dump. Belongs in
+        #: a receipt: a pass that resumed twice read the same bytes as one that
+        #: did not, but it is not the same run and should not be recorded as one.
+        self.resumes = 0
+
+    def _stream(self):
+        if self.local_file is not None:
+            self.source_url = str(self.local_file)
+            return open(self.local_file, "rb"), None  # noqa: SIM115
+        if self.dump_date is None:
+            raise ValueError("dump_date is required when reading over the network")
+        filename = f"{self.dataset}-{self.dump_date.isoformat()}.csv.bz2"
+        url = f"{BULK_BASE_URL}/{filename}"
+        self.source_url = url
+        logger.info("CourtListener bulk: streaming {}", url)
+        response = _open(url)
+        return response, response
+
+    def iter_records(self) -> Iterator[dict]:
+        handle, response = self._stream()
+        try:
+            if response is None:
+                raw: io.BufferedIOBase = io.BufferedReader(
+                    _LocalBz2Stream(handle, max_compressed_bytes=self.max_compressed_bytes)
+                )
+                counter = raw.raw  # type: ignore[assignment]
+            else:
+                url = self.source_url
+                counter = _CountingStream(
+                    handle,
+                    max_compressed_bytes=self.max_compressed_bytes,
+                    reopen=lambda offset: _open(str(url), extra_headers={"Range": f"bytes={offset}-"}),
+                )
+                raw = io.BufferedReader(counter)  # type: ignore[arg-type]
+            text = io.TextIOWrapper(raw, encoding="utf-8", errors="replace", newline="")
+            for row in csv.DictReader(text, **CSV_DIALECT):
+                self.rows_scanned += 1
+                if self.rows_scanned % _PROGRESS_EVERY == 0:
+                    logger.info(
+                        "CourtListener bulk {}: {:,} rows scanned, {:,} kept, {:.2f} GiB compressed",
+                        self.dataset,
+                        self.rows_scanned,
+                        self.rows_yielded,
+                        counter.compressed_bytes / 2**30,
+                    )
+                record = {k: (v if v != "" else None) for k, v in row.items() if k is not None}
+                if self.row_filter is not None and not self.row_filter(record):
+                    continue
+                self.rows_yielded += 1
+                yield record
+                if self.max_records is not None and self.rows_yielded >= self.max_records:
+                    self.stopped_early = True
+                    break
+            else:
+                self.stopped_early = bool(
+                    self.max_compressed_bytes is not None and counter._exhausted  # noqa: SLF001
+                )
+            self.compressed_bytes = counter.compressed_bytes
+            self.decompressed_bytes = counter.decompressed_bytes
+            self.resumes = counter.resumes
+        finally:
+            handle.close()
+        logger.info(
+            "CourtListener bulk {}: {:,} scanned / {:,} yielded ({:.2f} GiB compressed read, {} resume(s))",
+            self.dataset,
+            self.rows_scanned,
+            self.rows_yielded,
+            self.compressed_bytes / 2**30,
+            self.resumes,
+        )
+
+
+class _LocalBz2Stream(_CountingStream):
+    """``_CountingStream`` over an open local file rather than an HTTP response."""
+
+    def __init__(self, handle, *, max_compressed_bytes: int | None = None) -> None:
+        super().__init__(handle, max_compressed_bytes=max_compressed_bytes)

--- a/src/spicy_regs/transforms/__init__.py
+++ b/src/spicy_regs/transforms/__init__.py
@@ -12,6 +12,8 @@ from spicy_regs.transforms.build_fec_committees import build_fec_committees
 from spicy_regs.transforms.build_federal_register import build_federal_register
 from spicy_regs.transforms.build_feed_summary import build_feed_summary
 from spicy_regs.transforms.build_fr_docket_links import build_fr_docket_links
+from spicy_regs.transforms.build_court_opinion_bodies import build_court_opinion_bodies
+from spicy_regs.transforms.build_court_opinion_clusters import build_court_opinion_clusters
 from spicy_regs.transforms.build_org_committee_links import build_org_committee_links
 from spicy_regs.transforms.build_gao_reports import build_gao_reports
 from spicy_regs.transforms.build_lobbying_filings import build_lobbying_filings
@@ -61,6 +63,8 @@ __all__ = [
     "build_sam_entities",
     "build_federal_register",
     "build_fr_docket_links",
+    "build_court_opinion_bodies",
+    "build_court_opinion_clusters",
     "build_org_committee_links",
     "build_gao_reports",
     "build_lobbying_filings",

--- a/src/spicy_regs/transforms/build_court_opinion_bodies.py
+++ b/src/spicy_regs/transforms/build_court_opinion_bodies.py
@@ -1,0 +1,356 @@
+"""Transform: build ``court_opinion_bodies.parquet`` — actual opinion text.
+
+This is the table the ``court-opinion-v1`` profile has been forward-declaring.
+That profile lists ``html_with_citations`` and ``plain_text`` among its text
+columns, and until now no published table carried either: they are CourtListener
+opinion fields, and nothing in the corpus read CourtListener opinions. The bulk
+``opinions`` dump carries both verbatim, so this builder is where the declared
+seam finally resolves against real bytes.
+
+**One opinion per row, not one decision per row.** A cluster (see
+``build_court_opinion_clusters``) is the decision; an opinion is one voice within
+it — majority, concurrence, dissent, each with its own author and its own text.
+``cluster_id`` joins the two, and through the cluster's ``cl_docket_id`` to
+``court_dockets``.
+
+**Why this ingest is bounded, and by what.** The 2026-06-30 ``opinions`` dump is
+50.8 GiB compressed and about 422 GiB decompressed at its observed 8.3x ratio.
+Two independent limits bite:
+
+* *Disk.* Landing the compressed dump alone would take this workstation below
+  the 100 GiB free-space floor the project holds itself to. It is therefore
+  streamed and never written to disk, and the full backfill is refused outright
+  when headroom is short — see ``check_headroom``.
+* *Time.* The bucket serves one connection at roughly 1.7-2.0 MiB/s, so a single
+  full pass is about 8.6 hours. That is a scheduled-job cost, not a workstation
+  one.
+
+So a local run takes a *recorded slice*: ``max_records`` and/or
+``max_compressed_bytes`` bound it, and the builder logs exactly what the bound
+produced — rows, id range, date range, bytes read — so the resulting table's
+coverage is a stated number rather than an impression. ``cluster_ids`` narrows a
+pass to specific decisions, which is how the documented full backfill targets the
+APA docket set without keeping the other ~10 million opinions.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Container, Sized
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from loguru import logger
+
+from spicy_regs.sources import r2
+from spicy_regs.sources.courtlistener_bulk import (
+    CourtListenerBulkReader,
+    find_dump,
+    latest_dump_date,
+    list_bulk_dumps,
+)
+
+OUTPUT = "court_opinion_bodies.parquet"
+DATASET = "opinions"
+
+#: Free space this project refuses to eat into, in bytes. A bulk ingest that
+#: would cross it is stopped and recorded rather than run.
+DISK_HEADROOM_FLOOR = 100 * 2**30
+
+#: Compressed parquet bytes one opinion row costs, measured on the 250,000-row
+#: 2026-08-22 build: 1,735,931,994 bytes / 250,000 = 6,944 B/row, rounded up.
+BYTES_PER_OPINION_ROW = 8 * 2**10
+
+#: Opinions per cluster, used as a ceiling when sizing a ``cluster_ids`` pass.
+#: The most any single cluster carried in that same 250,000-row build was 8
+#: (majority, concurrences, dissents, and the odd combined rendering); doubling
+#: it keeps the estimate an over-estimate, which is the only direction a disk
+#: guard may err in.
+OPINIONS_PER_CLUSTER_CEILING = 16
+
+#: Rows buffered before each parquet batch write. Opinion bodies are large, so
+#: this batch is much smaller than the cluster builder's.
+BATCH_ROWS = 2_000
+
+#: The raw dump columns that can hold a body. CourtListener populates whichever
+#: one the upstream source provided, so "has text" is a question about the set,
+#: not about ``plain_text`` alone.
+_TEXT_FIELDS = (
+    "plain_text",
+    "html",
+    "html_lawbox",
+    "html_columbia",
+    "html_anon_2020",
+    "html_with_citations",
+    "xml_harvard",
+    "xml_scan",
+)
+
+COLUMNS = (
+    "opinion_id",
+    "cluster_id",
+    "opinion_type",
+    "author_str",
+    "author_id",
+    "joined_by_str",
+    "per_curiam",
+    "sha1",
+    "page_count",
+    "download_url",
+    "local_path",
+    "extracted_by_ocr",
+    "plain_text",
+    "html_with_citations",
+    "available_text_fields",
+    "text_char_count",
+    "date_created",
+    "date_modified",
+    "dump_date",
+)
+_SCHEMA = pa.schema([(c, pa.string()) for c in COLUMNS])
+
+
+def _s(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text != "" else None
+
+
+def check_headroom(needed_bytes: int, *, path: Path | None = None) -> None:
+    """Refuse an ingest that would take free space below the project floor.
+
+    Raises rather than warning: a run that silently fills the disk is worse than
+    a run that did not happen, and the whole point of recording sizes first is to
+    be able to make this call before the bytes arrive.
+    """
+    usage = shutil.disk_usage(path or Path.home())
+    remaining = usage.free - needed_bytes
+    if remaining < DISK_HEADROOM_FLOOR:
+        raise RuntimeError(
+            f"CourtListener bulk: refusing to ingest {needed_bytes / 2**30:.1f} GiB — "
+            f"would leave {remaining / 2**30:.1f} GiB free, below the "
+            f"{DISK_HEADROOM_FLOOR / 2**30:.0f} GiB floor "
+            f"(currently {usage.free / 2**30:.1f} GiB free)"
+        )
+
+
+def estimate_output_bytes(dump_size: int, cluster_ids: Container[str] | None) -> int:
+    """Bytes on disk an unbounded pass will actually cost.
+
+    The dump is *streamed* — decompressed inline, never landed — so what the
+    volume pays for is the parquet this run writes, not the 50.8 GiB it reads.
+    For an unfiltered pass those are close enough that the dump's compressed size
+    is the right stand-in (the measured output is 45-55 GiB). For a
+    ``cluster_ids`` pass they are nothing alike: the same 8.6 hours of reading
+    produces a table sized by the *targets*, and charging it 50.8 GiB refuses a
+    run that costs megabytes.
+
+    Falling back to the dump size for a filter whose length is unknowable keeps
+    the guard conservative when it cannot do arithmetic.
+    """
+    if cluster_ids is None or not isinstance(cluster_ids, Sized):
+        return dump_size
+    return len(cluster_ids) * OPINIONS_PER_CLUSTER_CEILING * BYTES_PER_OPINION_ROW
+
+
+def _shape(row: dict, *, dump_date: date | None) -> dict:
+    """Map one bulk ``opinions`` CSV row onto the published columns."""
+    present = [name for name in _TEXT_FIELDS if row.get(name)]
+    plain = _s(row.get("plain_text"))
+    with_citations = _s(row.get("html_with_citations"))
+    longest = max((len(str(row[name])) for name in present), default=0)
+    return {
+        "opinion_id": _s(row.get("id")),
+        "cluster_id": _s(row.get("cluster_id")),
+        "opinion_type": _s(row.get("type")),
+        "author_str": _s(row.get("author_str")),
+        "author_id": _s(row.get("author_id")),
+        "joined_by_str": _s(row.get("joined_by_str")),
+        "per_curiam": _s(row.get("per_curiam")),
+        "sha1": _s(row.get("sha1")),
+        "page_count": _s(row.get("page_count")),
+        "download_url": _s(row.get("download_url")),
+        "local_path": _s(row.get("local_path")),
+        "extracted_by_ocr": _s(row.get("extracted_by_ocr")),
+        "plain_text": plain,
+        "html_with_citations": with_citations,
+        "available_text_fields": ",".join(present) if present else None,
+        "text_char_count": str(longest),
+        "date_created": _s(row.get("date_created")),
+        "date_modified": _s(row.get("date_modified")),
+        "dump_date": dump_date.isoformat() if dump_date else None,
+    }
+
+
+class _BatchWriter:
+    """Append shaped rows to a parquet file in bounded batches."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.rows: list[dict] = []
+        self.written = 0
+        self._writer: pq.ParquetWriter | None = None
+
+    def add(self, row: dict) -> None:
+        self.rows.append(row)
+        if len(self.rows) >= BATCH_ROWS:
+            self.flush()
+
+    def flush(self) -> None:
+        if not self.rows:
+            return
+        table = pa.Table.from_pylist(self.rows, schema=_SCHEMA)
+        if self._writer is None:
+            self._writer = pq.ParquetWriter(self.path, _SCHEMA, compression="zstd")
+        self._writer.write_table(table)
+        self.written += len(self.rows)
+        self.rows.clear()
+
+    def close(self) -> None:
+        self.flush()
+        if self._writer is None:
+            pq.write_table(_SCHEMA.empty_table(), self.path, compression="zstd")
+        else:
+            self._writer.close()
+
+
+def build_court_opinion_bodies(
+    output_dir: Path,
+    *,
+    dump_date: date | None = None,
+    local_file: Path | None = None,
+    max_records: int | None = None,
+    max_compressed_bytes: int | None = None,
+    cluster_ids: Container[str] | None = None,
+) -> Path:
+    """Build ``court_opinion_bodies.parquet`` from a bounded slice of the dump.
+
+    Returns the written path. The exact bound reached is logged and is the number
+    that belongs in the coverage record — this builder never claims completeness
+    it did not achieve.
+    """
+    import duckdb
+
+    out_file = output_dir / OUTPUT
+    prior_file = output_dir / "_bodies_prior.parquet"
+    new_file = output_dir / "_bodies_new.parquet"
+
+    have_prior = prior_file.exists() or r2.download(OUTPUT, prior_file)
+    logger.info(
+        "Opinion bodies: {}",
+        f"merging against prior table {prior_file}" if have_prior else "no prior table — first build",
+    )
+
+    if local_file is None:
+        objects = list_bulk_dumps()
+        resolved = dump_date or latest_dump_date(objects, DATASET)
+        if resolved is None:
+            raise RuntimeError(f"CourtListener bulk: no published {DATASET} dump found")
+        published = find_dump(objects, DATASET, resolved)
+        if published is None:
+            raise RuntimeError(f"CourtListener bulk: no {DATASET} dump for {resolved}")
+        logger.info(
+            "Opinion bodies: dump {} is {:.3f} GiB compressed; bound = {} rows / {} bytes / {} cluster ids",
+            published.filename,
+            published.size / 2**30,
+            max_records or "unbounded",
+            max_compressed_bytes or "unbounded",
+            len(cluster_ids) if isinstance(cluster_ids, Sized) else "unbounded",
+        )
+        # An unbounded pass would stream the whole dump. Check that the *output*
+        # it implies still leaves headroom before a single byte moves.
+        if max_records is None and max_compressed_bytes is None:
+            needed = estimate_output_bytes(published.size, cluster_ids)
+            logger.info(
+                "Opinion bodies: unbounded pass, estimated output {:.3f} GiB",
+                needed / 2**30,
+            )
+            check_headroom(needed, path=output_dir)
+    else:
+        resolved = dump_date
+        logger.info("Opinion bodies: reading local dump {}", local_file)
+
+    row_filter = None
+    if cluster_ids is not None:
+
+        def row_filter(row: dict) -> bool:  # noqa: F811
+            return (row.get("cluster_id") or "") in cluster_ids
+
+    writer = _BatchWriter(new_file)
+    reader = CourtListenerBulkReader(
+        DATASET,
+        dump_date=resolved,
+        local_file=local_file,
+        max_records=max_records,
+        max_compressed_bytes=max_compressed_bytes,
+        row_filter=row_filter,
+    )
+    for row in reader.iter_records():
+        writer.add(_shape(row, dump_date=resolved))
+    writer.close()
+
+    logger.info(
+        "Opinion bodies: bound reached — {:,} rows scanned, {:,} kept, {:.3f} GiB compressed read",
+        reader.rows_scanned,
+        reader.rows_yielded,
+        reader.compressed_bytes / 2**30,
+    )
+
+    # A first build has no prior table to merge against and one input, whose
+    # opinion_id is the publisher's primary key — so the dedup cannot remove a
+    # row and the whole COPY is a sort. It is an expensive sort: ranking 250,000
+    # rows that each carry kilobytes of opinion text ran the 4 GiB duckdb budget
+    # out of memory, and holding the staged and merged copies at once is 3.5 GiB
+    # of disk against a 100 GiB floor. So promote the staged file instead, and
+    # pay for it in row order.
+    if not have_prior:
+        new_file.replace(out_file)
+        prior_file.unlink(missing_ok=True)
+        total = pq.ParquetFile(out_file).metadata.num_rows
+        logger.info("Court opinion bodies: {:,} rows (first build, dump order)", total)
+        return out_file
+
+    spill_dir = output_dir / ".duckdb_tmp"
+    spill_dir.mkdir(exist_ok=True)
+    con = duckdb.connect()
+    con.execute("SET memory_limit='4GB'")
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("SET threads=2")
+    con.execute(f"SET temp_directory='{spill_dir}'")
+
+    cols = ", ".join(COLUMNS)
+    if have_prior:
+        union = (
+            f"SELECT {cols}, 0 AS _src FROM read_parquet('{prior_file}') "
+            f"UNION ALL BY NAME "
+            f"SELECT {cols}, 1 AS _src FROM read_parquet('{new_file}')"
+        )
+    else:
+        union = f"SELECT {cols}, 1 AS _src FROM read_parquet('{new_file}')"
+
+    con.execute(
+        f"""
+        COPY (
+            SELECT {cols} FROM (
+                SELECT {cols}, ROW_NUMBER() OVER (
+                    PARTITION BY opinion_id ORDER BY _src DESC
+                ) AS _rn
+                FROM ({union})
+                WHERE opinion_id IS NOT NULL
+            )
+            WHERE _rn = 1
+            ORDER BY CAST(opinion_id AS BIGINT) DESC
+        ) TO '{out_file}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 2000);
+        """
+    )
+    con.close()
+
+    for scratch in (prior_file, new_file):
+        scratch.unlink(missing_ok=True)
+
+    total = pq.ParquetFile(out_file).metadata.num_rows
+    logger.info("Court opinion bodies: {:,} rows", total)
+    return out_file

--- a/src/spicy_regs/transforms/build_court_opinion_clusters.py
+++ b/src/spicy_regs/transforms/build_court_opinion_clusters.py
@@ -1,0 +1,400 @@
+"""Transform: build ``court_opinion_clusters.parquet`` from the CourtListener bulk dumps.
+
+A CourtListener *cluster* is one decision — the case-level record that a set of
+sibling opinions (majority, concurrence, dissent) hang off. It is the join that
+the corpus was missing: a cluster carries ``docket_id``, so it is what connects
+opinion text to the APA litigation already in ``court_dockets``, and through the
+docket's party names to the agencies in ``agency_stats``.
+
+**Bulk-first, because bulk is the only road.** The v4 ``/clusters/`` endpoint
+answers ``401`` without an API token, so the quarterly CSV dump is not a
+performance choice — it is the only keyless source. An incremental
+``/search/?type=o`` catch-up (keyless, cursor-paginated) tops the table up for
+decisions filed after the dump date, mirroring the incremental-merge idiom in
+``build_courtlistener`` / ``build_lobbying_filings``:
+
+1. Best-effort download the prior ``court_opinion_clusters.parquet`` from R2.
+2. Read the bulk dump (whole file — clusters are ~2.3 GiB compressed, which
+   streams in about 20 minutes and never lands decompressed).
+3. Fetch clusters filed since the dump date over the search API.
+4. Dedup the union on ``cluster_id``, preferring the freshest row.
+
+Rows are written in batches rather than materialized at once: the dump is on the
+order of ten million clusters, and one ``from_pylist`` over that is an
+out-of-memory error, not a table.
+
+**Which court decided it.** The dump has no ``court_id``: it lives on the
+docket, in a different 4.67 GiB file. Without it this table is ten million
+decisions from 3,361 courts with no way to ask for the 397 federal ones, so the
+build resolves ``court_id`` / ``court_jurisdiction`` / ``court_is_federal``
+from a docket→court map (see :mod:`spicy_regs.transforms.court_scope`) while
+each row is shaped. The map costs 46 minutes of streaming and is cached by dump
+date; ``skip_court_scope`` opts out and leaves the three columns NULL.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from loguru import logger
+
+from spicy_regs.sources import r2
+from spicy_regs.sources.courtlistener import CourtListenerOpinionSearchReader
+from spicy_regs.sources.courtlistener_bulk import (
+    CourtListenerBulkReader,
+    find_dump,
+    latest_dump_date,
+    list_bulk_dumps,
+)
+from spicy_regs.transforms.court_scope import (
+    CourtScope,
+    build_docket_court_map,
+    court_jurisdictions,
+)
+
+OUTPUT = "court_opinion_clusters.parquet"
+DATASET = "opinion-clusters"
+
+CL_BASE_URL = "https://www.courtlistener.com"
+
+#: Re-scan this many days before the dump date on the search catch-up, so
+#: decisions indexed or corrected just after the dump are still picked up.
+OVERLAP_DAYS = 7
+
+#: Rows buffered before each parquet batch write.
+BATCH_ROWS = 25_000
+
+# Published schema: all VARCHAR, keyed by cluster_id. ``cl_docket_id`` is the
+# bulk dump's ``docket_id``, renamed to match ``court_dockets.cl_docket_id`` so
+# the join reads the same on both sides.
+COLUMNS = (
+    "cluster_id",
+    "cl_docket_id",
+    "court_id",
+    "court_jurisdiction",
+    "court_is_federal",
+    "case_name",
+    "case_name_short",
+    "case_name_full",
+    "date_filed",
+    "date_filed_is_approximate",
+    "judges",
+    "nature_of_suit",
+    "precedential_status",
+    "citation_count",
+    "scdb_id",
+    "scdb_decision_direction",
+    "scdb_votes_majority",
+    "scdb_votes_minority",
+    "source",
+    "procedural_history",
+    "attorneys",
+    "posture",
+    "syllabus",
+    "headnotes",
+    "summary",
+    "disposition",
+    "history",
+    "other_dates",
+    "cross_reference",
+    "correction",
+    "arguments",
+    "headmatter",
+    "blocked",
+    "date_blocked",
+    "slug",
+    "absolute_url",
+    "date_created",
+    "date_modified",
+    "ingest_source",
+)
+_SCHEMA = pa.schema([(c, pa.string()) for c in COLUMNS])
+
+
+def _s(value: object) -> str | None:
+    """Coerce a scalar to str, preserving NULL."""
+    if value is None:
+        return None
+    text = str(value)
+    return text if text != "" else None
+
+
+def _cluster_url(cluster_id: str | None, slug: str | None) -> str | None:
+    """Build the canonical courtlistener.com opinion URL for a cluster."""
+    if not cluster_id:
+        return None
+    return f"{CL_BASE_URL}/opinion/{cluster_id}/{slug or ''}".rstrip("/") + "/"
+
+
+def _shape_bulk(row: dict, *, scope: CourtScope | None = None) -> dict:
+    """Map one bulk ``opinion-clusters`` CSV row onto the published columns."""
+    cluster_id = _s(row.get("id"))
+    slug = _s(row.get("slug"))
+    cl_docket_id = _s(row.get("docket_id"))
+    court_id, jurisdiction, federal = scope.for_docket(cl_docket_id) if scope else (None, None, None)
+    return {
+        "cluster_id": cluster_id,
+        "cl_docket_id": cl_docket_id,
+        "court_id": court_id,
+        "court_jurisdiction": jurisdiction,
+        "court_is_federal": federal,
+        "case_name": _s(row.get("case_name")),
+        "case_name_short": _s(row.get("case_name_short")),
+        "case_name_full": _s(row.get("case_name_full")),
+        "date_filed": _s(row.get("date_filed")),
+        "date_filed_is_approximate": _s(row.get("date_filed_is_approximate")),
+        "judges": _s(row.get("judges")),
+        "nature_of_suit": _s(row.get("nature_of_suit")),
+        "precedential_status": _s(row.get("precedential_status")),
+        "citation_count": _s(row.get("citation_count")),
+        "scdb_id": _s(row.get("scdb_id")),
+        "scdb_decision_direction": _s(row.get("scdb_decision_direction")),
+        "scdb_votes_majority": _s(row.get("scdb_votes_majority")),
+        "scdb_votes_minority": _s(row.get("scdb_votes_minority")),
+        "source": _s(row.get("source")),
+        "procedural_history": _s(row.get("procedural_history")),
+        "attorneys": _s(row.get("attorneys")),
+        "posture": _s(row.get("posture")),
+        "syllabus": _s(row.get("syllabus")),
+        "headnotes": _s(row.get("headnotes")),
+        "summary": _s(row.get("summary")),
+        "disposition": _s(row.get("disposition")),
+        "history": _s(row.get("history")),
+        "other_dates": _s(row.get("other_dates")),
+        "cross_reference": _s(row.get("cross_reference")),
+        "correction": _s(row.get("correction")),
+        "arguments": _s(row.get("arguments")),
+        "headmatter": _s(row.get("headmatter")),
+        "blocked": _s(row.get("blocked")),
+        "date_blocked": _s(row.get("date_blocked")),
+        "slug": slug,
+        "absolute_url": _cluster_url(cluster_id, slug),
+        "date_created": _s(row.get("date_created")),
+        "date_modified": _s(row.get("date_modified")),
+        "ingest_source": "bulk",
+    }
+
+
+def _shape_search(result: dict, *, scope: CourtScope | None = None) -> dict:
+    """Map one ``/search/?type=o`` result onto the published columns.
+
+    The search surface is narrower than the dump: it has no syllabus, headnotes,
+    or headmatter. Those stay NULL rather than being invented, so a row's
+    provenance is legible from ``ingest_source``.
+
+    It is *wider* in exactly one place: it names the court outright, so a
+    catch-up row does not need the docket map to be scoped — but it must be
+    classified by the same rule, or the two halves of the table would disagree
+    about what federal means.
+    """
+    cluster_id = _s(result.get("cluster_id"))
+    absolute = _s(result.get("absolute_url"))
+    if absolute and absolute.startswith("/"):
+        absolute = f"{CL_BASE_URL}{absolute}"
+    court_id, jurisdiction, federal = (
+        scope.for_court(_s(result.get("court_id"))) if scope else (_s(result.get("court_id")), None, None)
+    )
+    row = dict.fromkeys(COLUMNS)
+    row.update(
+        {
+            "cluster_id": cluster_id,
+            "cl_docket_id": _s(result.get("docket_id")),
+            "court_id": court_id,
+            "court_jurisdiction": jurisdiction,
+            "court_is_federal": federal,
+            "case_name": _s(result.get("caseName")),
+            "case_name_full": _s(result.get("caseNameFull")),
+            "date_filed": _s(result.get("dateFiled")),
+            "judges": _s(result.get("judge")),
+            "nature_of_suit": _s(result.get("suitNature")),
+            "precedential_status": _s(result.get("status")),
+            "citation_count": _s(result.get("citeCount")),
+            "scdb_id": _s(result.get("scdb_id")),
+            "source": _s(result.get("source")),
+            "procedural_history": _s(result.get("procedural_history")),
+            "attorneys": _s(result.get("attorney")),
+            "posture": _s(result.get("posture")),
+            "syllabus": _s(result.get("syllabus")),
+            "absolute_url": absolute,
+            "ingest_source": "search",
+        }
+    )
+    return row
+
+
+class _BatchWriter:
+    """Append shaped rows to a parquet file in bounded batches."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.rows: list[dict] = []
+        self.written = 0
+        self._writer: pq.ParquetWriter | None = None
+
+    def add(self, row: dict) -> None:
+        self.rows.append(row)
+        if len(self.rows) >= BATCH_ROWS:
+            self.flush()
+
+    def flush(self) -> None:
+        if not self.rows:
+            return
+        table = pa.Table.from_pylist(self.rows, schema=_SCHEMA)
+        if self._writer is None:
+            self._writer = pq.ParquetWriter(self.path, _SCHEMA, compression="zstd")
+        self._writer.write_table(table)
+        self.written += len(self.rows)
+        self.rows.clear()
+
+    def close(self) -> None:
+        self.flush()
+        if self._writer is None:
+            pq.write_table(_SCHEMA.empty_table(), self.path, compression="zstd")
+        else:
+            self._writer.close()
+
+
+def build_court_opinion_clusters(
+    output_dir: Path,
+    *,
+    dump_date: date | None = None,
+    local_file: Path | None = None,
+    max_records: int | None = None,
+    skip_search_catchup: bool = False,
+    docket_court_map: Path | None = None,
+    skip_court_scope: bool = False,
+) -> Path:
+    """Build ``court_opinion_clusters.parquet`` (bulk dump + search catch-up).
+
+    ``skip_court_scope`` leaves the three court columns NULL and skips the
+    46-minute ``dockets`` read. It is the honest way to build the table without
+    the scope, and it is not the default: a decision table that cannot say which
+    court decided is a table nobody can ask the obvious question of.
+    """
+    import duckdb
+
+    out_file = output_dir / OUTPUT
+    prior_file = output_dir / "_clusters_prior.parquet"
+    new_file = output_dir / "_clusters_new.parquet"
+
+    # 1. Prior table (absence just means first build).
+    have_prior = prior_file.exists() or r2.download(OUTPUT, prior_file)
+    logger.info(
+        "Opinion clusters: {}",
+        f"merging against prior table {prior_file}" if have_prior else "no prior table — full build",
+    )
+
+    # 2. Resolve which published dump to read.
+    if local_file is None:
+        objects = list_bulk_dumps()
+        resolved = dump_date or latest_dump_date(objects, DATASET)
+        if resolved is None:
+            raise RuntimeError(f"CourtListener bulk: no published {DATASET} dump found")
+        published = find_dump(objects, DATASET, resolved)
+        if published is None:
+            raise RuntimeError(f"CourtListener bulk: no {DATASET} dump for {resolved}")
+        logger.info(
+            "Opinion clusters: reading dump {} ({:.3f} GiB compressed)",
+            published.filename,
+            published.size / 2**30,
+        )
+    else:
+        resolved = dump_date
+        logger.info("Opinion clusters: reading local dump {}", local_file)
+
+    # 3. Load the court scope, so every row can say which court decided it.
+    #
+    # The cluster dump has no court_id — that lives on the docket, one join and
+    # a different 4.67 GiB file away. Resolving it *while shaping* rather than
+    # afterwards is what keeps the first build's promote path intact: joining
+    # ten million clusters against seventy-two million dockets in duckdb would
+    # rewrite the whole 3.9 GB table, and the whole reason that path exists is
+    # that this machine cannot afford to hold two copies of it.
+    scope: CourtScope | None = None
+    if not skip_court_scope:
+        map_file = docket_court_map or build_docket_court_map(output_dir, dump_date=resolved)
+        scope = CourtScope.from_map(map_file, court_jurisdictions(dump_date=resolved, local_file=None))
+
+    # 4. Stream the dump into the staging table, batch by batch.
+    writer = _BatchWriter(new_file)
+    reader = CourtListenerBulkReader(DATASET, dump_date=resolved, local_file=local_file, max_records=max_records)
+    for row in reader.iter_records():
+        writer.add(_shape_bulk(row, scope=scope))
+    bulk_rows = writer.written + len(writer.rows)
+
+    # 5. Search catch-up for decisions filed after the dump was cut.
+    search_rows = 0
+    if not skip_search_catchup and resolved is not None:
+        since = resolved - timedelta(days=OVERLAP_DAYS)
+        logger.info("Opinion clusters: search catch-up for decisions filed since {}", since)
+        for result in CourtListenerOpinionSearchReader(since=since).iter_records():
+            writer.add(_shape_search(result, scope=scope))
+            search_rows += 1
+    writer.close()
+    logger.info(
+        "Opinion clusters: staged {:,} rows ({:,} bulk + {:,} search)",
+        writer.written,
+        bulk_rows,
+        search_rows,
+    )
+
+    # 6. Merge prior + new, dedup on cluster_id preferring the freshest row.
+    #
+    # A first build has nothing to merge *against*: one dump, whose cluster_id is
+    # the publisher's primary key, so the dedup is a no-op. Running the merge
+    # anyway would hold the staged copy and the merged copy on disk at once —
+    # 7.1 GiB rather than 3.6 GiB at the 2026-06-30 dump's size — which is the
+    # difference between fitting inside the project's free-space floor and not.
+    # So the first build promotes the staged file instead, and pays for that with
+    # dump order rather than date order.
+    if not have_prior:
+        new_file.replace(out_file)
+        prior_file.unlink(missing_ok=True)
+        total = pq.ParquetFile(out_file).metadata.num_rows
+        logger.info("Court opinion clusters: {:,} rows (first build, dump order)", total)
+        return out_file
+
+    spill_dir = output_dir / ".duckdb_tmp"
+    spill_dir.mkdir(exist_ok=True)
+    con = duckdb.connect()
+    con.execute("SET memory_limit='4GB'")
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("SET threads=2")
+    con.execute(f"SET temp_directory='{spill_dir}'")
+
+    cols = ", ".join(COLUMNS)
+    if have_prior:
+        union = (
+            f"SELECT {cols}, 0 AS _src FROM read_parquet('{prior_file}') "
+            f"UNION ALL BY NAME "
+            f"SELECT {cols}, 1 AS _src FROM read_parquet('{new_file}')"
+        )
+    else:
+        union = f"SELECT {cols}, 1 AS _src FROM read_parquet('{new_file}')"
+
+    con.execute(
+        f"""
+        COPY (
+            SELECT {cols} FROM (
+                SELECT {cols}, ROW_NUMBER() OVER (
+                    PARTITION BY cluster_id ORDER BY _src DESC
+                ) AS _rn
+                FROM ({union})
+                WHERE cluster_id IS NOT NULL
+            )
+            WHERE _rn = 1
+            ORDER BY date_filed DESC, cluster_id
+        ) TO '{out_file}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 50000);
+        """
+    )
+    con.close()
+
+    for scratch in (prior_file, new_file):
+        scratch.unlink(missing_ok=True)
+
+    total = pq.ParquetFile(out_file).metadata.num_rows
+    logger.info("Court opinion clusters: {:,} rows", total)
+    return out_file

--- a/src/spicy_regs/transforms/court_scope.py
+++ b/src/spicy_regs/transforms/court_scope.py
@@ -1,0 +1,339 @@
+"""Where a decision was decided — the court scope the cluster dump omits.
+
+``court_opinion_clusters`` is the whole CourtListener corpus: ten million
+decisions from 3,361 courts, of which 397 are federal and 2,618 are state. A
+consumer asking "what have the federal courts said" has no way to ask it,
+because the ``opinion-clusters`` dump carries no ``court_id`` at all. That
+column lives on the *docket*, one join away and in a different 4.67 GiB file.
+
+This module is that join, in two pieces:
+
+* :func:`build_docket_court_map` streams the ``dockets`` dump for two columns
+  and throws the other fifty away. It is 46 minutes of reading to produce a few
+  hundred megabytes, which is the cheapest form the answer comes in — there is
+  no smaller published dataset that maps a docket to its court (checked against
+  the publisher's own listing of 46 datasets, 2026-08-22).
+* :func:`court_jurisdictions` reads the 81 KB ``courts`` dump, which is where
+  ``F``/``FD``/``FB``/``FS``/``FBP`` (federal) part company with ``ST``/``S``
+  (state) and the tribal, territorial and military codes.
+
+**"Federal" here means the publisher's jurisdiction code begins with F.** That
+is a decision about someone else's taxonomy, so it is one function
+(:func:`is_federal`) rather than a condition spelled out at each call site, and
+the raw code travels alongside the boolean so a consumer who disagrees can
+reclassify without re-reading 4.67 GiB.
+"""
+
+from __future__ import annotations
+
+import json
+from array import array
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from loguru import logger
+
+from spicy_regs.sources.courtlistener_bulk import (
+    CourtListenerBulkReader,
+    published_object_pin,
+)
+
+DOCKETS_DATASET = "dockets"
+COURTS_DATASET = "courts"
+
+#: Rows buffered per parquet batch. Two narrow columns, so this can be large.
+BATCH_ROWS = 500_000
+
+#: ``docket_number`` is not needed to answer "which court", and it is captured
+#: anyway because the pass that gets ``court_id`` has the row in hand and a
+#: second pass costs 111 minutes of the publisher's bandwidth.
+#:
+#: It is here for a measured reason. CourtListener carries **two docket records
+#: for one case** — a RECAP/PACER one and a scraper one — and the opinion cluster
+#: hangs off the scraper one while a nature-of-suit search returns the RECAP one.
+#: Measured 2026-08-22, that hides at least 249 APA decisions, 184 of them in
+#: D.D.C., which matched 0.0% of its 1,571 APA dockets against peers at 15-17%.
+#: Two records for one case share a docket number within a court, so
+#: ``(court_id, docket_number)`` is the exact join where matching case-name
+#: prose is a guess.
+MAP_COLUMNS = ("cl_docket_id", "court_id", "docket_number")
+
+#: The columns :class:`CourtScope` actually reads. Named separately so a map
+#: captured before ``docket_number`` existed still loads.
+SCOPE_COLUMNS = ("cl_docket_id", "court_id")
+
+_MAP_SCHEMA = pa.schema([(c, pa.string()) for c in MAP_COLUMNS])
+
+#: CourtListener jurisdiction codes that denote a federal court, as published in
+#: the ``courts`` dump: F (appellate), FD (district), FB (bankruptcy), FBP
+#: (bankruptcy appellate panel), FS (special). Every one starts with F, and no
+#: non-federal code does — state is S/ST/SA/SS/SAG, tribal T*, territorial TT/TS,
+#: military M*, international I, committee C.
+FEDERAL_PREFIX = "F"
+
+
+def is_federal(jurisdiction: str | None) -> bool:
+    """Whether a CourtListener jurisdiction code denotes a federal court."""
+    return bool(jurisdiction) and str(jurisdiction).startswith(FEDERAL_PREFIX)
+
+
+def court_jurisdictions(*, dump_date: date | None = None, local_file: Path | None = None) -> dict[str, str]:
+    """Map ``court_id`` to its published jurisdiction code.
+
+    The ``courts`` dump is 81 KB, so this is read whole and held in memory —
+    3,361 rows is a dict, not a table.
+    """
+    reader = CourtListenerBulkReader(COURTS_DATASET, dump_date=dump_date, local_file=local_file)
+    codes = {row["id"]: (row.get("jurisdiction") or "") for row in reader.iter_records() if row.get("id")}
+    federal = sum(1 for code in codes.values() if is_federal(code))
+    logger.info(
+        "Court scope: {:,} courts, {:,} federal / {:,} not",
+        len(codes),
+        federal,
+        len(codes) - federal,
+    )
+    return codes
+
+
+class CourtScope:
+    """Answer "which court, and is it federal" for a docket id, in constant time.
+
+    The obvious shape is a dict, and the obvious shape does not fit: the
+    ``dockets`` dump holds roughly 72 million rows, and 72 million Python string
+    keys is gigabytes before a single value. But docket ids are dense integers
+    and there are only 3,361 courts, so the map is a *dense array of small
+    integers* — one ``unsigned short`` per docket id, indexing a court
+    vocabulary — which is about 150 MB for the whole corpus and is built once
+    per run.
+
+    Index 0 is reserved for "no court recorded", so a docket the dump does not
+    place is distinguishable from one placed in the first court seen.
+    """
+
+    __slots__ = ("_courts", "_index", "_jurisdictions", "size")
+
+    def __init__(self, courts: list[str], index: array, jurisdictions: dict[str, str]):
+        self._courts = courts
+        self._index = index
+        self._jurisdictions = jurisdictions
+        self.size = len(index)
+
+    @classmethod
+    def from_map(cls, map_file: Path, jurisdictions: dict[str, str]) -> CourtScope:
+        """Load a ``(cl_docket_id, court_id)`` parquet into the dense index."""
+        parquet = pq.ParquetFile(map_file)
+        courts: list[str] = [""]
+        court_slots: dict[str, int] = {}
+        index = array("H", [0])
+        rows = 0
+
+        def grow_to(position: int) -> None:
+            """Extend the index so ``position`` is addressable, doubling as it goes."""
+            target = max(position + 1, len(index) * 2)
+            index.frombytes(bytes(index.itemsize * (target - len(index))))
+
+        for batch in parquet.iter_batches(batch_size=1_000_000, columns=list(SCOPE_COLUMNS)):
+            docket_ids = batch.column("cl_docket_id").to_pylist()
+            court_ids = batch.column("court_id").to_pylist()
+            for docket_id, court_id in zip(docket_ids, court_ids, strict=True):
+                rows += 1
+                if not docket_id or not court_id:
+                    continue
+                try:
+                    position = int(docket_id)
+                except ValueError:
+                    continue
+                if position < 0:
+                    continue
+                slot = court_slots.get(court_id)
+                if slot is None:
+                    slot = len(courts)
+                    court_slots[court_id] = slot
+                    courts.append(court_id)
+                if position >= len(index):
+                    grow_to(position)
+                index[position] = slot
+        logger.info(
+            "Court scope: indexed {:,} dockets across {:,} courts ({:.0f} MiB)",
+            rows,
+            len(courts) - 1,
+            index.buffer_info()[1] * index.itemsize / 2**20,
+        )
+        return cls(courts, index, jurisdictions)
+
+    def for_docket(self, docket_id: str | None) -> tuple[str | None, str | None, str | None]:
+        """``(court_id, jurisdiction, is_federal)`` for one docket, all NULL if unknown."""
+        if not docket_id:
+            return None, None, None
+        try:
+            position = int(docket_id)
+        except ValueError:
+            return None, None, None
+        if position < 0 or position >= self.size:
+            return None, None, None
+        slot = self._index[position]
+        if slot == 0:
+            return None, None, None
+        court_id = self._courts[slot]
+        return court_id, *self.for_court(court_id)[1:]
+
+    def for_court(self, court_id: str | None) -> tuple[str | None, str | None, str | None]:
+        """``(court_id, jurisdiction, is_federal)`` for a court named directly.
+
+        The ``/search/?type=o`` catch-up already knows its court, so it does not
+        need the docket map — but it does need the same classification, spelled
+        the same way.
+        """
+        if not court_id:
+            return None, None, None
+        jurisdiction = self._jurisdictions.get(court_id)
+        if jurisdiction is None:
+            # A court the dump does not describe: say so rather than call it
+            # non-federal, which is a claim this data cannot support.
+            return court_id, None, None
+        return court_id, jurisdiction, "t" if is_federal(jurisdiction) else "f"
+
+
+def build_docket_court_map(
+    output_dir: Path,
+    *,
+    dump_date: date | None = None,
+    local_file: Path | None = None,
+    max_compressed_bytes: int | None = None,
+) -> Path:
+    """Stream the ``dockets`` dump into a ``(cl_docket_id, court_id)`` table.
+
+    Cached by dump date: the map only changes when the publisher cuts a new
+    dump, so a second local build in the same quarter costs nothing rather than
+    46 minutes. Delete the file to force a re-read.
+    """
+    stamp = dump_date.isoformat() if dump_date else "local"
+    out_file = output_dir / f"docket_courts-{stamp}.parquet"
+    if out_file.exists():
+        cached = pq.ParquetFile(out_file)
+        missing = [c for c in MAP_COLUMNS if c not in cached.schema_arrow.names]
+        logger.info(
+            "Court scope: reusing cached docket->court map {} ({:,} rows)",
+            out_file,
+            cached.metadata.num_rows,
+        )
+        if missing:
+            # Not rebuilt automatically: that is 111 minutes of someone else's
+            # bandwidth, and it is not this function's call to spend it. Said
+            # loudly instead, because the alternative is a reconciliation that
+            # silently cannot run.
+            logger.warning(
+                "Court scope: cached map predates {} — delete it to recapture. "
+                "Duplicate-docket reconciliation is unavailable without it.",
+                ", ".join(missing),
+            )
+        return out_file
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    reader = CourtListenerBulkReader(
+        DOCKETS_DATASET,
+        dump_date=dump_date,
+        local_file=local_file,
+        max_compressed_bytes=max_compressed_bytes,
+    )
+    staging = out_file.with_suffix(".partial.parquet")
+    writer: pq.ParquetWriter | None = None
+    batch: list[dict] = []
+    written = 0
+
+    def flush() -> None:
+        nonlocal writer, written
+        if not batch:
+            return
+        table = pa.Table.from_pylist(batch, schema=_MAP_SCHEMA)
+        if writer is None:
+            writer = pq.ParquetWriter(staging, _MAP_SCHEMA, compression="zstd")
+        writer.write_table(table)
+        written += len(batch)
+        batch.clear()
+
+    try:
+        for row in reader.iter_records():
+            docket_id = row.get("id")
+            if not docket_id:
+                continue
+            batch.append(
+                {
+                    "cl_docket_id": docket_id,
+                    "court_id": row.get("court_id"),
+                    "docket_number": row.get("docket_number"),
+                }
+            )
+            if len(batch) >= BATCH_ROWS:
+                flush()
+        flush()
+    finally:
+        if writer is not None:
+            writer.close()
+        elif staging.exists():
+            staging.unlink()
+
+    if writer is None:
+        pq.write_table(_MAP_SCHEMA.empty_table(), staging, compression="zstd")
+    # Only name the file after the pass that filled it finished, so an
+    # interrupted 46-minute stream cannot be mistaken for a cached complete map.
+    staging.replace(out_file)
+    logger.info(
+        "Court scope: docket->court map has {:,} dockets ({:.2f} GiB compressed read, {} resume(s)) -> {:.1f} MiB",
+        written,
+        reader.compressed_bytes / 2**30,
+        reader.resumes,
+        out_file.stat().st_size / 2**20,
+    )
+    write_map_receipt(out_file, reader=reader, dump_date=dump_date, rows=written)
+    return out_file
+
+
+def write_map_receipt(
+    map_file: Path,
+    *,
+    reader: CourtListenerBulkReader,
+    dump_date: date | None,
+    rows: int,
+) -> Path:
+    """Record what the map cost and which published object it came from.
+
+    46 minutes of someone else's bandwidth is a capture, and a capture that
+    cannot say what it read is a file. The object is pinned by the publisher's
+    own byte size and last-modified stamp, so a map built against a re-cut dump
+    is a detectable difference rather than an unexplained one.
+    """
+    receipt: dict[str, object] = {
+        "artifact": map_file.name,
+        "written_at": datetime.now(UTC).isoformat(),
+        "bounds": {
+            "columns": list(MAP_COLUMNS),
+            "max_compressed_bytes": reader.max_compressed_bytes,
+            "rows_scanned": reader.rows_scanned,
+            "rows_written": rows,
+            "compressed_bytes_read": reader.compressed_bytes,
+            "resumes": reader.resumes,
+            "stopped_early": reader.stopped_early,
+        },
+        "result": {"bytes": map_file.stat().st_size, "dockets": rows},
+    }
+    if dump_date is not None and reader.local_file is None:
+        try:
+            receipt["source"] = {
+                "publisher": "CourtListener bulk data",
+                **published_object_pin(DOCKETS_DATASET, dump_date),
+            }
+        except Exception as exc:  # noqa: BLE001 - a receipt must not fail a capture
+            receipt["source"] = {"publisher": "CourtListener bulk data", "error": str(exc)}
+    else:
+        receipt["source"] = {
+            "publisher": "CourtListener bulk data",
+            "local_file": str(reader.local_file) if reader.local_file else None,
+            "dump_date": dump_date.isoformat() if dump_date else None,
+        }
+    path = map_file.with_suffix(".receipt.json")
+    path.write_text(json.dumps(receipt, indent=2) + "\n")
+    logger.info("Court scope: receipt written to {}", path)
+    return path

--- a/tests/test_cluster_court_scope_backfill.py
+++ b/tests/test_cluster_court_scope_backfill.py
@@ -1,0 +1,143 @@
+"""Contracts for scoping an already-built cluster table.
+
+Adding three derived columns by re-streaming the 2.3 GiB dump is 23 minutes of
+reading for facts the table already has the key for, so the backfill joins the
+docket→court map against the table on disk instead. It has one interesting
+decision in it: the better artifact — the whole cluster table rewritten with the
+columns inline — costs a second copy of a 3.9 GB file, and on the machine this
+was written for that crosses the project's free-space floor. So the mode is
+chosen by what fits, and the mode actually used is recorded, because a run that
+quietly produced the lesser artifact is the shape of degradation this ingest
+keeps having to guard against.
+"""
+
+from __future__ import annotations
+
+import bz2
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+_SPEC = importlib.util.spec_from_file_location(
+    "backfill_cluster_court_scope",
+    Path(__file__).resolve().parents[1] / "scripts" / "backfill_cluster_court_scope.py",
+)
+assert _SPEC and _SPEC.loader
+backfill_module = importlib.util.module_from_spec(_SPEC)
+sys.modules["backfill_cluster_court_scope"] = backfill_module
+_SPEC.loader.exec_module(backfill_module)
+
+
+def _fixtures(tmp_path: Path) -> tuple[Path, Path, Path]:
+    clusters = tmp_path / "court_opinion_clusters.parquet"
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                {"cluster_id": "1", "cl_docket_id": "10", "case_name": "Federal"},
+                {"cluster_id": "2", "cl_docket_id": "11", "case_name": "State"},
+                {"cluster_id": "3", "cl_docket_id": "99", "case_name": "Unplaced"},
+                {"cluster_id": "4", "cl_docket_id": None, "case_name": "No docket"},
+            ],
+            schema=pa.schema(
+                [
+                    ("cluster_id", pa.string()),
+                    ("cl_docket_id", pa.string()),
+                    ("case_name", pa.string()),
+                ]
+            ),
+        ),
+        clusters,
+    )
+    docket_map = tmp_path / "docket_courts.parquet"
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                {"cl_docket_id": "10", "court_id": "dcd"},
+                {"cl_docket_id": "11", "court_id": "nc"},
+            ],
+            schema=pa.schema([("cl_docket_id", pa.string()), ("court_id", pa.string())]),
+        ),
+        docket_map,
+    )
+    courts = tmp_path / "courts-2026-06-30.csv.bz2"
+    courts.write_bytes(bz2.compress(b"id,jurisdiction\ndcd,FD\nnc,S\n"))
+    return clusters, docket_map, courts
+
+
+def _run(tmp_path: Path, mode: str, monkeypatch) -> dict:
+    clusters, docket_map, courts = _fixtures(tmp_path)
+    if mode == "full":
+        # The real guard refuses this on the machine it was written for; the
+        # behaviour under test here is the rewrite, not the arithmetic.
+        monkeypatch.setattr(backfill_module, "check_headroom", lambda *a, **k: None)
+        monkeypatch.setattr(backfill_module, "_fits", lambda *a, **k: True)
+    return backfill_module.backfill(
+        clusters=clusters,
+        docket_court_map=docket_map,
+        courts_dump=courts,
+        output_dir=tmp_path / "out",
+        dump_date=date(2026, 6, 30),
+        mode=mode,
+    )
+
+
+def test_scope_mode_writes_a_joinable_side_table(tmp_path: Path, monkeypatch):
+    receipt = _run(tmp_path, "scope", monkeypatch)
+    rows = pq.read_table(tmp_path / "out" / "court_cluster_scope.parquet").to_pylist()
+
+    assert [r["cluster_id"] for r in rows] == ["1", "2", "3", "4"]
+    assert rows[0] == {
+        "cluster_id": "1",
+        "cl_docket_id": "10",
+        "court_id": "dcd",
+        "court_jurisdiction": "FD",
+        "court_is_federal": "t",
+    }
+    assert rows[1]["court_is_federal"] == "f"
+    # A docket the map does not place, and a cluster with no docket at all: both
+    # NULL. "We do not know" and "not federal" are different claims.
+    assert rows[2]["court_is_federal"] is None
+    assert rows[3]["court_id"] is None
+
+    assert receipt["mode"] == "scope"
+    assert receipt["coverage"]["denominator_count"] == 4
+    assert receipt["coverage"]["clusters_in_a_federal_court"] == 1
+    assert receipt["coverage"]["clusters_with_no_court"] == 2
+    assert receipt["coverage"]["by_jurisdiction"]["FD"] == 1
+
+
+def test_full_mode_keeps_every_original_column_and_the_published_order(tmp_path: Path, monkeypatch):
+    """The scope belongs next to the key it is derived from, not bolted on the end."""
+    receipt = _run(tmp_path, "full", monkeypatch)
+    table = pq.read_table(tmp_path / "out" / "court_opinion_clusters.parquet")
+
+    assert table.schema.names == [
+        "cluster_id",
+        "cl_docket_id",
+        "court_id",
+        "court_jurisdiction",
+        "court_is_federal",
+        "case_name",
+    ]
+    rows = table.to_pylist()
+    assert rows[0]["case_name"] == "Federal"
+    assert rows[0]["court_jurisdiction"] == "FD"
+    assert receipt["mode"] == "full"
+    assert receipt["coverage"]["rows_written"] == 4
+
+
+def test_auto_falls_back_to_the_side_table_when_the_rewrite_would_cross_the_floor(tmp_path: Path, monkeypatch):
+    """The choice is made by arithmetic, and the choice made is recorded."""
+    monkeypatch.setattr(backfill_module, "_fits", lambda *a, **k: False)
+    receipt = _run(tmp_path, "auto", monkeypatch)
+    assert receipt["mode"] == "scope"
+    assert (tmp_path / "out" / "court_cluster_scope.parquet").exists()
+    assert not (tmp_path / "out" / "court_opinion_clusters.parquet").exists()
+
+    monkeypatch.setattr(backfill_module, "_fits", lambda *a, **k: True)
+    receipt = _run(tmp_path, "auto", monkeypatch)
+    assert receipt["mode"] == "full"

--- a/tests/test_court_scope.py
+++ b/tests/test_court_scope.py
@@ -1,0 +1,225 @@
+"""Contracts for the court scope a cluster cannot state on its own.
+
+``court_opinion_clusters`` is the whole CourtListener corpus — ten million
+decisions from 3,361 courts — and the ``opinion-clusters`` dump carries no
+``court_id`` at all, so "what have the federal courts said" was not a question
+the table could answer. The answer lives on the docket, in a different 4.67 GiB
+file, and these are the pieces that carry it across.
+
+Two properties are worth pinning beyond the obvious lookup. The index must be a
+dense array rather than a dict, because seventy-two million Python string keys
+is gigabytes before a single value; and an unknown court must come back NULL
+rather than non-federal, because "we do not know" and "not federal" are
+different claims and only one of them is supported.
+"""
+
+from __future__ import annotations
+
+import bz2
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from spicy_regs.transforms.build_court_opinion_clusters import _shape_bulk, _shape_search
+from spicy_regs.transforms.court_scope import (
+    CourtScope,
+    build_docket_court_map,
+    court_jurisdictions,
+    is_federal,
+)
+
+_JURISDICTIONS = {
+    "ca9": "F",  # Ninth Circuit
+    "dcd": "FD",  # District of D.C. — where APA suits mostly land
+    "nyeb": "FB",  # bankruptcy
+    "cavc": "FS",  # special
+    "bap9": "FBP",  # bankruptcy appellate panel
+    "nc": "S",  # Supreme Court of North Carolina
+    "cal": "ST",
+    "navajo": "TRS",  # tribal
+    "asssup": "TT",  # territorial
+}
+
+
+def _map(tmp_path: Path, pairs: list[tuple[str, str | None]]) -> Path:
+    path = tmp_path / "docket_courts.parquet"
+    pq.write_table(
+        pa.Table.from_pylist(
+            [{"cl_docket_id": d, "court_id": c} for d, c in pairs],
+            schema=pa.schema([("cl_docket_id", pa.string()), ("court_id", pa.string())]),
+        ),
+        path,
+    )
+    return path
+
+
+def test_federal_is_every_jurisdiction_code_that_starts_with_f():
+    """Someone else's taxonomy, decided in one place rather than at each call site."""
+    assert [is_federal(code) for code in ("F", "FD", "FB", "FBP", "FS")] == [True] * 5
+    assert not any(is_federal(code) for code in ("S", "ST", "SA", "SS", "TRS", "TT", "MA", "I", "C"))
+    # Absence is not a jurisdiction.
+    assert not is_federal(None)
+    assert not is_federal("")
+
+
+def test_scope_resolves_a_docket_to_its_court_and_says_when_it_cannot(tmp_path: Path):
+    scope = CourtScope.from_map(
+        _map(
+            tmp_path,
+            [("10", "ca9"), ("11", "nc"), ("12", "dcd"), ("13", None), ("14", "xyzzy")],
+        ),
+        _JURISDICTIONS,
+    )
+
+    assert scope.for_docket("10") == ("ca9", "F", "t")
+    assert scope.for_docket("12") == ("dcd", "FD", "t")
+    assert scope.for_docket("11") == ("nc", "S", "f")
+
+    # A docket the dump does not place at all.
+    assert scope.for_docket("13") == (None, None, None)
+    # A docket id beyond anything the map saw, and one that is not a number.
+    assert scope.for_docket("999999") == (None, None, None)
+    assert scope.for_docket("not-an-id") == (None, None, None)
+    assert scope.for_docket(None) == (None, None, None)
+
+    # A court the courts dump does not describe: named, but not classified.
+    # Calling it non-federal would be a claim this data cannot support.
+    assert scope.for_docket("14") == ("xyzzy", None, None)
+
+
+def test_index_zero_is_reserved_so_an_unplaced_docket_is_not_the_first_court(
+    tmp_path: Path,
+):
+    """Docket 0 must not inherit whichever court happened to be seen first."""
+    scope = CourtScope.from_map(_map(tmp_path, [("7", "ca9")]), _JURISDICTIONS)
+    assert scope.for_docket("7") == ("ca9", "F", "t")
+    assert scope.for_docket("0") == (None, None, None)
+
+
+def test_index_is_dense_not_a_dict_of_seventy_two_million_strings(tmp_path: Path):
+    """The whole reason this is an array: a sparse high id must not cost a row each.
+
+    A dict would be ~100 bytes per docket; the real dump holds about 72 million
+    of them. The dense index is two bytes per *addressable id*, so a single
+    docket numbered 300,000 costs 600 KB and not one entry per integer below it.
+    """
+    scope = CourtScope.from_map(_map(tmp_path, [("300000", "dcd")]), _JURISDICTIONS)
+    assert scope.for_docket("300000") == ("dcd", "FD", "t")
+    assert scope.for_docket("299999") == (None, None, None)
+    assert scope.size > 300_000
+
+
+def test_search_rows_are_classified_by_the_same_rule_as_bulk_rows(tmp_path: Path):
+    """The catch-up names its court outright; it must still mean the same thing.
+
+    If the two halves of the table disagreed about what federal means, the
+    column would be worse than absent.
+    """
+    scope = CourtScope.from_map(_map(tmp_path, [("500", "ca9")]), _JURISDICTIONS)
+
+    bulk = _shape_bulk({"id": "1", "docket_id": "500", "slug": "x"}, scope=scope)
+    search = _shape_search({"cluster_id": "2", "docket_id": "500", "court_id": "ca9"}, scope=scope)
+
+    assert (bulk["court_id"], bulk["court_jurisdiction"], bulk["court_is_federal"]) == (
+        "ca9",
+        "F",
+        "t",
+    )
+    assert (
+        search["court_id"],
+        search["court_jurisdiction"],
+        search["court_is_federal"],
+    ) == ("ca9", "F", "t")
+
+
+def test_shaping_without_a_scope_leaves_the_columns_null_rather_than_guessing():
+    """``skip_court_scope`` must produce absence, not a default."""
+    row = _shape_bulk({"id": "1", "docket_id": "500", "slug": "x"})
+    assert row["court_id"] is None
+    assert row["court_jurisdiction"] is None
+    assert row["court_is_federal"] is None
+
+
+def test_map_build_streams_two_columns_and_caches_by_dump_date(tmp_path: Path):
+    """46 minutes of reading for two columns — a second build must not repeat it."""
+    from datetime import date
+
+    body = (
+        "id,court_id,docket_number,case_name,nature_of_suit\n"
+        "1,ca9,1:20-cv-01,Alpha,\n"
+        "2,nc,1:20-cv-02,Beta,899\n"
+        ",dcd,1:20-cv-03,Missing id,\n"
+    )
+    dump = tmp_path / "dockets-2026-06-30.csv.bz2"
+    dump.write_bytes(bz2.compress(body.encode()))
+
+    out = build_docket_court_map(tmp_path, dump_date=date(2026, 6, 30), local_file=dump)
+    rows = pq.read_table(out).to_pylist()
+    # docket_number rides along free: the pass that reads court_id has the row in
+    # hand, and it is the exact key for the duplicate docket records that hid 249
+    # APA decisions behind a case-name guess.
+    assert rows == [
+        {"cl_docket_id": "1", "court_id": "ca9", "docket_number": "1:20-cv-01"},
+        {"cl_docket_id": "2", "court_id": "nc", "docket_number": "1:20-cv-02"},
+    ]
+
+    # A cached map is reused rather than re-streamed...
+    assert build_docket_court_map(tmp_path, dump_date=date(2026, 6, 30)) == out
+    # ...and an interrupted pass never leaves a file that looks cached.
+    assert not list(tmp_path.glob("*.partial.parquet"))
+
+    # 46 minutes of someone else's bandwidth is a capture, and a capture that
+    # cannot say what it read is a file.
+    receipt = json.loads((out.with_suffix(".receipt.json")).read_text())
+    assert receipt["result"]["dockets"] == 2
+    assert receipt["bounds"]["rows_scanned"] == 3  # the row with no id was seen
+    assert receipt["bounds"]["resumes"] == 0
+    assert receipt["bounds"]["columns"] == ["cl_docket_id", "court_id", "docket_number"]
+    assert receipt["source"]["local_file"] == str(dump)
+
+
+def test_a_map_captured_before_docket_number_still_loads_and_says_so(tmp_path: Path):
+    """111 minutes of the publisher's bandwidth is not this function's to spend.
+
+    A cached map from before ``docket_number`` existed is still a perfectly good
+    docket→court map, so it is used. What it cannot do is the duplicate-docket
+    reconciliation, and a reconciliation that silently cannot run is exactly the
+    failure mode this ingest keeps finding in its own record.
+    """
+    from datetime import date
+
+    legacy = tmp_path / "docket_courts-2026-06-30.parquet"
+    pq.write_table(
+        pa.Table.from_pylist(
+            [{"cl_docket_id": "10", "court_id": "ca9"}],
+            schema=pa.schema([("cl_docket_id", pa.string()), ("court_id", pa.string())]),
+        ),
+        legacy,
+    )
+
+    from loguru import logger
+
+    warnings: list[str] = []
+    sink = logger.add(warnings.append, level="WARNING")
+    try:
+        assert build_docket_court_map(tmp_path, dump_date=date(2026, 6, 30)) == legacy
+    finally:
+        logger.remove(sink)
+    assert any("docket_number" in line for line in warnings), warnings
+
+    # And it still answers the question it was built for.
+    scope = CourtScope.from_map(legacy, _JURISDICTIONS)
+    assert scope.for_docket("10") == ("ca9", "F", "t")
+
+
+def test_courts_dump_reads_the_publisher_s_own_jurisdiction_codes(tmp_path: Path):
+    body = "id,short_name,jurisdiction\nca9,Ninth Circuit,F\nnc,North Carolina,S\nbap9,Ninth Circuit BAP,FBP\n"
+    dump = tmp_path / "courts-2026-06-30.csv.bz2"
+    dump.write_bytes(bz2.compress(body.encode()))
+    assert court_jurisdictions(local_file=dump) == {
+        "ca9": "F",
+        "nc": "S",
+        "bap9": "FBP",
+    }

--- a/tests/test_courtlistener_bulk.py
+++ b/tests/test_courtlistener_bulk.py
@@ -1,0 +1,524 @@
+"""Hermetic tests for the CourtListener bulk-dump ingest (no network).
+
+Covers the pieces with real logic: parsing the publisher's S3 listing into
+dataset/date pairs (which is how coverage gets checked at all), the streaming
+bzip2 CSV reader and its two bounds, the raw-row → published-schema mappings for
+both new tables, and the disk-headroom guard that is supposed to refuse a
+backfill rather than fill the volume.
+"""
+
+from __future__ import annotations
+
+import bz2
+import io
+from datetime import date
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from spicy_regs.sources.courtlistener_bulk import (
+    BulkObject,
+    CourtListenerBulkReader,
+    find_dump,
+    latest_dump_date,
+)
+from spicy_regs.transforms.build_court_opinion_bodies import (
+    COLUMNS as BODY_COLUMNS,
+)
+from spicy_regs.transforms.build_court_opinion_bodies import (
+    BYTES_PER_OPINION_ROW,
+    DISK_HEADROOM_FLOOR,
+    OPINIONS_PER_CLUSTER_CEILING,
+    check_headroom,
+    estimate_output_bytes,
+)
+from spicy_regs.transforms.build_court_opinion_bodies import _shape as shape_body
+from spicy_regs.transforms.build_court_opinion_clusters import (
+    COLUMNS as CLUSTER_COLUMNS,
+)
+from spicy_regs.transforms.build_court_opinion_clusters import (
+    _shape_bulk,
+    _shape_search,
+)
+
+# One real row from the 2026-06-30 opinions dump's column set, trimmed to the
+# fields the transform reads. `html_lawbox` is populated while `plain_text` is
+# empty — the exact case that makes "no text" and "no plain_text" different
+# questions.
+_RAW_OPINION = {
+    "id": "11422346",
+    "cluster_id": "10954746",
+    "type": "010combined",
+    "author_str": "Amit P. Mehta",
+    "author_id": "3227",
+    "joined_by_str": "",
+    "per_curiam": "f",
+    "sha1": "f1b0a6170c709af85ed4f18f1ff2d7cbebcc697d",
+    "page_count": "17",
+    "download_url": "https://ecf.dcd.uscourts.gov/cgi-bin/show_public_doc?2025cv3854-20",
+    "local_path": "pdf/2026/08/21/zeevi_v._united_states_department_of_state.pdf",
+    "extracted_by_ocr": "f",
+    "plain_text": "",
+    "html": "",
+    "html_lawbox": "<p>MEMORANDUM OPINION</p>",
+    "html_with_citations": "",
+    "date_created": "2026-08-21T14:02:11.000Z",
+    "date_modified": "2026-08-21T14:02:11.000Z",
+}
+
+_RAW_CLUSTER = {
+    "id": "10954746",
+    "docket_id": "73299709",
+    "case_name": "Zeevi v. United States Department of State",
+    "case_name_short": "Zeevi",
+    "case_name_full": "Yoav ZEEVI v. UNITED STATES DEPARTMENT OF STATE",
+    "date_filed": "2026-08-21",
+    "date_filed_is_approximate": "f",
+    "judges": "Amit P. Mehta",
+    "precedential_status": "Published",
+    "citation_count": "0",
+    "slug": "zeevi-v-united-states-department-of-state",
+    "date_created": "2026-08-21T14:02:11.000Z",
+}
+
+
+def _csv_bz2(tmp_path: Path, name: str, header: str, rows: list[str]) -> Path:
+    """Write a bzip2 CSV the reader can stream, exactly as the dumps are shaped."""
+    path = tmp_path / name
+    body = "\n".join([header, *rows]) + "\n"
+    path.write_bytes(bz2.compress(body.encode("utf-8")))
+    return path
+
+
+# -- listing / enumeration ---------------------------------------------------
+
+
+def test_bulk_object_splits_dataset_from_dump_date():
+    """Coverage is checked per dataset per dump, so both must parse out of the key."""
+    obj = BulkObject("bulk-data/opinion-clusters-2026-06-30.csv.bz2", 2_457_231_057, "2026-06-30T04:11:47.000Z")
+    assert obj.dataset == "opinion-clusters"
+    assert obj.dump_date == date(2026, 6, 30)
+    assert obj.filename == "opinion-clusters-2026-06-30.csv.bz2"
+    assert obj.url.endswith("/bulk-data/opinion-clusters-2026-06-30.csv.bz2")
+
+    # The bucket also holds undated one-off exports; those must not masquerade
+    # as a dated dump of some dataset.
+    undated = BulkObject("bulk-data/scotus_network.csv", 7_000, "2024-04-04T00:00:00.000Z")
+    assert undated.dump_date is None
+    assert undated.dataset == "scotus_network"
+
+
+def test_published_object_pin_identifies_what_a_capture_read():
+    """A receipt naming a filename has named a filename, not a thing.
+
+    The publisher's listing carries the object's exact byte size and
+    last-modified stamp, which is what makes two runs comparable and makes "the
+    dump was re-cut under us" a detectable event rather than an unexplained
+    difference in row counts. DocSpec pins the *population* at
+    ``fixtures/courtlistener-bulk-v1/``; this pins the one object a run read,
+    and lets that be checked against DocSpec's before the reading starts.
+    """
+    from spicy_regs.sources.courtlistener_bulk import published_object_pin
+
+    listing = [
+        BulkObject(
+            "bulk-data/opinions-2026-06-30.csv.bz2",
+            54_561_543_156,
+            "2026-06-30T09:56:48.000Z",
+        ),
+        BulkObject("bulk-data/courts-2026-06-30.csv.bz2", 81_180, "2026-06-30T09:00:26.000Z"),
+    ]
+
+    pin = published_object_pin("opinions", date(2026, 6, 30), objects=listing)
+    assert pin["bytes"] == 54_561_543_156
+    assert pin["last_modified"] == "2026-06-30T09:56:48.000Z"
+    assert pin["filename"] == "opinions-2026-06-30.csv.bz2"
+    assert pin["listing_object_count"] == 2
+
+    # Held against an expectation, it is a precondition rather than a note —
+    # which is the only useful place to discover a changed object when reading
+    # it costs 8.6 hours.
+    published_object_pin(
+        "opinions",
+        date(2026, 6, 30),
+        objects=listing,
+        expect_bytes=54_561_543_156,
+        expect_last_modified="2026-06-30T09:56:48.000Z",
+    )
+    with pytest.raises(RuntimeError, match="the publisher's object changed"):
+        published_object_pin("opinions", date(2026, 6, 30), objects=listing, expect_bytes=1)
+    with pytest.raises(RuntimeError, match="the publisher's object changed"):
+        published_object_pin(
+            "opinions",
+            date(2026, 6, 30),
+            objects=listing,
+            expect_last_modified="2026-07-01T00:00:00.000Z",
+        )
+    with pytest.raises(RuntimeError, match="no opinions dump published"):
+        published_object_pin("opinions", date(2026, 3, 31), objects=listing)
+
+
+def test_latest_dump_date_and_find_dump_pick_one_published_object():
+    objects = [
+        BulkObject("bulk-data/opinions-2026-03-31.csv.bz2", 54_190_000_000, ""),
+        BulkObject("bulk-data/opinions-2026-06-30.csv.bz2", 54_561_543_156, ""),
+        BulkObject("bulk-data/courts-2026-06-30.csv.bz2", 81_180, ""),
+    ]
+    assert latest_dump_date(objects, "opinions") == date(2026, 6, 30)
+    assert latest_dump_date(objects, "nonexistent") is None
+
+    found = find_dump(objects, "opinions", date(2026, 6, 30))
+    assert found is not None and found.size == 54_561_543_156
+    assert find_dump(objects, "opinions", date(2020, 1, 1)) is None
+
+
+# -- streaming reader --------------------------------------------------------
+
+
+def test_reader_streams_rows_and_normalizes_blanks(tmp_path: Path):
+    path = _csv_bz2(
+        tmp_path,
+        "courts-2026-06-30.csv.bz2",
+        "id,short_name,jurisdiction,notes",
+        ["ca9,Ninth Circuit,F,", "scotus,Supreme Court,F,seat of last resort"],
+    )
+    rows = list(CourtListenerBulkReader("courts", local_file=path).iter_records())
+    assert [r["id"] for r in rows] == ["ca9", "scotus"]
+    # An empty CSV field is absence, not the empty string — downstream NULL
+    # handling depends on that being decided here rather than per-transform.
+    assert rows[0]["notes"] is None
+    assert rows[1]["notes"] == "seat of last resort"
+
+
+def test_reader_honors_the_record_bound_and_reports_it(tmp_path: Path):
+    """A bounded run must be *recorded* as bounded, so coverage is not overclaimed."""
+    path = _csv_bz2(
+        tmp_path,
+        "opinions-2026-06-30.csv.bz2",
+        "id,cluster_id",
+        [f"{i},{i * 10}" for i in range(1, 51)],
+    )
+    reader = CourtListenerBulkReader("opinions", local_file=path, max_records=7)
+    rows = list(reader.iter_records())
+    assert len(rows) == 7
+    assert reader.rows_yielded == 7
+    assert reader.stopped_early is True
+
+    unbounded = CourtListenerBulkReader("opinions", local_file=path)
+    assert len(list(unbounded.iter_records())) == 50
+    assert unbounded.stopped_early is False
+
+
+def test_reader_applies_the_row_filter_before_materializing(tmp_path: Path):
+    """Filtering is what makes a targeted pass over a 50 GiB dump affordable."""
+    path = _csv_bz2(
+        tmp_path,
+        "opinions-2026-06-30.csv.bz2",
+        "id,cluster_id",
+        ["1,100", "2,200", "3,100"],
+    )
+    wanted = {"100"}
+    reader = CourtListenerBulkReader(
+        "opinions", local_file=path, row_filter=lambda row: (row.get("cluster_id") or "") in wanted
+    )
+    rows = list(reader.iter_records())
+    assert [r["id"] for r in rows] == ["1", "3"]
+    assert reader.rows_scanned == 3
+    assert reader.rows_yielded == 2
+
+
+def test_reader_reads_the_dumps_backslash_escaped_quotes(tmp_path: Path):
+    """The dumps escape an embedded quote as ``\\"``, not as the doubled ``""``.
+
+    Read with the stdlib default dialect this does not raise — it *desyncs*, and
+    the prose after the escaped quote becomes the next record's first column.
+    Measured on the real 2026-06-30 opinion-clusters dump that corrupted 1,987 of
+    the first 3,000 rows and dropped ``docket_id`` on two thirds of them, which
+    would have silently destroyed the docket join. A regression here is a data
+    corruption, not a parse error, so it is pinned.
+    """
+    path = _csv_bz2(
+        tmp_path,
+        "opinion-clusters-2026-06-30.csv.bz2",
+        "id,case_name,docket_id",
+        [r'"7290305","Ex parte \"Doe\", Inc.","64278691"', '"7290306","Plain v. Simple","64278692"'],
+    )
+    rows = list(CourtListenerBulkReader("opinion-clusters", local_file=path).iter_records())
+    assert [r["id"] for r in rows] == ["7290305", "7290306"]
+    assert rows[0]["case_name"] == 'Ex parte "Doe", Inc.'
+    # The row after the escaped quote must still be a row, with its join key intact.
+    assert rows[0]["docket_id"] == "64278691"
+    assert rows[1]["docket_id"] == "64278692"
+
+
+def test_reader_handles_embedded_newlines_in_opinion_text(tmp_path: Path):
+    """Opinion bodies contain newlines inside quoted fields; a naive line split loses rows."""
+    path = _csv_bz2(
+        tmp_path,
+        "opinions-2026-06-30.csv.bz2",
+        "id,plain_text",
+        ['1,"line one\nline two"', "2,short"],
+    )
+    rows = list(CourtListenerBulkReader("opinions", local_file=path).iter_records())
+    assert len(rows) == 2
+    assert rows[0]["plain_text"] == "line one\nline two"
+
+
+# -- resuming a long transfer ------------------------------------------------
+
+
+class _FlakyResponse:
+    """Serve bytes from an offset and die once, the way a long socket does."""
+
+    def __init__(
+        self,
+        payload: bytes,
+        *,
+        offset: int,
+        fail_after: int | None,
+        status: int | None = None,
+    ) -> None:
+        self._payload = payload
+        self._pos = offset
+        self._served = 0
+        self._fail_after = fail_after
+        self.status = status if status is not None else (206 if offset else 200)
+
+    def read(self, size: int) -> bytes:
+        if self._fail_after is not None and self._served >= self._fail_after:
+            raise OSError("connection reset by peer")
+        chunk = self._payload[self._pos : self._pos + size]
+        self._pos += len(chunk)
+        self._served += len(chunk)
+        return chunk
+
+    def close(self) -> None:
+        return None
+
+
+def test_counting_stream_resumes_a_dropped_transfer_at_the_exact_offset(monkeypatch):
+    """8.6 hours on one socket will be interrupted; the pass must survive it.
+
+    The resumed request must start at the compressed byte already consumed and
+    feed the *same* decompressor — bzip2 wants its bytes in order, not in one
+    connection. If the offset were wrong the failure would not be an error, it
+    would be corrupt text, so this pins the recovered bytes against the original.
+    """
+    from spicy_regs.sources import courtlistener_bulk
+    from spicy_regs.sources.courtlistener_bulk import _CountingStream
+
+    original = ("id,body\n" + "".join(f"{i},row {i}\n" for i in range(4000))).encode()
+    payload = bz2.compress(original)
+    # Read in small bites so the drop lands mid-dump, as a real one would.
+    monkeypatch.setattr(courtlistener_bulk, "_CHUNK", 1024)
+    assert len(payload) > 4096, "test payload must be big enough to interrupt mid-stream"
+
+    ranges: list[int] = []
+
+    def reopen(offset: int):
+        ranges.append(offset)
+        return _FlakyResponse(payload, offset=offset, fail_after=None)
+
+    stream = _CountingStream(_FlakyResponse(payload, offset=0, fail_after=2048), reopen=reopen)
+    recovered = io.BufferedReader(stream).read()
+
+    assert recovered == original
+    assert stream.resumes == 1
+    # Resumed once, from what was actually consumed — not from zero, not a guess.
+    assert ranges == [2048]
+    assert stream.compressed_bytes == len(payload)
+
+
+def test_a_resume_that_restarts_the_stream_is_refused_not_spliced(monkeypatch):
+    """A server that ignores Range answers 200 and starts over from byte zero.
+
+    Splicing that onto a transfer already gigabytes in does not raise — the
+    decompressor happily produces garbage that looks like rows. Refusing is the
+    only safe answer, and it has to be checked rather than assumed, because the
+    whole point of the resume is that nobody is watching when it happens.
+    """
+    from spicy_regs.sources import courtlistener_bulk
+    from spicy_regs.sources.courtlistener_bulk import _CountingStream
+
+    payload = bz2.compress(b"id,body\n" + b"".join(b"%d,row\n" % i for i in range(4000)))
+    monkeypatch.setattr(courtlistener_bulk, "_CHUNK", 1024)
+
+    def restart_from_zero(offset: int):  # noqa: ARG001 - the bug being simulated
+        return _FlakyResponse(payload, offset=0, fail_after=None, status=200)
+
+    stream = _CountingStream(_FlakyResponse(payload, offset=0, fail_after=2048), reopen=restart_from_zero)
+    with pytest.raises(RuntimeError, match="not 206"):
+        io.BufferedReader(stream).read()
+
+
+def test_counting_stream_reads_a_concatenated_bzip2_dump():
+    """``pbzip2`` writes many streams; a plain decompressor stops at the first.
+
+    The publisher's dumps are single-stream today. If that ever changes, a
+    decompressor that raises ``EOFError`` past the first boundary would end a
+    pass early — which is a coverage number that is quietly wrong, the failure
+    mode this ingest most has to avoid.
+    """
+    from spicy_regs.sources.courtlistener_bulk import _CountingStream
+
+    payload = bz2.compress(b"id,body\n1,first\n") + bz2.compress(b"2,second\n")
+    stream = _CountingStream(_FlakyResponse(payload, offset=0, fail_after=None))
+    assert io.BufferedReader(stream).read() == b"id,body\n1,first\n2,second\n"
+
+
+def test_reader_raises_on_a_broken_local_read_rather_than_resuming(tmp_path: Path):
+    """Resume is a network affordance; a local file has no ``Range`` to ask for."""
+    from spicy_regs.sources.courtlistener_bulk import _CountingStream
+
+    stream = _CountingStream(_FlakyResponse(b"anything", offset=0, fail_after=0))
+    with pytest.raises(OSError, match="connection reset"):
+        io.BufferedReader(stream).read()
+
+
+# -- shaping -----------------------------------------------------------------
+
+
+def test_body_shape_matches_the_published_schema_and_records_text_provenance():
+    row = shape_body(_RAW_OPINION, dump_date=date(2026, 6, 30))
+    assert set(row) == set(BODY_COLUMNS)
+    assert row["opinion_id"] == "11422346"
+    assert row["cluster_id"] == "10954746"
+    assert row["dump_date"] == "2026-06-30"
+
+    # plain_text is empty upstream, so it stays NULL rather than becoming "".
+    assert row["plain_text"] is None
+    assert row["html_with_citations"] is None
+    # ...but the row is not textless, and the table must say which rendering exists.
+    assert row["available_text_fields"] == "html_lawbox"
+    assert row["text_char_count"] == str(len("<p>MEMORANDUM OPINION</p>"))
+
+
+def test_body_shape_reports_a_genuinely_textless_opinion_as_zero():
+    bare = {**_RAW_OPINION, "html_lawbox": ""}
+    row = shape_body(bare, dump_date=None)
+    assert row["available_text_fields"] is None
+    assert row["text_char_count"] == "0"
+    assert row["dump_date"] is None
+
+
+def test_cluster_shape_matches_schema_and_renames_the_docket_join_key():
+    row = _shape_bulk(_RAW_CLUSTER)
+    assert set(row) == set(CLUSTER_COLUMNS)
+    assert row["cluster_id"] == "10954746"
+    # The dump calls it docket_id; court_dockets calls it cl_docket_id. The join
+    # only reads the same on both sides if the rename happens here.
+    assert row["cl_docket_id"] == "73299709"
+    assert row["absolute_url"] == (
+        "https://www.courtlistener.com/opinion/10954746/zeevi-v-united-states-department-of-state/"
+    )
+    assert row["ingest_source"] == "bulk"
+
+
+def test_search_shape_leaves_dump_only_columns_null():
+    """The catch-up API is narrower than the dump; absent prose must stay absent."""
+    result = {
+        "cluster_id": "10954746",
+        "docket_id": "73299709",
+        "caseName": "Zeevi v. United States Department of State",
+        "dateFiled": "2026-08-21",
+        "status": "Published",
+        "absolute_url": "/opinion/10954746/zeevi/",
+    }
+    row = _shape_search(result)
+    assert set(row) == set(CLUSTER_COLUMNS)
+    assert row["cl_docket_id"] == "73299709"
+    assert row["ingest_source"] == "search"
+    assert row["absolute_url"] == "https://www.courtlistener.com/opinion/10954746/zeevi/"
+    # Not supplied by /search/ — and not fabricated.
+    assert row["syllabus"] is None
+    assert row["headnotes"] is None
+    assert row["headmatter"] is None
+
+
+# -- the disk guard ----------------------------------------------------------
+
+
+def test_check_headroom_refuses_an_ingest_that_would_cross_the_floor(tmp_path: Path, monkeypatch):
+    """The floor exists so a backfill fails loudly instead of filling the volume."""
+    import shutil as shutil_module
+
+    free = DISK_HEADROOM_FLOOR + 10 * 2**30
+
+    def fake_usage(_path):
+        return shutil_module._ntuple_diskusage(total=free * 4, used=free * 3, free=free)
+
+    # The transform calls ``shutil.disk_usage`` through the stdlib module, so
+    # patching it there covers the real call site.
+    monkeypatch.setattr(shutil_module, "disk_usage", fake_usage)
+
+    # 5 GiB still leaves 5 GiB above the floor.
+    check_headroom(5 * 2**30, path=tmp_path)
+
+    # The real 2026-06-30 opinions dump does not fit, and must say so.
+    with pytest.raises(RuntimeError, match="below the 100 GiB floor"):
+        check_headroom(54_561_543_156, path=tmp_path)
+
+
+def test_estimate_output_bytes_charges_a_targeted_pass_for_its_output():
+    """A filtered pass reads 50.8 GiB and writes almost nothing; the guard must know.
+
+    The dump is streamed, never landed, so the disk cost of any pass is the
+    parquet it writes. Charging a 1,155-cluster APA pass the whole dump's size
+    refuses a run that costs tens of megabytes — the guard would be stopping the
+    single highest-value follow-up for a cost it does not incur.
+    """
+    dump = 54_561_543_156
+
+    # No filter: the output is the whole corpus, and the dump size stands in.
+    assert estimate_output_bytes(dump, None) == dump
+
+    # The real APA target set. Well under a gibibyte, so it clears a 7 GiB margin.
+    apa = estimate_output_bytes(dump, {str(i) for i in range(1155)})
+    assert apa < 2**30
+    assert apa == 1155 * OPINIONS_PER_CLUSTER_CEILING * BYTES_PER_OPINION_ROW
+
+    # Still refuses the thing it exists to refuse: filtering on every cluster in
+    # the corpus is a backfill wearing a filter, and must be sized as one.
+    assert estimate_output_bytes(dump, {str(i) for i in range(200_000)}) > 20 * 2**30
+
+    # A filter whose size cannot be known falls back to the conservative number
+    # rather than guessing small.
+    class _Unsized:
+        def __contains__(self, _item: object) -> bool:
+            return True
+
+    assert estimate_output_bytes(dump, _Unsized()) == dump
+
+
+# -- first build promotes rather than merges ---------------------------------
+
+
+def test_first_build_promotes_the_staged_table_without_merging(tmp_path: Path, monkeypatch):
+    """With no prior table the merge is a sort the machine cannot always afford.
+
+    One dump, whose id column is the publisher's primary key, so the dedup can
+    remove nothing. Running the COPY anyway held the staged and merged copies on
+    disk at once and — on 250,000 rows carrying kilobytes of opinion text each —
+    ran duckdb's memory budget out entirely. The first build promotes instead.
+    """
+    from spicy_regs.sources import r2
+    from spicy_regs.transforms.build_court_opinion_bodies import build_court_opinion_bodies
+
+    monkeypatch.setattr(r2, "download", lambda *_: False)
+    dump = _csv_bz2(
+        tmp_path,
+        "opinions-2026-06-30.csv.bz2",
+        "id,cluster_id,type,plain_text,html_with_citations",
+        ['"11","101","010combined","body one",""', '"12","102","040dissent","","<p>body two</p>"'],
+    )
+    out = build_court_opinion_bodies(tmp_path, dump_date=date(2026, 6, 30), local_file=dump)
+
+    stored = pq.read_table(out).to_pylist()
+    assert [r["opinion_id"] for r in stored] == ["11", "12"]
+    assert set(stored[0]) == set(BODY_COLUMNS)
+    assert stored[0]["plain_text"] == "body one"
+    assert stored[1]["html_with_citations"] == "<p>body two</p>"
+    assert stored[1]["available_text_fields"] == "html_with_citations"
+    # The staged file must not survive as a second copy of the same rows.
+    assert not (tmp_path / "_bodies_new.parquet").exists()


### PR DESCRIPTION
Court opinions cite statutes, not CFR parts, so today a user asking "which cases touch this rule" gets nothing — nothing joins a decision to the rule it concerns. This reads CourtListener's quarterly bulk dumps and publishes two tables: one row per decision with the court that decided it (the dump omits that; it is derived from a 71.7-million-row docket map), and the opinion text itself. spicysearch already tags court opinions it is handed as pinned parquet; this is what produces that parquet. The reader streams bz2 over HTTP, resumes with a Range request if the connection drops, and pins a CSV dialect that prevents a row desync the default dialect produces on this dump.

Run against the live 2026-06-30 dumps, bounded: the clusters transform on 20,000 rows with the real docket-to-court map resolved a deciding court on 20000 of 20000 (8325 federal), 43 s including the 40 s map index; the bodies transform on 50 MB of the 50.8 GiB opinions dump yielded 6,344 rows in 23 s; the reader alone on 50 MB of the clusters dump yielded 204,654 rows, every one 36 fields wide — no ragged rows, so the dialect fix holds on the current dump. Zero resumes. The Supreme Court half of the courts cluster is deliberately separate: its source needs bs4, which this repo does not carry, and that dependency choice gets its own PR. Registering the two tables in the data dictionary and MCP server follows as its own PR, the way #175 exposed the lifecycle rollups after they existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)