### PR TITLE
feat(bills): publish CRS policy areas and legislative subjects per bill

### DIFF
--- a/.github/workflows/rollup-bill-subjects.yml
+++ b/.github/workflows/rollup-bill-subjects.yml
@@ -1,0 +1,26 @@
+name: Rollup — bill_subjects
+on:
+  schedule:
+    # 21:15 UTC — one hour after the congress_bills ingest, so each enrichment
+    # run walks a bill table that has already been refreshed.
+    - cron: '15 21 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: 'Skip R2 upload (dry run)'
+        required: false
+        default: false
+        type: boolean
+      max_bills:
+        description: "Bills to enrich this run; blank uses the carrier's own cap (5000 keyless, 2000 keyed)"
+        required: false
+        default: ''
+        type: string
+jobs:
+  run:
+    uses: ./.github/workflows/_rollup.yml
+    secrets: inherit
+    with:
+      command: run-rollup-bill-subjects
+      skip_upload: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_upload || false }}
+      bill_subjects_max: ${{ inputs.max_bills || '' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ docs = [
 ]
 
 [project.scripts]
+run-rollup-bill-subjects = "spicy_regs.pipelines.rollups.bill_subjects:app"
 run-pipeline = "spicy_regs.pipelines.regulations:app"
 run-rollup-feed-summary = "spicy_regs.pipelines.rollups.feed_summary:app"
 run-rollup-agency-stats = "spicy_regs.pipelines.rollups.agency_stats:app"

--- a/src/spicy_regs/pipelines/rollups/bill_subjects.py
+++ b/src/spicy_regs/pipelines/rollups/bill_subjects.py
@@ -1,0 +1,50 @@
+"""Rollup pipeline: bill_subjects.parquet (Congress.gov / GPO subject enrichment).
+
+Reads the published ``congress_bills.parquet`` as its input snapshot — the
+``fr_docket_links`` shape, where a rollup keys off another published artifact
+without owning it — and fetches the per-bill subject assignment the ``/bill``
+list payload never carries. The bounded, resumable enrichment itself lives in
+``enrich_bill_subjects``; the base class handles priming the input and the
+shrink-guarded R2 upload of the single output.
+
+Runs on its own cron, deliberately offset from the congress_bills ingest so each
+run enriches against a table that has already been refreshed.
+"""
+
+import os
+from pathlib import Path
+from typing import ClassVar
+
+from spicy_regs.pipelines.rollups.base import RollupPipeline, make_rollup_app
+from spicy_regs.transforms import enrich_bill_subjects
+
+
+def _int_env(name: str) -> int | None:
+    """Read a positive integer override, or None to use the carrier's own cap."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {raw!r}") from exc
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+    return value
+
+
+class BillSubjectsRollup(RollupPipeline):
+    """Per-bill policy area and legislative subjects (Congress.gov / GPO BILLSTATUS)."""
+
+    name: ClassVar[str] = "bill-subjects"
+    inputs: ClassVar[tuple[str, ...]] = ("congress_bills.parquet",)
+    output: ClassVar[str] = "bill_subjects.parquet"
+
+    def build(self, output_dir: Path) -> Path:
+        return enrich_bill_subjects(output_dir, max_bills=_int_env("BILL_SUBJECTS_MAX"))
+
+
+app = make_rollup_app(BillSubjectsRollup)
+
+if __name__ == "__main__":
+    app()

--- a/src/spicy_regs/sources/bill_subjects.py
+++ b/src/spicy_regs/sources/bill_subjects.py
@@ -1,0 +1,359 @@
+"""Reader-side fetcher for one bill's CRS policy area + legislative subjects.
+
+``congress_bills.parquet`` is built list-level only: the ``/bill`` list payload
+carries no subject signal at all, so the published table can say *what* a bill is
+but never *what it is about*. Both missing fields are detail-endpoint-only, and
+this module is the per-bill fetch that
+:mod:`spicy_regs.transforms.enrich_bill_subjects` walks the table with.
+
+**Two carriers, one vocabulary.** The Library of Congress assigns each bill one
+``policyArea`` (a ~33-term controlled list) and any number of ``legislative
+subjects`` (a large controlled vocabulary). Two publishers serve those same
+assignments, and the reader picks whichever the environment can actually reach:
+
+``congress-api``
+    ``GET /v3/bill/{congress}/{type}/{number}/subjects`` returns **both** fields
+    in one response (``subjects.policyArea.name`` and
+    ``subjects.legislativeSubjects[].name``), so a bill costs one request, not
+    two — the ``/bill/{congress}/{type}/{number}` detail endpoint carries only
+    the policy area and is not needed. Coverage runs back to the 93rd Congress.
+    Requires an api.data.gov key, resolved through the same fallback chain as
+    :mod:`spicy_regs.sources.congress_bills`. Pagination defaults to 20 subjects
+    per page, so the request asks for the 250-item maximum and walks ``offset``
+    for the rare bill that carries more.
+
+``govinfo-billstatus``
+    GPO's BILLSTATUS bulk data serves the same assignments as XML with **no key
+    and no rate limit**: ``<policyArea><name>`` and
+    ``<subjects><legislativeSubjects><item><name>``. The terms are identical
+    strings; only the carrier differs — the same equivalence
+    ``tools/fuse_concept_registries.py`` already relies on to read these two
+    vocabularies. Its coverage floor is the **108th Congress** (2003); anything
+    earlier 404s, which is why the transform records the floor rather than
+    walking bills the carrier cannot answer for.
+
+Without a key the keyless carrier is chosen automatically, so a CI run is never
+a no-op — it just enriches a shallower slice of the archive.
+
+**Three outcomes, not two.** :meth:`BillSubjectsFetcher.subjects_for` returns a
+:class:`BillSubjects` when the carrier *answered* (including an answer of "no
+assignments"), and ``None`` when it did not (timeout, 5xx, exhausted retries).
+The transform writes a row only for an answer, so a network wobble leaves the
+bill un-enriched for the next run instead of pinning an empty answer to it.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from xml.etree import ElementTree
+
+import httpx
+from loguru import logger
+
+from spicy_regs.sources.congress_bills import API_BASE, API_KEY_ENV_VARS, _resolve_api_key
+
+BULKDATA_BASE = "https://www.govinfo.gov/bulkdata/BILLSTATUS"
+
+#: Carrier names, stored verbatim in ``bill_subjects.carrier`` so a reader can
+#: tell which publisher supplied a row (and the transform can re-ask a bill the
+#: *other* carrier had nothing for).
+CARRIER_API = "congress-api"
+CARRIER_BULKDATA = "govinfo-billstatus"
+
+#: Earliest Congress each carrier answers for. GPO's bulk-data repository starts
+#: at the 108th; the Congress.gov API's subject assignments start at the 93rd,
+#: when CRS began indexing legislation.
+FIRST_CONGRESS = {CARRIER_API: 93, CARRIER_BULKDATA: 108}
+
+#: An honest identifying User-Agent on every request, per the repo's other
+#: scraped sources (``uscode_olrc``, ``gao_reports``, ``courtlistener_bulk``).
+_USER_AGENT = "spicy-regs-etl/1.0 (+https://github.com/civictechdc/spicy-regs)"
+
+# Transport hygiene, matching ``sources.congress_bills``: bound every request and
+# retry transient failures with backoff.
+_TIMEOUT = httpx.Timeout(60.0, connect=30.0)
+_MAX_RETRIES = 4
+
+#: Max subjects the API returns per page (the ``limit`` ceiling), and how many
+#: pages to walk before settling for what we have. 4 x 250 = 1,000 subjects is
+#: far past the fattest bill observed; the bound just stops a runaway loop.
+_SUBJECTS_PER_PAGE = 250
+_MAX_SUBJECT_PAGES = 4
+
+#: Requests an hour Congress.gov documents for a keyed client. It is a stated
+#: budget, not a guess, and every attempt spends from it — retries included.
+API_HOURLY_BUDGET = 5_000
+
+#: Seconds to wait between requests, per carrier. The API carrier crawls at
+#: 1.33 requests a second, comfortably under the 1.39/s the hourly budget
+#: allows, so a run of retries cannot walk the pipeline into 429s. GPO's bulk
+#: data publishes no budget at all; 0.15s is a deliberate crawl rather than
+#: whatever the pipe happens to allow.
+DELAY_SECONDS = {CARRIER_API: 0.75, CARRIER_BULKDATA: 0.15}
+
+
+class _Absent:
+    """Sentinel: the carrier answered, and does not hold this bill."""
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<absent>"
+
+
+_ABSENT = _Absent()
+
+
+@dataclass(frozen=True)
+class BillSubjects:
+    """One bill's subject assignment, as a carrier actually answered it.
+
+    An answer of ``policy_area=None, subjects=()`` is a real answer, and it has
+    two distinguishable causes: the carrier holds the bill and no terms were
+    assigned to it (``held=True``), or the carrier has no record of the bill at
+    all (``held=False`` — a 404). Both publish the same null, but a coverage
+    number that cannot tell them apart is a coverage number nobody can read, so
+    the run report counts them separately. A carrier that never answered is
+    ``None`` from :meth:`BillSubjectsFetcher.subjects_for` instead, and is left
+    for the next run.
+    """
+
+    policy_area: str | None
+    subjects: tuple[str, ...]
+    carrier: str
+    held: bool = True
+
+
+@dataclass
+class FetchCounts:
+    """Per-run tally of how each fetch landed. Reported by the transform."""
+
+    answered: int = 0
+    with_policy_area: int = 0
+    subjects_only: int = 0
+    unassigned: int = 0
+    not_held: int = 0
+    failed: int = 0
+    policy_areas: dict[str, int] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "answered": self.answered,
+            "with_policy_area": self.with_policy_area,
+            "subjects_only": self.subjects_only,
+            "unassigned": self.unassigned,
+            "not_held": self.not_held,
+            "failed": self.failed,
+        }
+
+
+class BillSubjectsFetcher:
+    """Fetches one bill's policy area + legislative subjects from either carrier.
+
+    Build one per run and reuse it: the HTTP client is opened lazily on the
+    first fetch and held for connection reuse, and the run tallies accumulate on
+    :attr:`counts`. Not shared-safe across threads.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        carrier: str | None = None,
+        delay: float | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self.api_key = api_key if api_key is not None else _resolve_api_key()
+        self.carrier = carrier or (CARRIER_API if self.api_key else CARRIER_BULKDATA)
+        if self.carrier == CARRIER_API and not self.api_key:
+            raise ValueError(
+                f"carrier {CARRIER_API!r} needs an api.data.gov key (set one of {', '.join(API_KEY_ENV_VARS)})"
+            )
+        self.delay = DELAY_SECONDS[self.carrier] if delay is None else delay
+        self.counts = FetchCounts()
+        self._client = client
+        self._owns_client = client is None
+
+    @property
+    def first_congress(self) -> int:
+        """Earliest Congress this carrier can answer for."""
+        return FIRST_CONGRESS[self.carrier]
+
+    def __enter__(self) -> BillSubjectsFetcher:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._client is not None and self._owns_client:
+            self._client.close()
+            self._client = None
+
+    # -- fetch ---------------------------------------------------------------
+
+    def subjects_for(self, congress: str, bill_type: str, bill_number: str) -> BillSubjects | None:
+        """Return this bill's assignment, or None if the carrier never answered."""
+        if self.carrier == CARRIER_API:
+            result = self._from_api(congress, bill_type, bill_number)
+        else:
+            result = self._from_bulkdata(congress, bill_type, bill_number)
+        self._tally(result)
+        return result
+
+    def _tally(self, result: BillSubjects | None) -> None:
+        """Sort one answer into exactly one bucket, so the four always sum."""
+        if result is None:
+            self.counts.failed += 1
+            return
+        self.counts.answered += 1
+        if result.policy_area:
+            self.counts.with_policy_area += 1
+            self.counts.policy_areas[result.policy_area] = self.counts.policy_areas.get(result.policy_area, 0) + 1
+        elif result.subjects:
+            self.counts.subjects_only += 1
+        elif result.held:
+            self.counts.unassigned += 1
+        else:
+            self.counts.not_held += 1
+
+    def _from_api(self, congress: str, bill_type: str, bill_number: str) -> BillSubjects | None:
+        """One ``/subjects`` call (plus offset pages) for both fields."""
+        url = f"{API_BASE}/bill/{congress}/{str(bill_type).lower()}/{bill_number}/subjects"
+        policy_area: str | None = None
+        names: list[str] = []
+        for page in range(_MAX_SUBJECT_PAGES):
+            params = {
+                "offset": page * _SUBJECTS_PER_PAGE,
+                "limit": _SUBJECTS_PER_PAGE,
+                "format": "json",
+                "api_key": self.api_key,
+            }
+            payload = self._get_json(url, params=params)
+            if isinstance(payload, _Absent):
+                return BillSubjects(None, (), self.carrier, held=False)
+            if payload is None:
+                # A later page failing must not publish a truncated subject list.
+                return None
+            block = payload.get("subjects") or {}
+            policy_area = policy_area or _clean((block.get("policyArea") or {}).get("name"))
+            names.extend(
+                name
+                for item in block.get("legislativeSubjects") or []
+                if isinstance(item, dict) and (name := _clean(item.get("name")))
+            )
+            total = (payload.get("pagination") or {}).get("count")
+            if not isinstance(total, int) or len(names) >= total:
+                break
+        return BillSubjects(policy_area, _dedup(names), self.carrier)
+
+    def _from_bulkdata(self, congress: str, bill_type: str, bill_number: str) -> BillSubjects | None:
+        """One BILLSTATUS XML fetch, parsed for both fields."""
+        slug = f"{congress}{str(bill_type).lower()}{bill_number}"
+        url = f"{BULKDATA_BASE}/{congress}/{str(bill_type).lower()}/BILLSTATUS-{slug}.xml"
+        text = self._get_text(url)
+        if isinstance(text, _Absent):
+            return BillSubjects(None, (), self.carrier, held=False)
+        if text is None:
+            return None
+        policy_area, subjects = parse_billstatus_subjects(text)
+        return BillSubjects(policy_area, subjects, self.carrier)
+
+    # -- transport -----------------------------------------------------------
+
+    def _get_json(self, url: str, *, params: dict) -> dict | _Absent | None:
+        """Fetch a JSON body. A body that will not parse counts as no answer."""
+        response = self._request(url, params=params)
+        if response is None or isinstance(response, _Absent):
+            return response
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            logger.warning("Bill subjects: unparseable JSON from {}: {}", url, exc)
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def _get_text(self, url: str) -> str | _Absent | None:
+        """Fetch a text body (BILLSTATUS XML)."""
+        response = self._request(url, params=None)
+        return response if response is None or isinstance(response, _Absent) else response.text
+
+    def _request(self, url: str, *, params: dict | None) -> httpx.Response | _Absent | None:
+        """GET with bounded retries + exponential backoff.
+
+        Returns the response, :data:`_ABSENT` on a definitive 404 (the carrier
+        does not hold this bill), or ``None`` when no answer was obtained.
+        """
+        if self._client is None:
+            self._client = httpx.Client(
+                timeout=_TIMEOUT,
+                headers={"User-Agent": _USER_AGENT, "Accept": "application/json, text/xml"},
+            )
+        for attempt in range(1, _MAX_RETRIES + 1):
+            if self.delay:
+                time.sleep(self.delay)
+            try:
+                resp = self._client.get(url, params=params, follow_redirects=True)
+                if resp.status_code == 404:
+                    return _ABSENT
+                if resp.status_code == 429 or resp.status_code >= 500:
+                    raise httpx.HTTPStatusError("retryable", request=resp.request, response=resp)
+                resp.raise_for_status()
+                return resp
+            except httpx.HTTPError as exc:
+                if attempt == _MAX_RETRIES:
+                    logger.error("Bill subjects: giving up on {} after {} attempts: {}", url, attempt, exc)
+                    return None
+                backoff = min(2**attempt, 30)
+                logger.warning(
+                    "Bill subjects: {} (attempt {}/{}), retrying in {}s", exc, attempt, _MAX_RETRIES, backoff
+                )
+                time.sleep(backoff)
+        return None
+
+
+def parse_billstatus_subjects(xml_text: str) -> tuple[str | None, tuple[str, ...]]:
+    """Read ``(policy_area, legislative_subjects)`` out of one BILLSTATUS record.
+
+    ``<policyArea>`` appears twice in a BILLSTATUS document — once as a direct
+    child of ``<bill>`` and once inside ``<subjects>`` — carrying the same name,
+    so the first non-empty one wins. **No subject -> policy-area hierarchy is
+    derived**: the two are sibling assertions about the bill, never a parent and
+    its children (the reasoning ``tools/fuse_concept_registries.py`` sets out at
+    length). Malformed XML yields an empty answer rather than raising.
+    """
+    try:
+        root = ElementTree.fromstring(xml_text)
+    except ElementTree.ParseError:
+        return (None, ())
+    policy_area = next(
+        (name for element in root.iter("policyArea") if (name := _clean(element.findtext("name")))),
+        None,
+    )
+    subjects = [
+        name
+        for container in root.iter("legislativeSubjects")
+        for item in container.iter("item")
+        if (name := _clean(item.findtext("name")))
+    ]
+    return (policy_area, _dedup(subjects))
+
+
+def _clean(value: object) -> str | None:
+    """Collapse a possibly-absent XML/JSON text node to a non-empty string."""
+    if value is None:
+        return None
+    text = " ".join(str(value).split())
+    return text or None
+
+
+def _dedup(names: list[str]) -> tuple[str, ...]:
+    """Distinct names in first-seen order (a bill can list a term twice)."""
+    return tuple(dict.fromkeys(names))
+
+
+def resolve_carrier(api_key: str | None = None) -> str:
+    """Name the carrier a run would use, without opening a client."""
+    key = api_key if api_key is not None else _resolve_api_key()
+    return CARRIER_API if key else CARRIER_BULKDATA

--- a/src/spicy_regs/transforms/__init__.py
+++ b/src/spicy_regs/transforms/__init__.py
@@ -13,6 +13,7 @@ from spicy_regs.transforms.build_federal_register import build_federal_register
 from spicy_regs.transforms.build_feed_summary import build_feed_summary
 from spicy_regs.transforms.build_fr_docket_links import build_fr_docket_links
 from spicy_regs.transforms.build_org_committee_links import build_org_committee_links
+from spicy_regs.transforms.enrich_bill_subjects import enrich_bill_subjects
 from spicy_regs.transforms.build_gao_reports import build_gao_reports
 from spicy_regs.transforms.build_lobbying_filings import build_lobbying_filings
 from spicy_regs.transforms.build_rulemaking_lifecycles import build_rulemaking_lifecycles
@@ -62,6 +63,7 @@ __all__ = [
     "build_federal_register",
     "build_fr_docket_links",
     "build_org_committee_links",
+    "enrich_bill_subjects",
     "build_gao_reports",
     "build_lobbying_filings",
     "build_unified_agenda",

--- a/src/spicy_regs/transforms/enrich_bill_subjects.py
+++ b/src/spicy_regs/transforms/enrich_bill_subjects.py
@@ -56,7 +56,6 @@ from spicy_regs.sources.bill_subjects import (
     BillSubjects,
     BillSubjectsFetcher,
     FetchCounts,
-    FetchCounts,
 )
 
 OUTPUT = "bill_subjects.parquet"

--- a/src/spicy_regs/transforms/enrich_bill_subjects.py
+++ b/src/spicy_regs/transforms/enrich_bill_subjects.py
@@ -1,0 +1,329 @@
+"""Transform: build ``bill_subjects.parquet`` — one bill's subject assignment.
+
+The seam this closes is stated in :mod:`~spicy_regs.transforms.build_congress_bills`:
+``congress_bills`` is list-level only, and the Library of Congress subject
+assignment (one ``policy_area`` from a ~33-term controlled list, plus any number
+of ``legislative subjects``) is detail-endpoint-only. This is the per-bill
+enrichment pass that fetches it, via
+:class:`~spicy_regs.sources.bill_subjects.BillSubjectsFetcher`.
+
+**Why a sibling table and not extra columns on ``congress_bills``.** The two
+artifacts have utterly different fetch economics: the list ingest walks a handful
+of pages a day, while enrichment is one request per bill across a 192k-row
+archive. Folding them together would put a multi-week backfill inside a daily
+30-minute job, and would give one R2 key two writers. So this publishes its own
+artifact on its own cron, keyed by the same ``bill_id`` — the ``fr_docket_links``
+shape, joined with a one-line ``LEFT JOIN``::
+
+    SELECT b.*, s.policy_area, s.subjects_json
+    FROM congress_bills b LEFT JOIN bill_subjects s USING (bill_id)
+
+**Incremental, resumable, bounded.** Each run:
+
+1. Best-effort downloads the prior ``bill_subjects.parquet`` from R2.
+2. Selects bills in ``congress_bills.parquet`` that the current carrier has not
+   answered for yet, newest Congress first, capped at :data:`MAX_BILLS_PER_RUN`
+   so the run fits inside the CI timeout (the ``build_lobbying_filings``
+   ``MAX_WINDOW_DAYS`` idea, counted in bills rather than days).
+3. Fetches each, writing a row only when the carrier *answered*. A timeout or a
+   5xx writes nothing, so the bill is simply picked up next run — no half-written
+   state, and a re-run is never wasted work.
+4. Merges prior + new on ``bill_id``, preferring the fresh row.
+
+A bill the carrier definitively 404s gets a row with a null ``policy_area`` and
+its carrier recorded, so the next run does not ask again. Should a key later
+appear and switch the run to the deeper Congress.gov carrier, those rows *are*
+re-asked — the carrier that had nothing is not the carrier that might.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from loguru import logger
+
+from spicy_regs.sources import r2
+from spicy_regs.sources.bill_subjects import (
+    CARRIER_API,
+    CARRIER_BULKDATA,
+    FIRST_CONGRESS,
+    BillSubjects,
+    BillSubjectsFetcher,
+    FetchCounts,
+    FetchCounts,
+)
+
+OUTPUT = "bill_subjects.parquet"
+BILLS_INPUT = "congress_bills.parquet"
+
+#: Bills to enrich per run, per carrier. Each is what that carrier's crawl rate
+#: fits inside the reusable rollup workflow's 30-minute timeout: GPO's bulk data
+#: answers at ~4.7 bills a second (5,000 in ~18 minutes), while Congress.gov's
+#: documented 5,000-requests-an-hour budget caps the API carrier at 1.33 a
+#: second (2,000 in ~25 minutes). A cap of 5,000 on the API carrier would spend
+#: the whole hourly budget in one run and leave nothing for a retry.
+MAX_BILLS_PER_RUN = {CARRIER_API: 2_000, CARRIER_BULKDATA: 5_000}
+
+#: The published schema: all VARCHAR, keyed by ``bill_id``, joinable straight to
+#: ``congress_bills``. The subject list is a JSON string so the table stays flat
+#: and portable, matching ``lobbying_filings``' JSON-valued columns.
+COLUMNS = (
+    "bill_id",
+    "policy_area",
+    "subjects_json",
+    "subject_count",
+    "carrier",
+    "enriched_at",
+)
+_SCHEMA = pa.schema([(c, pa.string()) for c in COLUMNS])
+
+
+def _shape(bill_id: str, policy_area: str | None, subjects: tuple[str, ...], carrier: str, now: str) -> dict:
+    """Map one fetched assignment onto the published column shape."""
+    return {
+        "bill_id": bill_id,
+        "policy_area": policy_area,
+        "subjects_json": json.dumps(list(subjects)),
+        "subject_count": str(len(subjects)),
+        "carrier": carrier,
+        "enriched_at": now,
+    }
+
+
+def _pending_bills(
+    bills_file: Path,
+    prior_file: Path,
+    *,
+    carrier: str,
+    have_prior: bool,
+    limit: int,
+) -> list[tuple[str, str, str, str]]:
+    """Bills this carrier still owes an answer for, newest Congress first.
+
+    A bill is pending when the prior table has no row for it, or has a row that
+    another carrier left empty — the current carrier may well hold what that one
+    did not. Bills below the carrier's coverage floor are never asked for; the
+    request could only 404, and burning the run's budget on a guaranteed miss is
+    how a backfill stops making progress.
+    """
+    import duckdb
+
+    floor = FIRST_CONGRESS[carrier]
+    if have_prior:
+        # The OR group is parenthesized on purpose: without it the coverage-floor
+        # and not-null filters below would bind only to the second branch, and a
+        # first-time bill would be asked for regardless of the floor.
+        pending = f"""
+            LEFT JOIN read_parquet('{prior_file}') AS prior ON prior.bill_id = bill.bill_id
+            WHERE (
+                prior.bill_id IS NULL
+                OR (prior.policy_area IS NULL AND prior.carrier IS DISTINCT FROM '{carrier}')
+            )
+        """
+    else:
+        pending = "WHERE TRUE"
+
+    rows = duckdb.sql(
+        f"""
+        SELECT bill.bill_id, bill.congress, bill.bill_type, bill.bill_number
+        FROM read_parquet('{bills_file}') AS bill
+        {pending}
+          AND bill.bill_id IS NOT NULL
+          AND bill.bill_type IS NOT NULL
+          AND bill.bill_number IS NOT NULL
+          AND TRY_CAST(bill.congress AS INTEGER) >= {floor}
+        ORDER BY TRY_CAST(bill.congress AS INTEGER) DESC, bill.bill_id
+        LIMIT {int(limit)}
+        """
+    ).fetchall()
+    return [(str(a), str(b), str(c), str(d)) for a, b, c, d in rows]
+
+
+def _adopt_local_output(out_file: Path, prior_file: Path) -> bool:
+    """Treat an artifact left by a previous local run as this run's prior."""
+    if not out_file.exists():
+        return False
+    out_file.replace(prior_file)
+    logger.info("Bill subjects: adopting the local {} as this run's prior", out_file.name)
+    return True
+
+
+def _log_counts(counts: FetchCounts, *, carrier: str, attempted: int, elapsed: float) -> None:
+    """Report the run the way the repo's other incremental transforms do."""
+    rate = attempted / elapsed if elapsed > 0 else 0.0
+    logger.info(
+        "Bill subjects: carrier={} attempted={:,} answered={:,} with_policy_area={:,} "
+        "subjects_only={:,} unassigned={:,} not_held={:,} failed={:,} in {:.0f}s ({:.1f} bills/s)",
+        carrier,
+        attempted,
+        counts.answered,
+        counts.with_policy_area,
+        counts.subjects_only,
+        counts.unassigned,
+        counts.not_held,
+        counts.failed,
+        elapsed,
+        rate,
+    )
+    for name, n in sorted(counts.policy_areas.items(), key=lambda kv: (-kv[1], kv[0]))[:10]:
+        logger.info("Bill subjects:   {:>6,}  {}", n, name)
+
+
+def _log_coverage(out_file: Path, bills_file: Path) -> None:
+    """State enriched/total against the bill table, in named numbers."""
+    import duckdb
+
+    row = duckdb.sql(
+        f"""
+        SELECT
+            (SELECT count(*) FROM read_parquet('{bills_file}')) AS bills,
+            (SELECT count(*) FROM read_parquet('{out_file}')) AS rows,
+            (SELECT count(*) FROM read_parquet('{out_file}') WHERE policy_area IS NOT NULL) AS with_area
+        """
+    ).fetchone()
+    if not row:
+        return
+    bills, rows, with_area = row
+    share = (100.0 * with_area / bills) if bills else 0.0
+    logger.info(
+        "Bill subjects: {:,} rows, {:,} with a policy area, against {:,} bills ({:.1f}% of the archive)",
+        rows,
+        with_area,
+        bills,
+        share,
+    )
+
+
+class SubjectsFetcher(Protocol):
+    """What the enrichment pass needs from a fetcher: the real one, or a test's."""
+
+    carrier: str
+    counts: FetchCounts
+
+    @property
+    def first_congress(self) -> int: ...
+    def subjects_for(self, congress: str, bill_type: str, bill_number: str) -> BillSubjects | None: ...
+    def close(self) -> None: ...
+
+
+def enrich_bill_subjects(
+    output_dir: Path,
+    *,
+    max_bills: int | None = None,
+    fetcher: SubjectsFetcher | None = None,
+) -> Path:
+    """Build ``bill_subjects.parquet`` (bounded, resumable enrichment pass).
+
+    ``max_bills`` defaults to the chosen carrier's per-run cap, which is what
+    that carrier's crawl rate fits inside the CI timeout.
+    """
+    import duckdb
+
+    out_file = output_dir / OUTPUT
+    bills_file = output_dir / BILLS_INPUT
+    prior_file = output_dir / "_bill_subjects_prior.parquet"
+
+    if not bills_file.exists():
+        raise RuntimeError(f"Bill subjects: {BILLS_INPUT} not found in {output_dir} — prime it from R2 first")
+
+    # 1. Pull the prior table (best effort — absence just means a fresh backfill).
+    #    A backfill spread over many runs must never lose ground, so a local
+    #    artifact from a previous run counts as a prior in its own right: without
+    #    this, an R2-less re-run would silently overwrite everything enriched so
+    #    far and start again from the top of the archive.
+    have_prior = prior_file.exists() or r2.download(OUTPUT, prior_file) or _adopt_local_output(out_file, prior_file)
+    if have_prior:
+        logger.info("Bill subjects: merging against prior table {}", prior_file)
+    else:
+        logger.info("Bill subjects: no prior table found — starting the backfill")
+
+    owns_fetcher = fetcher is None
+    fetcher = fetcher or BillSubjectsFetcher()
+    if max_bills is None:
+        max_bills = MAX_BILLS_PER_RUN[fetcher.carrier]
+    logger.info(
+        "Bill subjects: carrier {} (bills from the {}th Congress on), up to {:,} bills this run",
+        fetcher.carrier,
+        fetcher.first_congress,
+        max_bills,
+    )
+
+    # 2. Pick this run's slice, newest Congress first.
+    pending = _pending_bills(
+        bills_file,
+        prior_file,
+        carrier=fetcher.carrier,
+        have_prior=have_prior,
+        limit=max_bills,
+    )
+    logger.info("Bill subjects: {:,} bills pending this run", len(pending))
+
+    # 3. Fetch. Only an answer becomes a row; a failure leaves the bill for next run.
+    now = datetime.now(UTC).isoformat(timespec="seconds")
+    started = datetime.now(UTC)
+    rows: list[dict] = []
+    try:
+        for seen, (bill_id, congress, bill_type, bill_number) in enumerate(pending, start=1):
+            result = fetcher.subjects_for(congress, bill_type, bill_number)
+            if result is not None:
+                rows.append(_shape(bill_id, result.policy_area, result.subjects, result.carrier, now))
+            if seen % 1_000 == 0:
+                logger.info("Bill subjects: {:,}/{:,} bills fetched...", seen, len(pending))
+    finally:
+        if owns_fetcher:
+            fetcher.close()
+    elapsed = (datetime.now(UTC) - started).total_seconds()
+    _log_counts(fetcher.counts, carrier=fetcher.carrier, attempted=len(pending), elapsed=elapsed)
+
+    # 4. Merge prior + new, dedup on bill_id preferring the fresh row.
+    new_file = output_dir / "_bill_subjects_new.parquet"
+    table = pa.Table.from_pylist(rows, schema=_SCHEMA) if rows else _SCHEMA.empty_table()
+    pq.write_table(table, new_file, compression="zstd")
+
+    spill_dir = output_dir / ".duckdb_tmp"
+    spill_dir.mkdir(exist_ok=True)
+    con = duckdb.connect()
+    con.execute("SET memory_limit='4GB'")
+    con.execute("SET preserve_insertion_order=false")
+    con.execute("SET threads=2")
+    con.execute(f"SET temp_directory='{spill_dir}'")
+
+    cols = ", ".join(COLUMNS)
+    if have_prior:
+        union = (
+            f"SELECT {cols}, 0 AS _src FROM read_parquet('{prior_file}') "
+            f"UNION ALL BY NAME "
+            f"SELECT {cols}, 1 AS _src FROM read_parquet('{new_file}')"
+        )
+    else:
+        union = f"SELECT {cols}, 1 AS _src FROM read_parquet('{new_file}')"
+
+    con.execute(
+        f"""
+        COPY (
+            SELECT {cols} FROM (
+                SELECT {cols}, ROW_NUMBER() OVER (
+                    PARTITION BY bill_id ORDER BY _src DESC
+                ) AS _rn
+                FROM ({union})
+                WHERE bill_id IS NOT NULL
+            )
+            WHERE _rn = 1
+            ORDER BY enriched_at DESC, bill_id
+        ) TO '{out_file}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 50000);
+        """
+    )
+    con.close()
+
+    # Housekeeping: drop scratch files so they aren't mistaken for outputs.
+    for scratch in (prior_file, new_file):
+        scratch.unlink(missing_ok=True)
+
+    _log_coverage(out_file, bills_file)
+    return out_file

--- a/tests/test_bill_subjects.py
+++ b/tests/test_bill_subjects.py
@@ -1,0 +1,402 @@
+"""Hermetic tests for the per-bill subject enrichment (no network).
+
+Covers the pieces with real logic: the BILLSTATUS XML parse, the two-carrier
+selection and its coverage floor, the ``/subjects`` page walk, and the three
+outcomes the transform depends on — an answer, a definitive "not held", and a
+failure that must leave the bill for the next run rather than pin an empty
+answer to it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from spicy_regs.sources.bill_subjects import (
+    API_HOURLY_BUDGET,
+    CARRIER_API,
+    CARRIER_BULKDATA,
+    DELAY_SECONDS,
+    FIRST_CONGRESS,
+    BillSubjects,
+    BillSubjectsFetcher,
+    parse_billstatus_subjects,
+    resolve_carrier,
+)
+from spicy_regs.sources.congress_bills import API_KEY_ENV_VARS
+from spicy_regs.transforms.enrich_bill_subjects import (
+    COLUMNS,
+    MAX_BILLS_PER_RUN,
+    _pending_bills,
+    _shape,
+    enrich_bill_subjects,
+)
+
+# A BILLSTATUS record in the shape GPO actually serves: <policyArea> appears
+# both as a direct child of <bill> and again inside <subjects>, and a term can
+# repeat across containers.
+_BILLSTATUS = """<?xml version="1.0" encoding="UTF-8"?>
+<billStatus>
+  <bill>
+    <congress>118</congress>
+    <type>HR</type>
+    <policyArea><name>Environmental Protection</name></policyArea>
+    <subjects>
+      <legislativeSubjects>
+        <item><name>Air quality</name></item>
+        <item><name>Congressional oversight</name></item>
+        <item><name>Air quality</name></item>
+        <item><name>  </name></item>
+      </legislativeSubjects>
+      <policyArea>
+        <name>Environmental Protection</name>
+        <updateDate>2024-01-02T00:00:00Z</updateDate>
+      </policyArea>
+    </subjects>
+  </bill>
+</billStatus>
+"""
+
+
+def _keyless(monkeypatch):
+    for var in API_KEY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _write_bills(path, rows):
+    """Write a minimal congress_bills.parquet fixture."""
+    columns = ("bill_id", "congress", "bill_type", "bill_number")
+    schema = pa.schema([(c, pa.string()) for c in columns])
+    pq.write_table(pa.Table.from_pylist([dict(zip(columns, r)) for r in rows], schema=schema), path)
+
+
+# -- BILLSTATUS parse --------------------------------------------------------
+
+
+def test_parse_billstatus_reads_policy_area_and_subjects():
+    policy_area, subjects = parse_billstatus_subjects(_BILLSTATUS)
+    assert policy_area == "Environmental Protection"
+    # Repeated terms collapse, whitespace-only names are dropped, order is kept.
+    assert subjects == ("Air quality", "Congressional oversight")
+
+
+def test_parse_billstatus_survives_malformed_xml():
+    # A truncated download must degrade to "no answer here", not raise.
+    assert parse_billstatus_subjects("<billStatus><bill>") == (None, ())
+
+
+def test_parse_billstatus_handles_a_bill_with_no_assignment():
+    assert parse_billstatus_subjects("<billStatus><bill/></billStatus>") == (None, ())
+
+
+# -- carrier selection -------------------------------------------------------
+
+
+def test_keyless_runs_pick_the_bulkdata_carrier(monkeypatch):
+    _keyless(monkeypatch)
+    assert resolve_carrier() == CARRIER_BULKDATA
+    assert BillSubjectsFetcher().carrier == CARRIER_BULKDATA
+
+
+def test_a_key_picks_the_deeper_congress_api_carrier(monkeypatch):
+    _keyless(monkeypatch)
+    monkeypatch.setenv("DATA_GOV_API_KEY", "a-key")
+    assert resolve_carrier() == CARRIER_API
+    assert BillSubjectsFetcher().carrier == CARRIER_API
+
+
+def test_the_api_carrier_refuses_to_run_without_a_key(monkeypatch):
+    _keyless(monkeypatch)
+    with pytest.raises(ValueError, match="api.data.gov key"):
+        BillSubjectsFetcher(carrier=CARRIER_API)
+
+
+def test_each_carrier_declares_its_coverage_floor(monkeypatch):
+    _keyless(monkeypatch)
+    # GPO's bulk data starts at the 108th Congress; the API reaches back to CRS's
+    # own indexing floor at the 93rd.
+    assert BillSubjectsFetcher().first_congress == FIRST_CONGRESS[CARRIER_BULKDATA] == 108
+    assert FIRST_CONGRESS[CARRIER_API] == 93
+
+
+def test_a_run_cannot_outspend_the_documented_hourly_budget():
+    """Congress.gov states 5,000 requests an hour; a capped run must fit inside it."""
+    per_hour = 3600 / DELAY_SECONDS[CARRIER_API]
+    assert per_hour < API_HOURLY_BUDGET
+    # And the run itself has to finish inside the workflow's 30-minute timeout.
+    assert MAX_BILLS_PER_RUN[CARRIER_API] * DELAY_SECONDS[CARRIER_API] < 30 * 60
+    assert MAX_BILLS_PER_RUN[CARRIER_BULKDATA] * DELAY_SECONDS[CARRIER_BULKDATA] < 30 * 60
+
+
+def test_each_carrier_gets_its_own_crawl_rate(monkeypatch):
+    _keyless(monkeypatch)
+    assert BillSubjectsFetcher().delay == DELAY_SECONDS[CARRIER_BULKDATA]
+    assert BillSubjectsFetcher(api_key="k").delay == DELAY_SECONDS[CARRIER_API]
+
+
+# -- the /subjects page walk -------------------------------------------------
+
+
+def _api_fetcher(monkeypatch, pages):
+    fetcher = BillSubjectsFetcher(api_key="test", carrier=CARRIER_API, delay=0)
+    calls: list[int] = []
+
+    def fake_get_json(url, *, params):
+        calls.append(params["offset"])
+        return pages[params["offset"]]
+
+    monkeypatch.setattr(fetcher, "_get_json", fake_get_json)
+    return fetcher, calls
+
+
+def test_one_call_carries_both_fields(monkeypatch):
+    """policyArea and legislativeSubjects arrive together — no second request."""
+    fetcher, calls = _api_fetcher(
+        monkeypatch,
+        {
+            0: {
+                "pagination": {"count": 2},
+                "subjects": {
+                    "policyArea": {"name": "Health"},
+                    "legislativeSubjects": [{"name": "Medicare"}, {"name": "Drug safety"}],
+                },
+            }
+        },
+    )
+    result = fetcher.subjects_for("118", "HR", "1")
+    assert result == BillSubjects("Health", ("Medicare", "Drug safety"), CARRIER_API)
+    assert calls == [0]
+
+
+def test_a_fat_bill_walks_offsets_until_the_count_is_met(monkeypatch):
+    fetcher, calls = _api_fetcher(
+        monkeypatch,
+        {
+            0: {
+                "pagination": {"count": 3},
+                "subjects": {
+                    "policyArea": {"name": "Taxation"},
+                    "legislativeSubjects": [{"name": "A"}, {"name": "B"}],
+                },
+            },
+            250: {
+                "pagination": {"count": 3},
+                "subjects": {"legislativeSubjects": [{"name": "C"}]},
+            },
+        },
+    )
+    result = fetcher.subjects_for("118", "HR", "1")
+    assert result is not None
+    assert result.policy_area == "Taxation"
+    assert result.subjects == ("A", "B", "C")
+    assert calls == [0, 250]
+
+
+def test_a_failed_later_page_publishes_nothing_rather_than_a_truncated_list(monkeypatch):
+    fetcher, _ = _api_fetcher(
+        monkeypatch,
+        {
+            0: {
+                "pagination": {"count": 400},
+                "subjects": {
+                    "policyArea": {"name": "Taxation"},
+                    "legislativeSubjects": [{"name": "A"}],
+                },
+            },
+            250: None,  # transport gave up
+        },
+    )
+    assert fetcher.subjects_for("118", "HR", "1") is None
+    assert fetcher.counts.failed == 1
+
+
+# -- the three outcomes ------------------------------------------------------
+
+
+def test_a_404_is_an_answer_not_a_failure(monkeypatch):
+    _keyless(monkeypatch)
+    fetcher = BillSubjectsFetcher(delay=0)
+    monkeypatch.setattr(fetcher, "_get_text", lambda url: _absent())
+    result = fetcher.subjects_for("108", "hr", "1")
+    # The carrier answered: it does not hold this bill. Recorded so the next run
+    # doesn't ask again.
+    assert result == BillSubjects(None, (), CARRIER_BULKDATA, held=False)
+    assert (fetcher.counts.answered, fetcher.counts.not_held, fetcher.counts.failed) == (1, 1, 0)
+
+
+def test_a_held_bill_with_no_terms_is_counted_apart_from_a_404(monkeypatch):
+    """Both publish a null policy_area; only one of them means "never heard of it"."""
+    _keyless(monkeypatch)
+    fetcher = BillSubjectsFetcher(delay=0)
+    monkeypatch.setattr(fetcher, "_get_text", lambda url: "<billStatus><bill/></billStatus>")
+    fetcher.subjects_for("118", "hr", "1")
+    assert (fetcher.counts.unassigned, fetcher.counts.not_held) == (1, 0)
+
+
+def test_every_answer_lands_in_exactly_one_bucket(monkeypatch):
+    _keyless(monkeypatch)
+    fetcher = BillSubjectsFetcher(delay=0)
+    bodies = iter([_BILLSTATUS, "<billStatus><bill/></billStatus>", _absent()])
+    monkeypatch.setattr(fetcher, "_get_text", lambda url: next(bodies))
+    for n in range(3):
+        fetcher.subjects_for("118", "hr", str(n))
+    counts = fetcher.counts
+    buckets = counts.with_policy_area + counts.subjects_only + counts.unassigned + counts.not_held
+    assert buckets == counts.answered == 3
+
+
+def _absent():
+    from spicy_regs.sources.bill_subjects import _ABSENT
+
+    return _ABSENT
+
+
+def test_counts_tally_policy_areas_for_the_run_report(monkeypatch):
+    _keyless(monkeypatch)
+    fetcher = BillSubjectsFetcher(delay=0)
+    monkeypatch.setattr(fetcher, "_get_text", lambda url: _BILLSTATUS)
+    fetcher.subjects_for("118", "hr", "1")
+    fetcher.subjects_for("118", "hr", "2")
+    assert fetcher.counts.with_policy_area == 2
+    assert fetcher.counts.policy_areas == {"Environmental Protection": 2}
+
+
+# -- the published shape -----------------------------------------------------
+
+
+def test_shape_produces_exact_schema():
+    row = _shape("118-hr-1", "Health", ("Medicare",), CARRIER_API, "2026-08-22T00:00:00+00:00")
+    assert set(row) == set(COLUMNS)
+    assert len(COLUMNS) == 6
+    assert json.loads(row["subjects_json"]) == ["Medicare"]
+    assert row["subject_count"] == "1"
+    assert row["carrier"] == CARRIER_API
+
+
+# -- the transform: bounded, resumable ---------------------------------------
+
+
+class _StubFetcher:
+    """Answers from a canned map; anything unmapped is a transport failure."""
+
+    def __init__(self, answers, carrier=CARRIER_BULKDATA):
+        self.answers = answers
+        self.carrier = carrier
+        self.asked: list[str] = []
+        from spicy_regs.sources.bill_subjects import FetchCounts
+
+        self.counts = FetchCounts()
+
+    @property
+    def first_congress(self):
+        return FIRST_CONGRESS[self.carrier]
+
+    def subjects_for(self, congress, bill_type, bill_number):
+        key = f"{congress}-{bill_type}-{bill_number}"
+        self.asked.append(key)
+        answer = self.answers.get(key)
+        if answer is None:
+            self.counts.failed += 1
+            return None
+        self.counts.answered += 1
+        return answer
+
+    def close(self):
+        pass
+
+
+def _answer(policy_area, *subjects):
+    return BillSubjects(policy_area, subjects, CARRIER_BULKDATA)
+
+
+def test_a_run_is_capped_and_the_next_one_resumes_where_it_stopped(tmp_path):
+    _write_bills(
+        tmp_path / "congress_bills.parquet",
+        [(f"118-hr-{n}", "118", "hr", str(n)) for n in range(1, 6)],
+    )
+    answers = {f"118-hr-{n}": _answer("Health", "Medicare") for n in range(1, 6)}
+
+    first = _StubFetcher(answers)
+    enrich_bill_subjects(tmp_path, max_bills=2, fetcher=first)
+    assert len(first.asked) == 2
+
+    second = _StubFetcher(answers)
+    out = enrich_bill_subjects(tmp_path, max_bills=2, fetcher=second)
+    # The second run asks about two *different* bills and keeps the first two.
+    assert len(second.asked) == 2
+    assert set(second.asked).isdisjoint(first.asked)
+    assert pq.ParquetFile(out).metadata.num_rows == 4
+    assert pq.ParquetFile(out).schema_arrow.names == list(COLUMNS)
+
+
+def test_a_failed_fetch_leaves_the_bill_un_enriched_for_the_next_run(tmp_path):
+    _write_bills(
+        tmp_path / "congress_bills.parquet",
+        [("118-hr-1", "118", "hr", "1"), ("118-hr-2", "118", "hr", "2")],
+    )
+    # hr-2 has no canned answer, so the stub reports a transport failure.
+    flaky = _StubFetcher({"118-hr-1": _answer("Health")})
+    out = enrich_bill_subjects(tmp_path, max_bills=2, fetcher=flaky)
+
+    rows = pq.read_table(out).to_pylist()
+    assert [r["bill_id"] for r in rows] == ["118-hr-1"]
+
+    # Next run picks the failed bill straight back up — no half-written row to
+    # mistake for an answer.
+    recovered = _StubFetcher({"118-hr-2": _answer("Taxation")})
+    out = enrich_bill_subjects(tmp_path, max_bills=2, fetcher=recovered)
+    assert recovered.asked == ["118-hr-2"]
+    assert {r["bill_id"] for r in pq.read_table(out).to_pylist()} == {"118-hr-1", "118-hr-2"}
+
+
+def test_a_definitive_miss_is_recorded_and_not_asked_again(tmp_path):
+    _write_bills(tmp_path / "congress_bills.parquet", [("118-hr-1", "118", "hr", "1")])
+    first = _StubFetcher({"118-hr-1": BillSubjects(None, (), CARRIER_BULKDATA)})
+    enrich_bill_subjects(tmp_path, max_bills=5, fetcher=first)
+
+    second = _StubFetcher({"118-hr-1": _answer("Health")})
+    enrich_bill_subjects(tmp_path, max_bills=5, fetcher=second)
+    assert second.asked == []
+
+
+def test_switching_to_a_deeper_carrier_re_asks_what_the_other_one_lacked(tmp_path):
+    _write_bills(tmp_path / "congress_bills.parquet", [("118-hr-1", "118", "hr", "1")])
+    enrich_bill_subjects(
+        tmp_path,
+        max_bills=5,
+        fetcher=_StubFetcher({"118-hr-1": BillSubjects(None, (), CARRIER_BULKDATA)}),
+    )
+    # A key appears; the Congress.gov carrier may well hold what GPO did not.
+    api = _StubFetcher({"118-hr-1": BillSubjects("Health", (), CARRIER_API)}, carrier=CARRIER_API)
+    out = enrich_bill_subjects(tmp_path, max_bills=5, fetcher=api)
+    assert api.asked == ["118-hr-1"]
+    rows = pq.read_table(out).to_pylist()
+    assert (rows[0]["policy_area"], rows[0]["carrier"]) == ("Health", CARRIER_API)
+
+
+def test_bills_below_the_carrier_floor_are_never_asked_for(tmp_path):
+    bills = tmp_path / "congress_bills.parquet"
+    _write_bills(
+        bills,
+        [
+            ("107-hr-1", "107", "hr", "1"),  # below GPO's 108th-Congress floor
+            ("118-hr-1", "118", "hr", "1"),
+            ("118-hr-2", "118", "hr", None),  # unusable: no bill number
+        ],
+    )
+    pending = _pending_bills(
+        bills,
+        tmp_path / "_absent_prior.parquet",
+        carrier=CARRIER_BULKDATA,
+        have_prior=False,
+        limit=10,
+    )
+    assert [p[0] for p in pending] == ["118-hr-1"]
+
+
+def test_a_missing_bill_table_fails_loudly(tmp_path):
+    with pytest.raises(RuntimeError, match="congress_bills.parquet"):
+        enrich_bill_subjects(tmp_path, max_bills=1, fetcher=_StubFetcher({}))


### PR DESCRIPTION
Every bill on Congress.gov carries a CRS policy area and a set of legislative subjects, and today the platform has neither. With them, a user filters bills by topic and relates bills to rules by subject — the first link between the legislative and regulatory halves of the corpus that does not run through a statute citation. The reader picks whichever carrier the environment can reach: the Congress.gov API when a key is present, GovInfo's bulk XML otherwise, which needs no key and has no rate limit. The pass is bounded and resumes from the prior table, so a nightly run enriches a slice and never re-fetches what it already has.

Run against the live `congress_bills.parquet` as published on 2026-09-04 — 418,543 bills — through the keyless bulk carrier: 50 bills enriched in 12 s, 50 of 50 with a policy area (Congress, International Affairs, Economics and Public Finance, Crime and Law Enforcement…) and 50 of 50 with subjects. Registering the table in the data dictionary and MCP server follows as its own PR, the way #175 exposed the lifecycle rollups after they existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)